### PR TITLE
Link integrations.sh in registry hero

### DIFF
--- a/registry/src/app/page.tsx
+++ b/registry/src/app/page.tsx
@@ -19,6 +19,7 @@ import {
   EmptyTitle,
 } from "@/components/ui/empty";
 import { getTrendingTerms } from "@/lib/analytics/search-stats";
+import { BRAND } from "@/lib/brand";
 import { getRegistryOverview, listServersByPage } from "@/lib/registry-service";
 import { getSiteConfig } from "@/lib/site-config";
 
@@ -107,7 +108,16 @@ export default async function HomePage({ searchParams }: PageProps) {
               {site.name}
             </h1>
             <p className="text-pretty text-base text-muted-foreground md:text-lg">
-              {site.description}
+              Registry for the add-mcp CLI — a cached snapshot of the{" "}
+              <a
+                href={BRAND.integrationsShUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="font-medium text-foreground underline underline-offset-4 transition-colors hover:text-primary"
+              >
+                integrations.sh
+              </a>{" "}
+              MCP servers, ranked by searches.
             </p>
           </div>
 

--- a/registry/src/lib/brand.ts
+++ b/registry/src/lib/brand.ts
@@ -10,6 +10,7 @@ export const BRAND = {
   githubUrl: "https://github.com/neon-solutions/add-mcp",
   npmUrl: "https://www.npmjs.com/package/add-mcp",
   blumeUrl: "https://blume-eight.vercel.app",
+  integrationsShUrl: "https://integrations.sh",
   authorUrl: "https://x.com/andrelandgraf",
   authorName: "andrelandgraf",
 } as const;


### PR DESCRIPTION
Makes integrations.sh a link (new tab) in the registry homepage hero. Plain-text description unchanged for page metadata.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the home page hero text with a clearer product description.
  * Added a new link in the hero area that opens an external integrations page in a new tab.

* **UI Updates**
  * Improved the styling of the hero link for better visibility and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->