### PR TITLE
feat: add Kiro CLI support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.11.0] - 2026-06-18
+
+- add support for Kiro CLI (`kiro-cli` / `kiro`)
+
 ## [1.10.4] - 2026-05-23
 
 - add `-h` shorthand for `--header` (use `--help` for help)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Add MCP servers to your favorite coding agents with a single command.
 
-Supports **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **VSCode** and [10 more](#supported-agents).
+Supports **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **VSCode** and [11 more](#supported-agents).
 
 ## Install an MCP Server
 
@@ -48,25 +48,26 @@ When running `find`/`search` for the first time, the CLI prompts you to choose w
 
 MCP servers can be installed to any of these agents:
 
-| Agent                  | `--agent`            | Project Path            | Global Path                                                                                                     |
-| ---------------------- | -------------------- | ----------------------- | --------------------------------------------------------------------------------------------------------------- |
-| Antigravity            | `antigravity`        | -                       | `~/.gemini/antigravity/mcp_config.json`                                                                         |
-| Cline VSCode Extension | `cline`              | -                       | `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` |
-| Cline CLI              | `cline-cli`          | -                       | `~/.cline/data/settings/cline_mcp_settings.json`                                                                |
-| Claude Code            | `claude-code`        | `.mcp.json`             | `~/.claude.json`                                                                                                |
-| Claude Desktop         | `claude-desktop`     | -                       | `~/Library/Application Support/Claude/claude_desktop_config.json`                                               |
-| Codex                  | `codex`              | `.codex/config.toml`    | `~/.codex/config.toml`                                                                                          |
-| Cursor                 | `cursor`             | `.cursor/mcp.json`      | `~/.cursor/mcp.json`                                                                                            |
-| Gemini CLI             | `gemini-cli`         | `.gemini/settings.json` | `~/.gemini/settings.json`                                                                                       |
-| Goose                  | `goose`              | `.goose/config.yaml`    | `~/.config/goose/config.yaml`                                                                                   |
-| GitHub Copilot CLI     | `github-copilot-cli` | `.vscode/mcp.json`      | `~/.copilot/mcp-config.json`                                                                                    |
-| MCPorter               | `mcporter`           | `config/mcporter.json`  | `~/.mcporter/mcporter.json` (or existing `~/.mcporter/mcporter.jsonc`)                                          |
-| OpenCode               | `opencode`           | `opencode.json`         | `~/.config/opencode/opencode.json`                                                                              |
-| VS Code                | `vscode`             | `.vscode/mcp.json`      | `~/Library/Application Support/Code/User/mcp.json`                                                              |
-| Windsurf               | `windsurf`           | -                       | `~/.codeium/windsurf/mcp_config.json`                                                                           |
-| Zed                    | `zed`                | `.zed/settings.json`    | `~/Library/Application Support/Zed/settings.json`                                                               |
+| Agent                  | `--agent`            | Project Path              | Global Path                                                                                                     |
+| ---------------------- | -------------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Antigravity            | `antigravity`        | -                         | `~/.gemini/antigravity/mcp_config.json`                                                                         |
+| Cline VSCode Extension | `cline`              | -                         | `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` |
+| Cline CLI              | `cline-cli`          | -                         | `~/.cline/data/settings/cline_mcp_settings.json`                                                                |
+| Claude Code            | `claude-code`        | `.mcp.json`               | `~/.claude.json`                                                                                                |
+| Claude Desktop         | `claude-desktop`     | -                         | `~/Library/Application Support/Claude/claude_desktop_config.json`                                               |
+| Codex                  | `codex`              | `.codex/config.toml`      | `~/.codex/config.toml`                                                                                          |
+| Cursor                 | `cursor`             | `.cursor/mcp.json`        | `~/.cursor/mcp.json`                                                                                            |
+| Gemini CLI             | `gemini-cli`         | `.gemini/settings.json`   | `~/.gemini/settings.json`                                                                                       |
+| Goose                  | `goose`              | `.goose/config.yaml`      | `~/.config/goose/config.yaml`                                                                                   |
+| Kiro CLI               | `kiro-cli`           | `.kiro/settings/mcp.json` | `~/.kiro/settings/mcp.json`                                                                                     |
+| GitHub Copilot CLI     | `github-copilot-cli` | `.vscode/mcp.json`        | `~/.copilot/mcp-config.json`                                                                                    |
+| MCPorter               | `mcporter`           | `config/mcporter.json`    | `~/.mcporter/mcporter.json` (or existing `~/.mcporter/mcporter.jsonc`)                                          |
+| OpenCode               | `opencode`           | `opencode.json`           | `~/.config/opencode/opencode.json`                                                                              |
+| VS Code                | `vscode`             | `.vscode/mcp.json`        | `~/Library/Application Support/Code/User/mcp.json`                                                              |
+| Windsurf               | `windsurf`           | -                         | `~/.codeium/windsurf/mcp_config.json`                                                                           |
+| Zed                    | `zed`                | `.zed/settings.json`      | `~/Library/Application Support/Zed/settings.json`                                                               |
 
-**Aliases:** `codeium`, `cascade` → `windsurf`, `cline-vscode` → `cline`, `gemini` → `gemini-cli`, `github-copilot` → `vscode`
+**Aliases:** `codeium`, `cascade` → `windsurf`, `cline-vscode` → `cline`, `gemini` → `gemini-cli`, `github-copilot` → `vscode`, `kiro` → `kiro-cli`
 
 ## Installation Scope
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-mcp",
-  "version": "1.10.4",
+  "version": "1.11.0",
   "description": "Add MCP servers to your favorite coding agents with a single command.",
   "author": "Andre Landgraf <andre@neon.tech>",
   "license": "Apache-2.0",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -436,6 +436,20 @@ export const agents: Record<AgentType, AgentConfig> = {
     transformConfig: transformGooseConfig,
   },
 
+  "kiro-cli": {
+    name: "kiro-cli",
+    displayName: "Kiro CLI",
+    configPath: join(home, ".kiro", "settings", "mcp.json"),
+    localConfigPath: ".kiro/settings/mcp.json",
+    projectDetectPaths: [".kiro"],
+    configKey: "mcpServers",
+    format: "json",
+    supportedTransports: ["stdio", "http", "sse"],
+    detectGlobalInstall: async () => {
+      return existsSync(join(home, ".kiro"));
+    },
+  },
+
   "github-copilot-cli": {
     name: "github-copilot-cli",
     displayName: "GitHub Copilot CLI",

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export type AgentType =
   | "gemini-cli"
   | "goose"
   | "github-copilot-cli"
+  | "kiro-cli"
   | "mcporter"
   | "opencode"
   | "vscode"
@@ -21,6 +22,7 @@ export const agentAliases: Record<string, AgentType> = {
   cascade: "windsurf",
   gemini: "gemini-cli",
   "github-copilot": "vscode",
+  kiro: "kiro-cli",
 };
 
 export type ConfigFormat = "json" | "yaml" | "toml";

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -59,9 +59,9 @@ function cleanup() {
 // Agent Configuration Tests
 // ============================================
 
-test("getAgentTypes returns all 15 agents", () => {
+test("getAgentTypes returns all 16 agents", () => {
   const types = getAgentTypes();
-  assert.strictEqual(types.length, 15);
+  assert.strictEqual(types.length, 16);
   assert.ok(types.includes("antigravity"));
   assert.ok(types.includes("cline"));
   assert.ok(types.includes("cline-cli"));
@@ -72,6 +72,7 @@ test("getAgentTypes returns all 15 agents", () => {
   assert.ok(types.includes("gemini-cli"));
   assert.ok(types.includes("goose"));
   assert.ok(types.includes("github-copilot-cli"));
+  assert.ok(types.includes("kiro-cli"));
   assert.ok(types.includes("mcporter"));
   assert.ok(types.includes("opencode"));
   assert.ok(types.includes("vscode"));
@@ -112,6 +113,7 @@ test("supportsProjectConfig - returns true for project-capable agents", () => {
   assert.strictEqual(supportsProjectConfig("opencode"), true);
   assert.strictEqual(supportsProjectConfig("gemini-cli"), true);
   assert.strictEqual(supportsProjectConfig("github-copilot-cli"), true);
+  assert.strictEqual(supportsProjectConfig("kiro-cli"), true);
   assert.strictEqual(supportsProjectConfig("mcporter"), true);
   assert.strictEqual(supportsProjectConfig("codex"), true);
   assert.strictEqual(supportsProjectConfig("zed"), true);
@@ -125,15 +127,16 @@ test("supportsProjectConfig - returns false for global-only agents", () => {
   assert.strictEqual(supportsProjectConfig("windsurf"), false);
 });
 
-test("getProjectCapableAgents returns 9 agents", () => {
+test("getProjectCapableAgents returns 10 agents", () => {
   const projectAgents = getProjectCapableAgents();
-  assert.strictEqual(projectAgents.length, 9);
+  assert.strictEqual(projectAgents.length, 10);
   assert.ok(projectAgents.includes("claude-code"));
   assert.ok(projectAgents.includes("cursor"));
   assert.ok(projectAgents.includes("vscode"));
   assert.ok(projectAgents.includes("opencode"));
   assert.ok(projectAgents.includes("gemini-cli"));
   assert.ok(projectAgents.includes("github-copilot-cli"));
+  assert.ok(projectAgents.includes("kiro-cli"));
   assert.ok(projectAgents.includes("mcporter"));
   assert.ok(projectAgents.includes("codex"));
   assert.ok(projectAgents.includes("zed"));
@@ -244,6 +247,14 @@ test("detectProjectAgents - detects .zed directory", () => {
   assert.ok(detected.includes("zed"));
 });
 
+test("detectProjectAgents - detects .kiro directory", () => {
+  const tempDir = createTempDir();
+  mkdirSync(join(tempDir, ".kiro"));
+
+  const detected = detectProjectAgents(tempDir);
+  assert.ok(detected.includes("kiro-cli"));
+});
+
 test("detectProjectAgents - detects config/mcporter.json", () => {
   const tempDir = createTempDir();
   mkdirSync(join(tempDir, "config"), { recursive: true });
@@ -307,6 +318,7 @@ test("isTransportSupported - most agents support http", () => {
     "gemini-cli",
     "github-copilot-cli",
     "goose",
+    "kiro-cli",
     "mcporter",
     "opencode",
     "vscode",
@@ -334,6 +346,7 @@ test("isTransportSupported - most agents support sse", () => {
     "gemini-cli",
     "github-copilot-cli",
     "goose",
+    "kiro-cli",
     "mcporter",
     "opencode",
     "vscode",

--- a/tests/e2e/install.test.ts
+++ b/tests/e2e/install.test.ts
@@ -321,6 +321,53 @@ test("E2E: Install to Gemini CLI (local)", () => {
   assert.ok(mcpServers.github);
 });
 
+test("E2E: Install to Kiro CLI (local) - stdio", () => {
+  const tempDir = createTempDir();
+  const parsed = parseSource("mcp-server-github");
+  const config = buildServerConfig(parsed);
+
+  const result = installServerForAgent("github", config, "kiro-cli", {
+    local: true,
+    cwd: tempDir,
+  });
+
+  assert.strictEqual(result.success, true);
+
+  const configPath = join(tempDir, ".kiro", "settings", "mcp.json");
+  assert.strictEqual(existsSync(configPath), true);
+
+  const savedConfig = readJsonConfig(configPath);
+  const mcpServers = savedConfig.mcpServers as Record<string, unknown>;
+  assert.ok(mcpServers.github);
+
+  const serverConfig = mcpServers.github as Record<string, unknown>;
+  assert.strictEqual(serverConfig.command, "npx");
+  assert.deepStrictEqual(serverConfig.args, ["-y", "mcp-server-github"]);
+});
+
+test("E2E: Install to Kiro CLI (local) - remote", () => {
+  const tempDir = createTempDir();
+  const parsed = parseSource("https://mcp.example.com/api");
+  const config = buildServerConfig(parsed);
+
+  const result = installServerForAgent("example", config, "kiro-cli", {
+    local: true,
+    cwd: tempDir,
+  });
+
+  assert.strictEqual(result.success, true);
+
+  const configPath = join(tempDir, ".kiro", "settings", "mcp.json");
+  assert.strictEqual(existsSync(configPath), true);
+
+  const savedConfig = readJsonConfig(configPath);
+  const mcpServers = savedConfig.mcpServers as Record<string, unknown>;
+  assert.ok(mcpServers.example);
+
+  const serverConfig = mcpServers.example as Record<string, unknown>;
+  assert.strictEqual(serverConfig.url, "https://mcp.example.com/api");
+});
+
 // ============================================
 // E2E Tests: Merge existing config
 // ============================================


### PR DESCRIPTION
## Summary

  - Add Kiro CLI (\`kiro-cli\` / \`kiro\`) as a supported agent
  - Config stored at \`.kiro/settings/mcp.json\` (local) and \`~/.kiro/settings/mcp.json\` (global)
  - Supports stdio, http, and sse transports
  - Detects existing \`.kiro\` directory for project-level installs

  ## Test plan

  - [x] Unit tests for agent count, project detection, and transport support
  - [x] E2E tests for stdio and remote installs to Kiro CLI