### PR TITLE
[codex] default find to integrations registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.13.2] - 2026-07-06
+
+- make `find` / `search` default to the integrations.sh registry on first run instead of prompting for an initial registry selection.
+
 ## [1.13.1] - 2026-07-05
 
 - expand the `find` / `search` registry from integrations.sh data and update registry messaging to point maintainers to integrations.sh.

--- a/README.md
+++ b/README.md
@@ -34,15 +34,15 @@ console.log(result);
 
 You can add env variables and arguments (stdio) and headers (remote) to the server config using the `--env`, `--args` and `--header` options. With `${VAR}` placeholders, interactive installs prompt for each variable (omit skipped optional keys so empty strings are not written to config).
 
-## Find an MCP Servers
+## Find MCP Servers
 
-Find and install MCP servers from the integrations.sh MCP registry and/or the official Anthropic MCP registry:
+Find and install MCP servers from the integrations.sh MCP registry:
 
 ```bash
 npx add-mcp find vercel
 ```
 
-When running `find`/`search` for the first time, the CLI prompts you to choose which registries to enable (integrations.sh MCP registry and/or official Anthropic registry). You can also add custom registries to the configuration file.
+The first `find`/`search` run automatically saves the integrations.sh registry to `~/.config/add-mcp/config.json` (or `$XDG_CONFIG_HOME/add-mcp/config.json`). You can edit that file to replace the default registry, add the official Anthropic registry, or point at any registry-compatible server.
 
 ## Supported Agents
 
@@ -284,9 +284,7 @@ If a selected remote server defines URL variables or header inputs:
 
 ### Configuring Registries for Find / Search
 
-The first time you run `find` or `search`, the CLI prompts you to choose which registries to enable. Your selection is saved to `~/.config/add-mcp/config.json` (respects `XDG_CONFIG_HOME`) and reused on every subsequent search.
-
-If you run with `-y` before this one-time registry setup is completed, the CLI exits with guidance to rerun without `--yes`.
+The first time you run `find` or `search`, the CLI automatically saves the integrations.sh MCP registry to `~/.config/add-mcp/config.json` (respects `XDG_CONFIG_HOME`) and reuses that registry on every subsequent search.
 
 ### Built-in Registries
 
@@ -308,7 +306,37 @@ bun run registry:verify
 
 ### Editing or Removing Registries
 
-Registry selections are stored in `~/.config/add-mcp/config.json` under the `findRegistries` key. You can edit this file directly to add, remove, or reorder registries:
+Registry selections are stored in `~/.config/add-mcp/config.json` under the `findRegistries` key. You can edit this file directly to replace, add, remove, or reorder registries.
+
+Default integrations.sh registry:
+
+```json
+{
+  "version": 1,
+  "findRegistries": [
+    {
+      "url": "https://mcp.agent-tooling.dev/api/v1/servers",
+      "label": "integrations.sh MCP registry"
+    }
+  ]
+}
+```
+
+Replace the default with the official Anthropic registry:
+
+```json
+{
+  "version": 1,
+  "findRegistries": [
+    {
+      "url": "https://registry.modelcontextprotocol.io/v0.1/servers",
+      "label": "Official Anthropic registry"
+    }
+  ]
+}
+```
+
+Search both integrations.sh and the official Anthropic registry:
 
 ```json
 {
@@ -326,7 +354,7 @@ Registry selections are stored in `~/.config/add-mcp/config.json` under the `fin
 }
 ```
 
-To reset and re-trigger the interactive selection prompt, remove the `findRegistries` key (or delete the file entirely).
+To reset to the default integrations.sh registry, remove the `findRegistries` key or delete the config file.
 
 ### Adding a Custom Registry
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-mcp",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "Add MCP servers to your favorite coding agents with a single command.",
   "author": "Andre Landgraf <andre@neon.tech>",
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,40 +168,23 @@ interface Options {
   gitignore?: boolean;
 }
 
-async function ensureFindRegistriesConfigured(
-  yes: boolean | undefined,
-): Promise<FindRegistrySearchConfig[] | null> {
+async function ensureFindRegistriesConfigured(): Promise<
+  FindRegistrySearchConfig[] | null
+> {
   const configured = await getFindRegistries();
   if (configured.length > 0) {
     return configured;
   }
 
-  p.log.warn("Find requires configuring one or more registries");
-  if (yes) {
-    p.log.error("Re-run without --yes to configure registries for find/search");
-    return null;
+  const defaultRegistry = getDefaultFindRegistries()[0];
+  if (!defaultRegistry) {
+    throw new Error("No default find registry is configured");
   }
 
-  const defaults = getDefaultFindRegistries();
-  const selected = await p.multiselect({
-    message:
-      "[One time] Please select what MCP registries you would like to configure globally for search",
-    options: defaults.map((registry) => ({
-      value: registry.url,
-      label: registry.label ?? registry.url,
-    })),
-    required: true,
-  });
-  if (p.isCancel(selected)) {
-    return null;
-  }
-
-  const selectedRegistries = defaults.filter((registry) =>
-    (selected as string[]).includes(registry.url),
-  );
+  const selectedRegistries = [defaultRegistry];
   await saveFindRegistries(selectedRegistries);
   p.log.info(
-    `Selection has been saved to ${shortenPath(getConfigPath())} - you can remove or update it any time.`,
+    `Using ${defaultRegistry.label ?? defaultRegistry.url}. Saved to ${shortenPath(getConfigPath())} - you can remove or update it any time.`,
   );
   return selectedRegistries;
 }
@@ -518,7 +501,7 @@ async function runFindCommand(
   };
   const query = (keyword ?? "").trim();
 
-  const registries = await ensureFindRegistriesConfigured(options.yes);
+  const registries = await ensureFindRegistriesConfigured();
   if (!registries) {
     p.cancel("Find cancelled");
     process.exit(0);

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -310,22 +310,46 @@ test("E2E CLI: global-only selections force a shared global scope", () => {
   assert.match(output, /Scope:\s*Global/);
 });
 
-test("E2E CLI: find -y without registry config asks to configure registries", () => {
+test("E2E CLI: find -y seeds the default registry and installs", () => {
   const projectDir = createTempDir();
   const homeDir = createTempDir();
 
   const result = runCli(
-    ["find", "postman", "-a", "cursor", "-y"],
+    ["find", "neon", "-a", "cursor", "-y"],
     projectDir,
     homeDir,
   );
-  assert.strictEqual(result.status, 0, "CLI should exit gracefully");
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
 
   const output = `${result.stdout}\n${result.stderr}`;
-  assert.match(output, /Find requires configuring one or more registries/);
-  assert.match(
-    output,
-    /Re-run without --yes to configure registries for find\/search/,
+  assert.match(output, /Using integrations\.sh MCP registry/);
+
+  const addMcpConfigPath = join(homeDir, ".config", "add-mcp", "config.json");
+  const addMcpConfig = JSON.parse(readFileSync(addMcpConfigPath, "utf-8")) as {
+    findRegistries?: Array<{ url: string; label?: string }>;
+  };
+  assert.deepStrictEqual(addMcpConfig.findRegistries, [
+    {
+      url: "https://mcp.agent-tooling.dev/api/v1/servers",
+      label: "integrations.sh MCP registry",
+    },
+  ]);
+
+  const cursorConfigPath = join(projectDir, ".cursor", "mcp.json");
+  assert.strictEqual(existsSync(cursorConfigPath), true);
+  const cursorConfig = JSON.parse(readFileSync(cursorConfigPath, "utf-8")) as {
+    mcpServers?: Record<string, { url?: string }>;
+  };
+  const neonConfig = Object.values(cursorConfig.mcpServers ?? {}).find(
+    (server) => server.url === "https://mcp.neon.tech/mcp",
+  );
+  assert.ok(
+    neonConfig,
+    "Neon remote should be installed from default registry",
   );
 });
 


### PR DESCRIPTION
## Summary

- Default first-run `find` / `search` to the integrations.sh MCP registry instead of prompting for an initial registry selection.
- Keep the existing `~/.config/add-mcp/config.json` registry storage path as the override point.
- Document how to replace the default with the official Anthropic registry or combine both registries.
- Bump to `1.13.2` with a changelog entry.

## Validation

- `bun install --frozen-lockfile`
- `bun run registry:verify`
- `bun run typecheck`
- `bun run test`
- `bun run fmt`
- `bun run build`
- `bun run typecheck`
- `bun run test`
- Manual isolated interactive smoke: `find neon -a cursor` seeded integrations.sh and went directly to server selection.

## Notes

- `bun run fallow -- --summary` still fails on existing dead-code / duplication / complexity findings; CI does not run Fallow.
