### PR TITLE
Move default find registry to add-mcp.com/registry (v1.14.0), auto-migrate saved configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.14.0] - 2026-07-06
+
+- move the default `find` / `search` registry to its new home at `https://add-mcp.com/registry/api/v1/servers` (label: "add-mcp registry"). The previous `mcp.agent-tooling.dev` URL keeps working; saved configs referencing it are migrated automatically on the next `find` / `search` run (custom labels are preserved, duplicates are deduped).
+
 ## [1.13.3] - 2026-07-06
 
 - show registry result install targets, such as remote MCP URLs or package names, instead of reverse-domain registry IDs in `find` / `search` selection rows.

--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ You can add env variables and arguments (stdio) and headers (remote) to the serv
 
 ## Find MCP Servers
 
-Find and install MCP servers from the integrations.sh MCP registry:
+Find and install MCP servers from the [add-mcp registry](https://add-mcp.com/registry):
 
 ```bash
 npx add-mcp find vercel
 ```
 
-The first `find`/`search` run automatically saves the integrations.sh registry to `~/.config/add-mcp/config.json` (or `$XDG_CONFIG_HOME/add-mcp/config.json`). You can edit that file to replace the default registry, add the official Anthropic registry, or point at any registry-compatible server.
+The first `find`/`search` run automatically saves the add-mcp registry to `~/.config/add-mcp/config.json` (or `$XDG_CONFIG_HOME/add-mcp/config.json`). You can edit that file to replace the default registry, add the official Anthropic registry, or point at any registry-compatible server.
 
 ## Supported Agents
 
@@ -284,14 +284,16 @@ If a selected remote server defines URL variables or header inputs:
 
 ### Configuring Registries for Find / Search
 
-The first time you run `find` or `search`, the CLI automatically saves the integrations.sh MCP registry to `~/.config/add-mcp/config.json` (respects `XDG_CONFIG_HOME`) and reuses that registry on every subsequent search.
+The first time you run `find` or `search`, the CLI automatically saves the add-mcp registry to `~/.config/add-mcp/config.json` (respects `XDG_CONFIG_HOME`) and reuses that registry on every subsequent search.
 
 ### Built-in Registries
 
-| Registry                         | Base URL                                                | Description                                                                                                                                                      |
-| -------------------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **integrations.sh MCP registry** | `https://mcp.agent-tooling.dev/api/v1/servers`          | MCP servers discovered by integrations.sh and exposed through an MCP registry-compatible API, using add-mcp's checked-in `registry.json` as the source of truth. |
-| **Official Anthropic registry**  | `https://registry.modelcontextprotocol.io/v0.1/servers` | The community-driven MCP server registry maintained by Anthropic. Contains the broadest catalog of MCP servers.                                                  |
+| Registry                        | Base URL                                                | Description                                                                                                                                                      |
+| ------------------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **add-mcp registry**            | `https://add-mcp.com/registry/api/v1/servers`           | MCP servers discovered by integrations.sh and exposed through an MCP registry-compatible API, using add-mcp's checked-in `registry.json` as the source of truth. |
+| **Official Anthropic registry** | `https://registry.modelcontextprotocol.io/v0.1/servers` | The community-driven MCP server registry maintained by Anthropic. Contains the broadest catalog of MCP servers.                                                  |
+
+> The add-mcp registry previously lived at `https://mcp.agent-tooling.dev/api/v1/servers`. That URL keeps working, and saved configs referencing it are migrated to the add-mcp.com address automatically on the next `find`/`search` run.
 
 ### Missing A Server in integrations.sh?
 
@@ -308,15 +310,15 @@ bun run registry:verify
 
 Registry selections are stored in `~/.config/add-mcp/config.json` under the `findRegistries` key. You can edit this file directly to replace, add, remove, or reorder registries.
 
-Default integrations.sh registry:
+Default add-mcp registry:
 
 ```json
 {
   "version": 1,
   "findRegistries": [
     {
-      "url": "https://mcp.agent-tooling.dev/api/v1/servers",
-      "label": "integrations.sh MCP registry"
+      "url": "https://add-mcp.com/registry/api/v1/servers",
+      "label": "add-mcp registry"
     }
   ]
 }
@@ -336,15 +338,15 @@ Replace the default with the official Anthropic registry:
 }
 ```
 
-Search both integrations.sh and the official Anthropic registry:
+Search both the add-mcp registry and the official Anthropic registry:
 
 ```json
 {
   "version": 1,
   "findRegistries": [
     {
-      "url": "https://mcp.agent-tooling.dev/api/v1/servers",
-      "label": "integrations.sh MCP registry"
+      "url": "https://add-mcp.com/registry/api/v1/servers",
+      "label": "add-mcp registry"
     },
     {
       "url": "https://registry.modelcontextprotocol.io/v0.1/servers",
@@ -354,7 +356,7 @@ Search both integrations.sh and the official Anthropic registry:
 }
 ```
 
-To reset to the default integrations.sh registry, remove the `findRegistries` key or delete the config file.
+To reset to the default add-mcp registry, remove the `findRegistries` key or delete the config file.
 
 ### Adding a Custom Registry
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-mcp",
-  "version": "1.13.3",
+  "version": "1.14.0",
   "description": "Add MCP servers to your favorite coding agents with a single command.",
   "author": "Andre Landgraf <andre@neon.tech>",
   "license": "Apache-2.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,31 @@ export interface FindRegistryConfigEntry {
   label?: string;
 }
 
+export const DEFAULT_FIND_REGISTRY_URL =
+  "https://add-mcp.com/registry/api/v1/servers";
+export const DEFAULT_FIND_REGISTRY_LABEL = "add-mcp registry";
+
+/**
+ * Previous home of the default registry. The URL keeps working, but saved
+ * configs are auto-migrated to the add-mcp.com address on read.
+ */
+export const LEGACY_FIND_REGISTRY_URL =
+  "https://mcp.agent-tooling.dev/api/v1/servers";
+const LEGACY_FIND_REGISTRY_LABEL = "integrations.sh MCP registry";
+
+function migrateFindRegistryEntry(
+  entry: FindRegistryConfigEntry,
+): FindRegistryConfigEntry {
+  if (entry.url !== LEGACY_FIND_REGISTRY_URL) {
+    return entry;
+  }
+  const label =
+    !entry.label || entry.label === LEGACY_FIND_REGISTRY_LABEL
+      ? DEFAULT_FIND_REGISTRY_LABEL
+      : entry.label;
+  return { url: DEFAULT_FIND_REGISTRY_URL, label };
+}
+
 export interface AddMcpConfig {
   version: number;
   lastSelectedAgents?: string[];
@@ -105,7 +130,37 @@ export async function saveSelectedAgents(agents: string[]): Promise<void> {
 export async function getFindRegistries(): Promise<FindRegistryConfigEntry[]> {
   const config = await readConfig();
   if (!config.findRegistries) return [];
-  return config.findRegistries.map(normalizeFindRegistryEntry);
+
+  const normalized = config.findRegistries.map(normalizeFindRegistryEntry);
+
+  // Migrate legacy registry URLs and drop duplicates that migration may
+  // produce (e.g. a config that already listed both the old and new URL).
+  const migrated: FindRegistryConfigEntry[] = [];
+  const seen = new Set<string>();
+  for (const entry of normalized.map(migrateFindRegistryEntry)) {
+    if (seen.has(entry.url)) continue;
+    seen.add(entry.url);
+    migrated.push(entry);
+  }
+
+  const changed =
+    migrated.length !== normalized.length ||
+    migrated.some(
+      (entry, i) =>
+        entry.url !== normalized[i]?.url ||
+        entry.label !== normalized[i]?.label,
+    );
+
+  if (changed) {
+    try {
+      config.findRegistries = migrated;
+      await writeConfig(config);
+    } catch {
+      // Best-effort persistence; the in-memory result is already migrated.
+    }
+  }
+
+  return migrated;
 }
 
 interface LegacyFindRegistryEntry {

--- a/src/find.ts
+++ b/src/find.ts
@@ -1,4 +1,8 @@
 import * as p from "@clack/prompts";
+import {
+  DEFAULT_FIND_REGISTRY_LABEL,
+  DEFAULT_FIND_REGISTRY_URL,
+} from "./config.js";
 import type { TransportType } from "./types.js";
 import {
   type PackageArgPrompt,
@@ -217,14 +221,11 @@ export function resolveOfficialRegistryServersUrl(): string {
   return `${OFFICIAL_REGISTRY_BASE_URL}/v0.1/servers`;
 }
 
-const VERIFIED_ESSENTIALS_DEFAULT_SERVERS_URL =
-  "https://mcp.agent-tooling.dev/api/v1/servers";
-
 export function getDefaultFindRegistries(): FindRegistrySearchConfig[] {
   return [
     {
-      url: VERIFIED_ESSENTIALS_DEFAULT_SERVERS_URL,
-      label: "integrations.sh MCP registry",
+      url: DEFAULT_FIND_REGISTRY_URL,
+      label: DEFAULT_FIND_REGISTRY_LABEL,
     },
     {
       url: resolveOfficialRegistryServersUrl(),

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -24,6 +24,7 @@ import {
   readConfig,
   saveFindRegistries,
   saveSelectedAgents,
+  type AddMcpConfig,
 } from "../src/config.js";
 
 let passed = 0;
@@ -108,8 +109,8 @@ async function run() {
     setupTempHome();
     await saveFindRegistries([
       {
-        url: "https://mcp.agent-tooling.dev/api/v1/servers",
-        label: "integrations.sh MCP registry",
+        url: "https://add-mcp.com/registry/api/v1/servers",
+        label: "add-mcp registry",
       },
       {
         url: "https://registry.modelcontextprotocol.io/v0.1/servers",
@@ -119,12 +120,83 @@ async function run() {
     const registries = await getFindRegistries();
     assert.deepStrictEqual(registries, [
       {
+        url: "https://add-mcp.com/registry/api/v1/servers",
+        label: "add-mcp registry",
+      },
+      {
+        url: "https://registry.modelcontextprotocol.io/v0.1/servers",
+        label: "Official Anthropic registry",
+      },
+    ]);
+  });
+
+  await test("getFindRegistries migrates the legacy registry URL and persists it", async () => {
+    setupTempHome();
+    await saveFindRegistries([
+      {
         url: "https://mcp.agent-tooling.dev/api/v1/servers",
         label: "integrations.sh MCP registry",
       },
       {
         url: "https://registry.modelcontextprotocol.io/v0.1/servers",
         label: "Official Anthropic registry",
+      },
+    ]);
+
+    const registries = await getFindRegistries();
+    assert.deepStrictEqual(registries, [
+      {
+        url: "https://add-mcp.com/registry/api/v1/servers",
+        label: "add-mcp registry",
+      },
+      {
+        url: "https://registry.modelcontextprotocol.io/v0.1/servers",
+        label: "Official Anthropic registry",
+      },
+    ]);
+
+    const persisted = JSON.parse(
+      readFileSync(getConfigPath(), "utf-8"),
+    ) as AddMcpConfig;
+    assert.deepStrictEqual(persisted.findRegistries, registries);
+  });
+
+  await test("getFindRegistries keeps a custom label on the migrated URL", async () => {
+    setupTempHome();
+    await saveFindRegistries([
+      {
+        url: "https://mcp.agent-tooling.dev/api/v1/servers",
+        label: "My pinned registry",
+      },
+    ]);
+
+    const registries = await getFindRegistries();
+    assert.deepStrictEqual(registries, [
+      {
+        url: "https://add-mcp.com/registry/api/v1/servers",
+        label: "My pinned registry",
+      },
+    ]);
+  });
+
+  await test("getFindRegistries dedupes when old and new URLs both exist", async () => {
+    setupTempHome();
+    await saveFindRegistries([
+      {
+        url: "https://add-mcp.com/registry/api/v1/servers",
+        label: "add-mcp registry",
+      },
+      {
+        url: "https://mcp.agent-tooling.dev/api/v1/servers",
+        label: "integrations.sh MCP registry",
+      },
+    ]);
+
+    const registries = await getFindRegistries();
+    assert.deepStrictEqual(registries, [
+      {
+        url: "https://add-mcp.com/registry/api/v1/servers",
+        label: "add-mcp registry",
       },
     ]);
   });

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -103,8 +103,8 @@ function seedFindRegistries(homeDir: string) {
         version: 1,
         findRegistries: [
           {
-            url: "https://mcp.agent-tooling.dev/api/v1/servers",
-            label: "integrations.sh MCP registry",
+            url: "https://add-mcp.com/registry/api/v1/servers",
+            label: "add-mcp registry",
           },
           {
             url: "https://registry.modelcontextprotocol.io/v0.1/servers",
@@ -326,7 +326,7 @@ test("E2E CLI: find -y seeds the default registry and installs", () => {
   }
 
   const output = `${result.stdout}\n${result.stderr}`;
-  assert.match(output, /Using integrations\.sh MCP registry/);
+  assert.match(output, /Using add-mcp registry/);
 
   const addMcpConfigPath = join(homeDir, ".config", "add-mcp", "config.json");
   const addMcpConfig = JSON.parse(readFileSync(addMcpConfigPath, "utf-8")) as {
@@ -334,8 +334,8 @@ test("E2E CLI: find -y seeds the default registry and installs", () => {
   };
   assert.deepStrictEqual(addMcpConfig.findRegistries, [
     {
-      url: "https://mcp.agent-tooling.dev/api/v1/servers",
-      label: "integrations.sh MCP registry",
+      url: "https://add-mcp.com/registry/api/v1/servers",
+      label: "add-mcp registry",
     },
   ]);
 

--- a/tests/find.test.ts
+++ b/tests/find.test.ts
@@ -896,14 +896,14 @@ test("resolveServerName returns 'server' as ultimate fallback", () => {
 test("formatRegistryFailure shows label for known registries", () => {
   const msg = formatRegistryFailure({
     registry: {
-      url: "https://mcp.agent-tooling.dev/api/v1/servers",
-      label: "integrations.sh MCP registry",
+      url: "https://add-mcp.com/registry/api/v1/servers",
+      label: "add-mcp registry",
     },
     detail: "HTTP 500",
   });
-  assert.strictEqual(msg.includes('"integrations.sh MCP registry"'), true);
+  assert.strictEqual(msg.includes('"add-mcp registry"'), true);
   assert.strictEqual(
-    msg.includes("https://mcp.agent-tooling.dev/api/v1/servers"),
+    msg.includes("https://add-mcp.com/registry/api/v1/servers"),
     true,
   );
   assert.strictEqual(msg.includes("HTTP 500"), true);
@@ -926,7 +926,7 @@ test("formatRegistryFailure shows only URL for custom registries", () => {
 test("getDefaultFindRegistries returns two hardcoded registries", () => {
   const defaults = getDefaultFindRegistries();
   assert.strictEqual(defaults.length, 2);
-  assert.ok(defaults[0]?.url.includes("agent-tooling.dev"));
+  assert.ok(defaults[0]?.url.includes("add-mcp.com/registry"));
   assert.ok(defaults[1]?.url.includes("modelcontextprotocol.io"));
 });
 


### PR DESCRIPTION
## Summary

- The default `find`/`search` registry moves to its new home: `https://add-mcp.com/registry/api/v1/servers`, labeled **add-mcp registry** (was `mcp.agent-tooling.dev`, "integrations.sh MCP registry").
- **Auto-migration ("update" behavior):** `getFindRegistries` rewrites saved config entries that reference the legacy URL to the new one — preserving custom labels, deduping when a config already lists both URLs — and persists the migrated config. Users don't have to touch `~/.config/add-mcp/config.json`.
- **No breakage either way:** the legacy URL stays live on the server side forever (the registry serves old root URLs with 200s), so CLIs released before this change keep working untouched.
- Version bumped to 1.14.0 with a changelog entry; README registry docs updated with the new URLs and a migration note.

## Rollout ordering (important)

`https://add-mcp.com/registry` must be live **before** this ships:

1. agent-tooling/mcp-registry#7 — registry base path (merge + deploy first)
2. #68 — add-mcp.com website with the `/registry` proxy (merge + deploy second)
3. This PR — merge once add-mcp.com/registry responds, then cut the v1.14.0 release

⚠️ CI on this PR will stay red until step 2 is deployed: the e2e `find` tests hit the real default registry URL over the network. Re-run checks after add-mcp.com/registry is live.

## Test plan

- [x] Typecheck, unit tests (13 config + 40 find pass), `bun run build`
- [x] New tests: legacy URL migrated + persisted; custom label preserved; old+new dedupe
- [ ] e2e tests once add-mcp.com/registry is live

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the default registry used by `find` and `search` to the new add-mcp registry.
  * Saved registry settings are now automatically updated to the new registry on the next run, while preserving custom labels and removing duplicates.

* **Documentation**
  * Refreshed the changelog and setup guidance to reflect the new default registry and first-run experience.

* **Bug Fixes**
  * Improved registry migration behavior so existing configurations continue working without manual changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->