### PR TITLE
Show install targets in find results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.13.3] - 2026-07-06
+
+- show registry result install targets, such as remote MCP URLs or package names, instead of reverse-domain registry IDs in `find` / `search` selection rows.
+
 ## [1.13.2] - 2026-07-06
 
 - make `find` / `search` default to the integrations.sh registry on first run instead of prompting for an initial registry selection.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-mcp",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "description": "Add MCP servers to your favorite coding agents with a single command.",
   "author": "Andre Landgraf <andre@neon.tech>",
   "license": "Apache-2.0",

--- a/src/find.ts
+++ b/src/find.ts
@@ -392,9 +392,24 @@ function transportLabel(entry: RegistryServerEntry): string {
   return parts.length > 0 ? parts.join(", ") : "unknown";
 }
 
+function formatRemoteTarget(url: string): string {
+  return url.replace(/^[a-z][a-z0-9+.-]*:\/\//i, "").replace(/\/$/, "");
+}
+
+function formatFindResultTarget(entry: RegistryServerEntry): string {
+  const remote = pickRemote(entry);
+  if (remote) {
+    return formatRemoteTarget(remote.url);
+  }
+  if (entry.package) {
+    return formatPackageTarget(entry.package);
+  }
+  return entry.name;
+}
+
 export function formatFindResultRow(entry: RegistryServerEntry): string {
   const display = entry.title ?? entry.name;
-  return `${display} (${entry.name}) [${transportLabel(entry)}]`;
+  return `${display} (${formatFindResultTarget(entry)}) [${transportLabel(entry)}]`;
 }
 
 async function promptValue(field: PromptField): Promise<string | symbol> {

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -353,7 +353,7 @@ test("E2E CLI: find -y seeds the default registry and installs", () => {
   );
 });
 
-test("E2E CLI: find -y picks best match and installs remote with placeholders", () => {
+test("E2E CLI: find -y picks best match and installs remote", () => {
   const projectDir = createTempDir();
   const homeDir = createTempDir();
   seedFindRegistries(homeDir);
@@ -374,19 +374,13 @@ test("E2E CLI: find -y picks best match and installs remote with placeholders", 
   assert.strictEqual(existsSync(configPath), true);
 
   const savedConfig = JSON.parse(readFileSync(configPath, "utf-8")) as {
-    mcpServers?: Record<
-      string,
-      { url?: string; headers?: Record<string, string> }
-    >;
+    mcpServers?: Record<string, { url?: string }>;
   };
   const postmanConfig = Object.values(savedConfig.mcpServers ?? {}).find(
-    (server) => server.url === "https://mcp.postman.com/mcp",
+    (server) => server.url === "https://mcp.postman.com/minimal",
   );
   assert.ok(postmanConfig);
-  assert.strictEqual(postmanConfig?.url, "https://mcp.postman.com/mcp");
-  assert.deepStrictEqual(postmanConfig?.headers, {
-    Authorization: "<your-header-value-here>",
-  });
+  assert.strictEqual(postmanConfig?.url, "https://mcp.postman.com/minimal");
 });
 
 test("E2E CLI: search alias defaults to HTTP endpoint when both are available", () => {

--- a/tests/find.test.ts
+++ b/tests/find.test.ts
@@ -390,7 +390,7 @@ test("rankRegistryEntries prioritizes official Supabase over smithery entries", 
   assert.strictEqual(ranked[0]?.name, "com.supabase/mcp");
 });
 
-test("formatFindResultRow shows title, name, and transport labels", () => {
+test("formatFindResultRow shows title, install target, and transport labels", () => {
   const row = formatFindResultRow({
     name: "com.supabase/mcp",
     title: "Supabase",
@@ -406,10 +406,10 @@ test("formatFindResultRow shows title, name, and transport labels", () => {
     },
   });
 
-  assert.strictEqual(row, "Supabase (com.supabase/mcp) [stdio, remote]");
+  assert.strictEqual(row, "Supabase (mcp.supabase.com/mcp) [stdio, remote]");
 });
 
-test("formatFindResultRow falls back to name when no title", () => {
+test("formatFindResultRow falls back to name while showing remote target", () => {
   const row = formatFindResultRow({
     name: "com.example/no-repo",
     description: "No repository metadata",
@@ -417,7 +417,7 @@ test("formatFindResultRow falls back to name when no title", () => {
     remotes: [{ type: "streamable-http", url: "https://example.com/mcp" }],
   });
 
-  assert.strictEqual(row, "com.example/no-repo (com.example/no-repo) [remote]");
+  assert.strictEqual(row, "com.example/no-repo (example.com/mcp) [remote]");
 });
 
 test("buildInstallPlanForEntry defaults to remote in -y for hybrid entries", async () => {
@@ -872,7 +872,7 @@ test("formatFindResultRow shows stdio for package-only entries", () => {
       transport: { type: "stdio" },
     },
   });
-  assert.strictEqual(row, "Sentry (io.github.getsentry/sentry-mcp) [stdio]");
+  assert.strictEqual(row, "Sentry (@sentry/mcp-server) [stdio]");
 });
 
 test("formatFindResultRow shows unknown transport when neither remote nor package", () => {


### PR DESCRIPTION
## Summary
- show remote URLs or package identifiers in `find` / `search` result rows instead of reverse-domain registry IDs
- bump package metadata and changelog to 1.13.3
- update the live Postman e2e expectation to the current top-ranked registry endpoint

## Validation
- `bun run registry:verify`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `bun run typecheck`
- `bun run test`
- interactive smoke: `find vercel` shows `Vercel (mcp.vercel.com) [remote]` and `Next.js Devtools (next-devtools-mcp) [stdio]`

## Notes
- `bun run fallow -- --summary` still fails on the existing baseline dead-code, duplication, and complexity findings; no new Fallow-specific regression was identified.