### PR TITLE
Add GitHub star + npm download badges to add-mcp.com header

### DIFF
--- a/web/components.ts
+++ b/web/components.ts
@@ -1,9 +1,11 @@
 import { defineComponents } from "blume";
 
 import Footer from "./components/Footer.astro";
+import Header from "./components/Header.astro";
 
 export default defineComponents({
   layout: {
+    Header,
     Footer,
   },
 });

--- a/web/components/Header.astro
+++ b/web/components/Header.astro
@@ -1,0 +1,16 @@
+---
+// Wraps Blume's built-in header to add the GitHub/npm stat badges to the
+// action area on docs pages (registered as the Header layout slot in
+// components.ts). The landing page passes HeaderBadges to PageLayout's
+// `ask` slot directly, landing in the same spot.
+import BlumeHeader from "blume/components/layout/Header.astro";
+
+import HeaderBadges from "./HeaderBadges.astro";
+---
+
+<BlumeHeader {...Astro.props}>
+  <Fragment slot="ask">
+    <HeaderBadges />
+    <slot name="ask" />
+  </Fragment>
+</BlumeHeader>

--- a/web/components/HeaderBadges.astro
+++ b/web/components/HeaderBadges.astro
@@ -1,0 +1,50 @@
+---
+// GitHub stars + npm weekly downloads, shown in the header on every page.
+// Stats are fetched at build time (static site), so they refresh per deploy.
+import { fetchProjectStats } from "../lib/stats.ts";
+
+const { stars, weeklyDownloads } = await fetchProjectStats();
+
+const badge =
+  "inline-flex h-9 items-center gap-1.5 rounded-full px-3 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground";
+---
+
+<a
+  aria-label="add-mcp on GitHub"
+  class={badge}
+  href="https://github.com/neon-solutions/add-mcp"
+  rel="noreferrer"
+  target="_blank"
+>
+  <svg aria-hidden="true" fill="currentColor" height="16" viewBox="0 0 16 16" width="16">
+    <path
+      d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"
+    ></path>
+  </svg>
+  {
+    stars && (
+      <span class="hidden items-center gap-1 sm:inline-flex">
+        <svg aria-hidden="true" fill="currentColor" height="12" viewBox="0 0 16 16" width="12">
+          <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
+        </svg>
+        {stars}
+      </span>
+    )
+  }
+</a>
+<a
+  aria-label="add-mcp on npm"
+  class={badge}
+  href="https://www.npmjs.com/package/add-mcp"
+  rel="noreferrer"
+  target="_blank"
+>
+  <svg aria-hidden="true" fill="currentColor" height="16" viewBox="0 0 16 16" width="16">
+    <path d="M0 0v16h16V0H0zm13 13h-2V5H8v8H3V3h10v10z"></path>
+  </svg>
+  {
+    weeklyDownloads && (
+      <span class="hidden sm:inline">{weeklyDownloads}/wk</span>
+    )
+  }
+</a>

--- a/web/lib/stats.ts
+++ b/web/lib/stats.ts
@@ -1,0 +1,52 @@
+const compact = new Intl.NumberFormat("en", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
+export interface ProjectStats {
+  /** e.g. "245" — null when the fetch failed at build time. */
+  stars: string | null;
+  /** e.g. "180k" — null when the fetch failed at build time. */
+  weeklyDownloads: string | null;
+}
+
+/**
+ * Fetched once per build (static output), so the numbers refresh on every
+ * deploy. Failures degrade to plain links without counts instead of failing
+ * the build — the GitHub API is unauthenticated and rate-limited per IP.
+ */
+export async function fetchProjectStats(): Promise<ProjectStats> {
+  const [stars, weeklyDownloads] = await Promise.all([
+    fetchStars(),
+    fetchWeeklyDownloads(),
+  ]);
+  return { stars, weeklyDownloads };
+}
+
+async function fetchStars(): Promise<string | null> {
+  try {
+    const res = await fetch("https://api.github.com/repos/neon-solutions/add-mcp");
+    if (!res.ok) return null;
+    const data = (await res.json()) as { stargazers_count?: number };
+    return typeof data.stargazers_count === "number"
+      ? compact.format(data.stargazers_count)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchWeeklyDownloads(): Promise<string | null> {
+  try {
+    const res = await fetch(
+      "https://api.npmjs.org/downloads/point/last-week/add-mcp",
+    );
+    if (!res.ok) return null;
+    const data = (await res.json()) as { downloads?: number };
+    return typeof data.downloads === "number"
+      ? compact.format(data.downloads)
+      : null;
+  } catch {
+    return null;
+  }
+}

--- a/web/pages/index.astro
+++ b/web/pages/index.astro
@@ -3,6 +3,7 @@ import PageLayout from "blume/components/layout/PageLayout.astro";
 import data from "blume:data";
 
 import Footer from "../components/Footer.astro";
+import HeaderBadges from "../components/HeaderBadges.astro";
 
 const { config } = data;
 
@@ -104,6 +105,7 @@ const structuredData = JSON.stringify({
     description: config.description,
   }}
 >
+  <HeaderBadges slot="ask" />
   <script is:inline set:html={structuredData} type="application/ld+json" />
   <section class="mx-auto max-w-4xl px-6 pt-24 pb-16 text-center">
     <h1 class="text-4xl font-semibold tracking-tight text-balance sm:text-5xl">


### PR DESCRIPTION
## Summary
- Adds GitHub (with star count) and npm (with weekly downloads) badges to the header on every add-mcp.com page — landing and docs.
- Stats are fetched at build time from the GitHub and npm APIs and formatted compactly (e.g. `★ 245`, `180.2K/wk`); fetch failures degrade to plain icon links instead of failing the build.
- Docs pages get the badges via a `Header` layout-slot wrapper around Blume's built-in header; the landing page passes the same `HeaderBadges` component through `PageLayout`'s `ask` slot. Counts hide below the `sm` breakpoint (icons only on mobile).

## Test plan
- [x] `bun run build` succeeds; badges present in built HTML for `/` and `/docs`
- [x] Screenshots verified on desktop (landing + docs) and mobile viewport

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a refreshed header area to the site layout.
  * Displayed live project badges for GitHub stars and npm weekly downloads.
  * Surfaced the same header badge content on the home page.

* **Chores**
  * Introduced build-time project stats fetching with graceful fallback when data isn’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->