### PR TITLE
feat: add antigravity-ide and antigravity-cli agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Add MCP servers to your favorite coding agents with a single command.
 
-Supports **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **VSCode** and [10 more](#supported-agents).
+Supports **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **VSCode** and [12 more](#supported-agents).
 
 ## Install an MCP Server
 
@@ -51,6 +51,8 @@ MCP servers can be installed to any of these agents:
 | Agent                  | `--agent`            | Project Path            | Global Path                                                                                                     |
 | ---------------------- | -------------------- | ----------------------- | --------------------------------------------------------------------------------------------------------------- |
 | Antigravity            | `antigravity`        | -                       | `~/.gemini/antigravity/mcp_config.json`                                                                         |
+| Antigravity CLI        | `antigravity-cli`    | -                       | `~/.gemini/antigravity-cli/mcp_config.json`                                                                     |
+| Antigravity IDE        | `antigravity-ide`    | -                       | `~/.gemini/antigravity-ide/mcp_config.json`                                                                     |
 | Cline VSCode Extension | `cline`              | -                       | `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` |
 | Cline CLI              | `cline-cli`          | -                       | `~/.cline/data/settings/cline_mcp_settings.json`                                                                |
 | Claude Code            | `claude-code`        | `.mcp.json`             | `~/.claude.json`                                                                                                |

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -48,6 +48,18 @@ const antigravityConfigPath = join(
   "antigravity",
   "mcp_config.json",
 );
+const antigravityIdeConfigPath = join(
+  home,
+  ".gemini",
+  "antigravity-ide",
+  "mcp_config.json",
+);
+const antigravityCliConfigPath = join(
+  home,
+  ".gemini",
+  "antigravity-cli",
+  "mcp_config.json",
+);
 const clineCliConfigPath = join(
   process.env.CLINE_DIR || join(home, ".cline"),
   "data",
@@ -406,7 +418,37 @@ export const agents: Record<AgentType, AgentConfig> = {
     supportedTransports: ["stdio", "http", "sse"],
     supportedFields: [],
     detectGlobalInstall: async () => {
-      return existsSync(join(home, ".gemini"));
+      return existsSync(join(home, ".gemini", "antigravity"));
+    },
+    transformConfig: transformAntigravityConfig,
+  },
+
+  "antigravity-ide": {
+    name: "antigravity-ide",
+    displayName: "Antigravity IDE",
+    configPath: antigravityIdeConfigPath,
+    projectDetectPaths: [], // Global only - no project support
+    configKey: "mcpServers",
+    format: "json",
+    supportedTransports: ["stdio", "http", "sse"],
+    supportedFields: [],
+    detectGlobalInstall: async () => {
+      return existsSync(join(home, ".gemini", "antigravity-ide"));
+    },
+    transformConfig: transformAntigravityConfig,
+  },
+
+  "antigravity-cli": {
+    name: "antigravity-cli",
+    displayName: "Antigravity CLI",
+    configPath: antigravityCliConfigPath,
+    projectDetectPaths: [], // Global only - no project support
+    configKey: "mcpServers",
+    format: "json",
+    supportedTransports: ["stdio", "http", "sse"],
+    supportedFields: [],
+    detectGlobalInstall: async () => {
+      return existsSync(join(home, ".gemini", "antigravity-cli"));
     },
     transformConfig: transformAntigravityConfig,
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,8 @@ import type { OptionalField } from "./schema.js";
 
 export type AgentType =
   | "antigravity"
+  | "antigravity-cli"
+  | "antigravity-ide"
   | "cline"
   | "cline-cli"
   | "claude-code"

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -59,10 +59,12 @@ function cleanup() {
 // Agent Configuration Tests
 // ============================================
 
-test("getAgentTypes returns all 15 agents", () => {
+test("getAgentTypes returns all 17 agents", () => {
   const types = getAgentTypes();
-  assert.strictEqual(types.length, 15);
+  assert.strictEqual(types.length, 17);
   assert.ok(types.includes("antigravity"));
+  assert.ok(types.includes("antigravity-cli"));
+  assert.ok(types.includes("antigravity-ide"));
   assert.ok(types.includes("cline"));
   assert.ok(types.includes("cline-cli"));
   assert.ok(types.includes("claude-code"));
@@ -154,6 +156,9 @@ test("supportsProjectConfig - returns true for project-capable agents", () => {
 });
 
 test("supportsProjectConfig - returns false for global-only agents", () => {
+  assert.strictEqual(supportsProjectConfig("antigravity"), false);
+  assert.strictEqual(supportsProjectConfig("antigravity-cli"), false);
+  assert.strictEqual(supportsProjectConfig("antigravity-ide"), false);
   assert.strictEqual(supportsProjectConfig("cline"), false);
   assert.strictEqual(supportsProjectConfig("cline-cli"), false);
   assert.strictEqual(supportsProjectConfig("claude-desktop"), false);
@@ -175,10 +180,12 @@ test("getProjectCapableAgents returns 9 agents", () => {
   assert.ok(projectAgents.includes("zed"));
 });
 
-test("getGlobalOnlyAgents returns 6 agents", () => {
+test("getGlobalOnlyAgents returns 8 agents", () => {
   const globalAgents = getGlobalOnlyAgents();
-  assert.strictEqual(globalAgents.length, 6);
+  assert.strictEqual(globalAgents.length, 8);
   assert.ok(globalAgents.includes("antigravity"));
+  assert.ok(globalAgents.includes("antigravity-cli"));
+  assert.ok(globalAgents.includes("antigravity-ide"));
   assert.ok(globalAgents.includes("cline"));
   assert.ok(globalAgents.includes("cline-cli"));
   assert.ok(globalAgents.includes("claude-desktop"));
@@ -316,6 +323,9 @@ test("detectProjectAgents - does not detect global-only agents", () => {
   assert.ok(!detected.includes("claude-desktop"));
   assert.ok(!detected.includes("goose"));
   assert.ok(!detected.includes("windsurf"));
+  assert.ok(!detected.includes("antigravity"));
+  assert.ok(!detected.includes("antigravity-cli"));
+  assert.ok(!detected.includes("antigravity-ide"));
 });
 
 // ============================================
@@ -335,6 +345,8 @@ test("isTransportSupported - all agents support stdio", () => {
 test("isTransportSupported - most agents support http", () => {
   const httpAgents: AgentType[] = [
     "antigravity",
+    "antigravity-cli",
+    "antigravity-ide",
     "cline",
     "cline-cli",
     "claude-code",
@@ -362,6 +374,8 @@ test("isTransportSupported - most agents support http", () => {
 test("isTransportSupported - most agents support sse", () => {
   const sseAgents: AgentType[] = [
     "antigravity",
+    "antigravity-cli",
+    "antigravity-ide",
     "cline",
     "cline-cli",
     "claude-code",
@@ -386,31 +400,43 @@ test("isTransportSupported - most agents support sse", () => {
   }
 });
 
-test("isTransportSupported - antigravity supports stdio, http, and sse", () => {
-  assert.strictEqual(
-    isTransportSupported("antigravity", "stdio"),
-    true,
-    "antigravity should support stdio",
-  );
-  assert.strictEqual(
-    isTransportSupported("antigravity", "http"),
-    true,
-    "antigravity should support http",
-  );
-  assert.strictEqual(
-    isTransportSupported("antigravity", "sse"),
-    true,
-    "antigravity should support sse",
-  );
+test("antigravity variants support stdio, http, and sse", () => {
+  for (const type of [
+    "antigravity",
+    "antigravity-cli",
+    "antigravity-ide",
+  ] as const) {
+    assert.strictEqual(
+      isTransportSupported(type, "stdio"),
+      true,
+      `${type} should support stdio`,
+    );
+    assert.strictEqual(
+      isTransportSupported(type, "http"),
+      true,
+      `${type} should support http`,
+    );
+    assert.strictEqual(
+      isTransportSupported(type, "sse"),
+      true,
+      `${type} should support sse`,
+    );
+  }
 });
 
-test("antigravity has no unsupportedTransportMessage", () => {
-  const msg = agents.antigravity.unsupportedTransportMessage;
-  assert.strictEqual(
-    msg,
-    undefined,
-    "antigravity should not have an unsupportedTransportMessage",
-  );
+test("antigravity variants have no unsupportedTransportMessage", () => {
+  for (const type of [
+    "antigravity",
+    "antigravity-cli",
+    "antigravity-ide",
+  ] as const) {
+    const msg = agents[type].unsupportedTransportMessage;
+    assert.strictEqual(
+      msg,
+      undefined,
+      `${type} should not have an unsupportedTransportMessage`,
+    );
+  }
 });
 
 test("isTransportSupported - claude-desktop only supports stdio", () => {


### PR DESCRIPTION
## Problem

Antigravity ships three separate data directories under `~/.gemini/`, each with its own `mcp_config.json`:

| Directory | Tool |
|-----------|------|
| `~/.gemini/antigravity/` | Standalone Antigravity app (already supported) |
| `~/.gemini/antigravity-ide/` | Antigravity IDE (VSCode-based fork) |
| `~/.gemini/antigravity-cli/` | `agy` CLI tool |

Currently `add-mcp` only writes to `~/.gemini/antigravity/mcp_config.json`. Users running the IDE or the CLI never see their servers because `add-mcp` writes to the wrong path.

## Solution

Adds two new agents:
- `antigravity-ide` → `~/.gemini/antigravity-ide/mcp_config.json`
- `antigravity-cli` → `~/.gemini/antigravity-cli/mcp_config.json`

Both reuse `transformAntigravityConfig` since the format is identical. Detection checks for the presence of the respective `~/.gemini/antigravity-{ide,cli}/` directory.

## Usage

```bash
# Install to IDE
bunx add-mcp postgres-mcp --agent antigravity-ide -g

# Install to CLI (agy)
bunx add-mcp postgres-mcp --agent antigravity-cli -g
```

## Testing

- `list-agents` output now shows all three `antigravity*` variants
- Build passes with `npm run build`