### PR TITLE
feat(lib)!: default upsertServer / removeServer to local installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.0.0] - 2026-05-23
+
+- **BREAKING**: `upsertServer` and `removeServer` programmatic APIs now default to project-level (`local: true`) installs to match the CLI default; previously they wrote the global config when `local` was omitted. Pass `{ local: false }` explicitly to target the global config. Callers writing to global-only agents (`claude-desktop`, etc.) must now pass `{ local: false }` since the new default is rejected for those agents (mirrors how `local: true` was rejected before).
+
 ## [1.10.1] - 2026-05-22
 
 - use single quotes in `--header` / `--env` "Use 'Key: Value' format." error messages so the example matches the recommended shell-quoting style (was double quotes, which contradicted the shell-expansion hint that recommends single quotes)

--- a/README.md
+++ b/README.md
@@ -373,8 +373,7 @@ import {
 const project = detectProjectAgents("/path/to/project");
 const global = await detectGlobalAgents();
 
-// Remote server — defaults to project-level (`.mcp.json` here),
-// matching the CLI default. Pass `local: false` to write the global config.
+// Remote server (project-level by default; pass `local: false` for global)
 upsertServer(
   "claude-code",
   "example",
@@ -382,7 +381,7 @@ upsertServer(
   { cwd: "/path/to/project" },
 );
 
-// Stdio (npm package) installed to the global Claude Code config
+// Stdio (npm package), global install
 upsertServer(
   "claude-code",
   "postgres",
@@ -403,7 +402,7 @@ removeServer("claude-code", "example", {
 });
 ```
 
-`upsertServer` and `removeServer` default to project-level installs (`local: true`); pass `local: false` to target the global config. Both return `{ success, path, error? }` rather than throwing.
+`upsertServer` and `removeServer` return `{ success, path, error? }` rather than throwing.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -373,19 +373,25 @@ import {
 const project = detectProjectAgents("/path/to/project");
 const global = await detectGlobalAgents();
 
-// Remote server
+// Remote server — defaults to project-level (`.mcp.json` here),
+// matching the CLI default. Pass `local: false` to write the global config.
 upsertServer(
   "claude-code",
   "example",
   { type: "http", url: "https://mcp.example.com/api" },
-  { local: true, cwd: "/path/to/project" },
+  { cwd: "/path/to/project" },
 );
 
-// Stdio (npm package)
-upsertServer("claude-code", "postgres", {
-  command: "npx",
-  args: ["-y", "@modelcontextprotocol/server-postgres"],
-});
+// Stdio (npm package) installed to the global Claude Code config
+upsertServer(
+  "claude-code",
+  "postgres",
+  {
+    command: "npx",
+    args: ["-y", "@modelcontextprotocol/server-postgres"],
+  },
+  { local: false },
+);
 
 const projectServers = await listInstalledServers({
   cwd: "/path/to/project",
@@ -393,12 +399,11 @@ const projectServers = await listInstalledServers({
 const globalServers = await listInstalledServers({ global: true });
 
 removeServer("claude-code", "example", {
-  local: true,
   cwd: "/path/to/project",
 });
 ```
 
-`upsertServer` and `removeServer` return `{ success, path, error? }` rather than throwing.
+`upsertServer` and `removeServer` default to project-level installs (`local: true`); pass `local: false` to target the global config. Both return `{ success, path, error? }` rather than throwing.
 
 ## Troubleshooting
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-mcp",
-  "version": "1.10.1",
+  "version": "2.0.0",
   "description": "Add MCP servers to your favorite coding agents with a single command.",
   "author": "Andre Landgraf <andre@neon.tech>",
   "license": "Apache-2.0",

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -42,7 +42,7 @@ function isKnownAgent(agentType: string): agentType is AgentType {
   return Object.prototype.hasOwnProperty.call(agents, agentType);
 }
 
-function validate(agentType: AgentInput, local?: boolean): string | null {
+function validate(agentType: AgentInput, local: boolean): string | null {
   if (!isKnownAgent(agentType)) {
     return `Unknown agent type: ${String(agentType)}`;
   }
@@ -52,19 +52,27 @@ function validate(agentType: AgentInput, local?: boolean): string | null {
   return null;
 }
 
+// Default to project-level (local) installs so the programmatic API matches
+// the CLI, where global is the opt-in (`-g`). Callers can still pass
+// `{ local: false }` to write the global config explicitly.
+function withDefaults(options: InstallOptions): InstallOptions {
+  return { ...options, local: options.local ?? true };
+}
+
 export function upsertServer(
   agentType: AgentInput,
   serverName: string,
   serverConfig: McpServerConfig,
   options: InstallOptions = {},
 ): InstallResult {
-  const error = validate(agentType, options.local);
+  const resolved = withDefaults(options);
+  const error = validate(agentType, resolved.local === true);
   if (error) return { success: false, path: "", error };
   return installServerForAgent(
     serverName,
     serverConfig,
     agentType as AgentType,
-    options,
+    resolved,
   );
 }
 
@@ -111,15 +119,16 @@ export function removeServer(
   serverName: string,
   options: InstallOptions = {},
 ): RemoveServerResult {
-  const error = validate(agentType, options.local);
+  const resolved = withDefaults(options);
+  const error = validate(agentType, resolved.local === true);
   if (error) return { success: false, path: "", removed: false, error };
   const known = agentType as AgentType;
   try {
-    return doRemove(known, serverName, options);
+    return doRemove(known, serverName, resolved);
   } catch (e) {
     return {
       success: false,
-      path: getConfigPath(agents[known], options),
+      path: getConfigPath(agents[known], resolved),
       removed: false,
       error: e instanceof Error ? e.message : "Unknown error",
     };

--- a/tests/lib.test.ts
+++ b/tests/lib.test.ts
@@ -228,24 +228,86 @@ await test("removeServer returns error result for unknown agent type", () => {
   assert.ok(result.error?.includes("Unknown agent type"));
 });
 
-await test("upsertServer + removeServer reject local: true for global-only agents", () => {
+await test("upsertServer + removeServer reject local default for global-only agents", () => {
   const dir = createTempDir();
+  // Default is `local: true`, so global-only agents must be rejected when the
+  // caller omits the flag (rather than silently writing the global config).
   const upsert = upsertServer(
     "claude-desktop",
     "x",
     remote("https://x.example.com"),
-    { local: true, cwd: dir },
+    { cwd: dir },
   );
   assert.strictEqual(upsert.success, false);
   assert.ok(upsert.error?.includes("does not support project-level"));
 
-  const remove = removeServer("claude-desktop", "x", {
-    local: true,
-    cwd: dir,
-  });
+  const remove = removeServer("claude-desktop", "x", { cwd: dir });
   assert.strictEqual(remove.success, false);
   assert.strictEqual(remove.removed, false);
   assert.ok(remove.error?.includes("does not support project-level"));
+});
+
+await test("upsertServer defaults to project-level install (matches CLI)", () => {
+  const dir = createTempDir();
+  // No `local` flag — should write the project-level `.cursor/mcp.json`,
+  // matching the CLI default where `-g` is the opt-in for global installs.
+  const result = upsertServer(
+    "cursor",
+    "defaulted",
+    remote("https://mcp.example.com/api"),
+    { cwd: dir },
+  );
+
+  assert.ok(result.success, result.error);
+  assert.ok(
+    result.path.includes(dir),
+    `expected project path under ${dir}, got ${result.path}`,
+  );
+  assert.ok(
+    result.path.endsWith(join(".cursor", "mcp.json")),
+    `expected .cursor/mcp.json path, got ${result.path}`,
+  );
+
+  const written = readJson(join(dir, ".cursor", "mcp.json"));
+  const servers = written.mcpServers as Record<string, unknown>;
+  assert.ok(servers.defaulted, "server should be present at the project path");
+});
+
+await test("upsertServer with local: false targets the global config", () => {
+  const dir = createTempDir();
+  const result = upsertServer(
+    "cursor",
+    "globalish",
+    remote("https://mcp.example.com/api"),
+    { local: false, cwd: dir },
+  );
+
+  assert.ok(result.success, result.error);
+  assert.ok(
+    !result.path.includes(dir),
+    `expected global path outside ${dir}, got ${result.path}`,
+  );
+  assert.strictEqual(
+    existsSync(join(dir, ".cursor", "mcp.json")),
+    false,
+    "project config should not be written when local: false",
+  );
+});
+
+await test("removeServer defaults to project-level config (matches CLI)", () => {
+  const dir = createTempDir();
+  upsertServer("cursor", "rm-default", remote("https://x.example.com"), {
+    cwd: dir,
+  });
+
+  // No `local` flag — should target the project config we just wrote.
+  const result = removeServer("cursor", "rm-default", { cwd: dir });
+  assert.ok(result.success, result.error);
+  assert.strictEqual(result.removed, true);
+
+  const written = readJson(join(dir, ".cursor", "mcp.json"));
+  const servers = (written.mcpServers ?? {}) as Record<string, unknown>;
+  assert.ok(!servers["rm-default"], "server should be removed");
 });
 
 await test("upsertServer + removeServer honor github-copilot-cli local `servers` key", () => {


### PR DESCRIPTION
## Summary

- Flip the `upsertServer` / `removeServer` programmatic API default so that omitting the `local` option installs to the project-level config — matching the CLI, where global is the opt-in (`-g`).
- Update the README programmatic API example to show the new default and how to opt into the global config (`local: false`).
- Add unit tests covering the new default, the explicit `local: false` escape hatch, and the updated rejection behavior for global-only agents (e.g. `claude-desktop`).
- Add a `CHANGELOG.md` entry and bump `package.json` from `1.10.1` → `2.0.0` (the API changed default behavior in a breaking way; the programmatic surface shipped in `1.10.0`).

## Why

The CLI defaults to local (project) installs and treats global as the opt-in via `-g`. The programmatic API shipped with the opposite default, which forced every caller to remember `{ local: true }` and made the two surfaces inconsistent. This aligns them.

## Breaking change

Callers that relied on the old global-by-default behavior must now pass `{ local: false }`. In particular, callers writing to global-only agents (e.g. `claude-desktop`, `antigravity`, `cline`) will now hit the existing `"does not support project-level config"` validation error unless they pass `{ local: false }` explicitly. This mirrors how `{ local: true }` was rejected before, just with the default flipped.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test:unit` (incl. 4 new / updated cases in `tests/lib.test.ts`)
- [x] `npm test` (full unit + e2e suite, 32 passed in the e2e block)
- [x] `npm run build`
- [x] `npm run fmt`
- [x] `npm run fallow` (advisory; no new findings introduced by this diff)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Programmatic server install/removal now defaults to project-level configuration when `local` is omitted.
  * Use `local: false` for global installs; global-only agents will reject the new default.

* **New Features**
  * Updated the API behavior and examples to reflect project-level defaults and global-install options.

* **Bug Fixes**
  * Improved consistency between install and remove flows so they use the same default configuration behavior.

* **Documentation**
  * Updated release notes and README examples to match the new defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->