### PR TITLE
feat: add Grok Build agent support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # add-mcp
 
-A CLI to install MCP servers for different coding agents (Claude Code, Cursor, VS Code, OpenCode, Codex) with a single command.
+A CLI to install MCP servers for different coding agents (Claude Code, Cursor, VS Code, OpenCode, Codex, Grok Build) with a single command.
 
 ## Dev environment
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.15.0] - 2026-07-11
+
+- add `grok-build` support with project installs to `.grok/config.toml` and global installs to `~/.grok/config.toml` (`mcp_servers` TOML tables); alias: `grok`
+
 ## [1.14.0] - 2026-07-06
 
 - move the default `find` / `search` registry to its new home at `https://add-mcp.com/registry/api/v1/servers` (label: "add-mcp registry"). The previous `mcp.agent-tooling.dev` URL keeps working; saved configs referencing it are migrated automatically on the next `find` / `search` run (custom labels are preserved, duplicates are deduped).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Add MCP servers to your favorite coding agents with a single command.
 
-Supports **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **VSCode** and [10 more](#supported-agents).
+Supports **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **VS Code**, **Grok Build** and [10 more](#supported-agents).
 
 Docs and registry: [add-mcp.com](https://add-mcp.com)
 
@@ -62,13 +62,14 @@ MCP servers can be installed to any of these agents:
 | Gemini CLI             | `gemini-cli`         | `.gemini/settings.json` | `~/.gemini/settings.json`                                                                                       |
 | Goose                  | `goose`              | `.goose/config.yaml`    | `~/.config/goose/config.yaml`                                                                                   |
 | GitHub Copilot CLI     | `github-copilot-cli` | `.vscode/mcp.json`      | `~/.copilot/mcp-config.json`                                                                                    |
+| Grok Build             | `grok-build`         | `.grok/config.toml`     | `~/.grok/config.toml`                                                                                           |
 | MCPorter               | `mcporter`           | `config/mcporter.json`  | `~/.mcporter/mcporter.json` (or existing `~/.mcporter/mcporter.jsonc`)                                          |
 | OpenCode               | `opencode`           | `opencode.json`         | `~/.config/opencode/opencode.json`                                                                              |
 | VS Code                | `vscode`             | `.vscode/mcp.json`      | `~/Library/Application Support/Code/User/mcp.json`                                                              |
 | Windsurf               | `windsurf`           | -                       | `~/.codeium/windsurf/mcp_config.json`                                                                           |
 | Zed                    | `zed`                | `.zed/settings.json`    | `~/Library/Application Support/Zed/settings.json`                                                               |
 
-**Aliases:** `codeium`, `cascade` → `windsurf`, `cline-vscode` → `cline`, `gemini` → `gemini-cli`, `github-copilot` → `vscode`
+**Aliases:** `codeium`, `cascade` → `windsurf`, `cline-vscode` → `cline`, `gemini` → `gemini-cli`, `github-copilot` → `vscode`, `grok` → `grok-build`
 
 ## Installation Scope
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-mcp",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Add MCP servers to your favorite coding agents with a single command.",
   "author": "Andre Landgraf <andre@neon.tech>",
   "license": "Apache-2.0",
@@ -49,6 +49,8 @@
     "github-copilot-cli",
     "gemini-cli",
     "goose",
+    "grok",
+    "grok-build",
     "mcporter",
     "opencode",
     "vscode",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -255,6 +255,30 @@ function transformCodexConfig(
   );
 }
 
+/**
+ * Grok Build stores MCP servers in config.toml under [mcp_servers.<name>].
+ * Remote servers use url + optional headers (no type field). Stdio uses
+ * command / args / env. See Grok user guide: MCP Servers.
+ */
+function transformGrokBuildConfig(
+  _serverName: string,
+  config: McpServerConfig,
+): unknown {
+  if (config.url) {
+    const remoteConfig: Record<string, unknown> = {
+      url: config.url,
+    };
+
+    if (config.headers && Object.keys(config.headers).length > 0) {
+      remoteConfig.headers = config.headers;
+    }
+
+    return remoteConfig;
+  }
+
+  return buildStandardLocal(config);
+}
+
 function transformCursorConfig(
   _serverName: string,
   config: McpServerConfig,
@@ -555,6 +579,22 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(dirname(copilotConfigPath));
     },
     transformConfig: transformGitHubCopilotCliConfig,
+  },
+
+  "grok-build": {
+    name: "grok-build",
+    displayName: "Grok Build",
+    configPath: join(home, ".grok", "config.toml"),
+    localConfigPath: ".grok/config.toml",
+    projectDetectPaths: [".grok"],
+    configKey: "mcp_servers",
+    format: "toml",
+    supportedTransports: ["stdio", "http", "sse"],
+    supportedFields: [],
+    detectGlobalInstall: async () => {
+      return existsSync(join(home, ".grok"));
+    },
+    transformConfig: transformGrokBuildConfig,
   },
 
   mcporter: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export type AgentType =
   | "gemini-cli"
   | "goose"
   | "github-copilot-cli"
+  | "grok-build"
   | "mcporter"
   | "opencode"
   | "vscode"
@@ -23,6 +24,7 @@ export const agentAliases: Record<string, AgentType> = {
   cascade: "windsurf",
   gemini: "gemini-cli",
   "github-copilot": "vscode",
+  grok: "grok-build",
 };
 
 export type ConfigFormat = "json" | "yaml" | "toml";

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -60,9 +60,9 @@ function cleanup() {
 // Agent Configuration Tests
 // ============================================
 
-test("getAgentTypes returns all 15 agents", () => {
+test("getAgentTypes returns all 16 agents", () => {
   const types = getAgentTypes();
-  assert.strictEqual(types.length, 15);
+  assert.strictEqual(types.length, 16);
   assert.ok(types.includes("antigravity"));
   assert.ok(types.includes("cline"));
   assert.ok(types.includes("cline-cli"));
@@ -73,6 +73,7 @@ test("getAgentTypes returns all 15 agents", () => {
   assert.ok(types.includes("gemini-cli"));
   assert.ok(types.includes("goose"));
   assert.ok(types.includes("github-copilot-cli"));
+  assert.ok(types.includes("grok-build"));
   assert.ok(types.includes("mcporter"));
   assert.ok(types.includes("opencode"));
   assert.ok(types.includes("vscode"));
@@ -149,6 +150,7 @@ test("supportsProjectConfig - returns true for project-capable agents", () => {
   assert.strictEqual(supportsProjectConfig("opencode"), true);
   assert.strictEqual(supportsProjectConfig("gemini-cli"), true);
   assert.strictEqual(supportsProjectConfig("github-copilot-cli"), true);
+  assert.strictEqual(supportsProjectConfig("grok-build"), true);
   assert.strictEqual(supportsProjectConfig("mcporter"), true);
   assert.strictEqual(supportsProjectConfig("codex"), true);
   assert.strictEqual(supportsProjectConfig("zed"), true);
@@ -163,15 +165,16 @@ test("supportsProjectConfig - returns false for global-only agents", () => {
   assert.strictEqual(supportsProjectConfig("windsurf"), false);
 });
 
-test("getProjectCapableAgents returns 9 agents", () => {
+test("getProjectCapableAgents returns 10 agents", () => {
   const projectAgents = getProjectCapableAgents();
-  assert.strictEqual(projectAgents.length, 9);
+  assert.strictEqual(projectAgents.length, 10);
   assert.ok(projectAgents.includes("claude-code"));
   assert.ok(projectAgents.includes("cursor"));
   assert.ok(projectAgents.includes("vscode"));
   assert.ok(projectAgents.includes("opencode"));
   assert.ok(projectAgents.includes("gemini-cli"));
   assert.ok(projectAgents.includes("github-copilot-cli"));
+  assert.ok(projectAgents.includes("grok-build"));
   assert.ok(projectAgents.includes("mcporter"));
   assert.ok(projectAgents.includes("codex"));
   assert.ok(projectAgents.includes("zed"));
@@ -293,6 +296,14 @@ test("detectProjectAgents - detects .codex directory", () => {
   assert.ok(detected.includes("codex"));
 });
 
+test("detectProjectAgents - detects .grok directory", () => {
+  const tempDir = createTempDir();
+  mkdirSync(join(tempDir, ".grok"));
+
+  const detected = detectProjectAgents(tempDir);
+  assert.ok(detected.includes("grok-build"));
+});
+
 test("detectProjectAgents - detects .zed directory", () => {
   const tempDir = createTempDir();
   mkdirSync(join(tempDir, ".zed"));
@@ -365,6 +376,7 @@ test("isTransportSupported - most agents support http", () => {
     "gemini-cli",
     "github-copilot-cli",
     "goose",
+    "grok-build",
     "mcporter",
     "opencode",
     "vscode",
@@ -392,6 +404,7 @@ test("isTransportSupported - most agents support sse", () => {
     "gemini-cli",
     "github-copilot-cli",
     "goose",
+    "grok-build",
     "mcporter",
     "opencode",
     "vscode",

--- a/tests/e2e/install.test.ts
+++ b/tests/e2e/install.test.ts
@@ -764,6 +764,101 @@ test("E2E: Write TOML config file (Codex format)", () => {
 });
 
 // ============================================
+// E2E Tests: Grok Build (TOML format)
+// ============================================
+
+test("E2E: Grok Build config transformation - remote", () => {
+  const parsed = parseSource("https://mcp.example.com/api");
+  const config = buildServerConfig(parsed);
+
+  const grokAgent = agents["grok-build"];
+  const transformed = grokAgent.transformConfig!("example", config) as Record<
+    string,
+    unknown
+  >;
+
+  assert.strictEqual(transformed.url, "https://mcp.example.com/api");
+  assert.strictEqual("type" in transformed, false);
+});
+
+test("E2E: Grok Build config transformation with headers", () => {
+  const parsed = parseSource("https://mcp.example.com/api");
+  const config = buildServerConfig(parsed, {
+    headers: {
+      Authorization: "Bearer token",
+    },
+  });
+
+  const grokAgent = agents["grok-build"];
+  const transformed = grokAgent.transformConfig!("example", config) as Record<
+    string,
+    unknown
+  >;
+
+  assert.deepStrictEqual(transformed.headers, {
+    Authorization: "Bearer token",
+  });
+  assert.strictEqual(transformed.url, "https://mcp.example.com/api");
+});
+
+test("E2E: Grok Build config transformation - local server", () => {
+  const parsed = parseSource("mcp-server-postgres");
+  const config = buildServerConfig(parsed);
+
+  const grokAgent = agents["grok-build"];
+  const transformed = grokAgent.transformConfig!("postgres", config) as Record<
+    string,
+    unknown
+  >;
+
+  assert.strictEqual(transformed.command, "npx");
+  assert.deepStrictEqual(transformed.args, ["-y", "mcp-server-postgres"]);
+});
+
+test("E2E: Grok Build config transformation - local server includes env", () => {
+  const parsed = parseSource("mcp-server-postgres");
+  const config = buildServerConfig(parsed, {
+    env: {
+      OPENAI_API_KEY: "secret",
+    },
+  });
+
+  const grokAgent = agents["grok-build"];
+  const transformed = grokAgent.transformConfig!("postgres", config) as Record<
+    string,
+    unknown
+  >;
+
+  assert.deepStrictEqual(transformed.env, {
+    OPENAI_API_KEY: "secret",
+  });
+});
+
+test("E2E: Write TOML config file (Grok Build format)", () => {
+  const tempDir = createTempDir();
+  const grokConfigPath = join(tempDir, ".grok", "config.toml");
+
+  const parsed = parseSource("mcp-server-postgres");
+  const serverConfig = buildServerConfig(parsed);
+
+  const grokAgent = agents["grok-build"];
+  const transformed = grokAgent.transformConfig!("postgres", serverConfig);
+
+  const config = buildConfigWithKey("mcp_servers", "postgres", transformed);
+  writeConfig(grokConfigPath, config, "toml", "mcp_servers");
+
+  assert.strictEqual(existsSync(grokConfigPath), true);
+
+  const savedConfig = readTomlConfig(grokConfigPath);
+  const mcpServers = savedConfig.mcp_servers as Record<string, unknown>;
+  assert.ok(mcpServers);
+
+  const serverEntry = mcpServers.postgres as Record<string, unknown>;
+  assert.strictEqual(serverEntry.command, "npx");
+  assert.deepStrictEqual(serverEntry.args, ["-y", "mcp-server-postgres"]);
+});
+
+// ============================================
 // E2E Tests: Multiple agents at once
 // ============================================
 

--- a/web/content/docs/05-agents.mdx
+++ b/web/content/docs/05-agents.mdx
@@ -17,6 +17,7 @@ MCP servers can be installed to any of these agents. Project paths are relative 
 | Gemini CLI             | `gemini-cli`         | `.gemini/settings.json` | `~/.gemini/settings.json`                                                                                       |
 | Goose                  | `goose`              | `.goose/config.yaml`    | `~/.config/goose/config.yaml`                                                                                   |
 | GitHub Copilot CLI     | `github-copilot-cli` | `.vscode/mcp.json`      | `~/.copilot/mcp-config.json`                                                                                    |
+| Grok Build             | `grok-build`         | `.grok/config.toml`     | `~/.grok/config.toml`                                                                                           |
 | MCPorter               | `mcporter`           | `config/mcporter.json`  | `~/.mcporter/mcporter.json` (or existing `~/.mcporter/mcporter.jsonc`)                                          |
 | OpenCode               | `opencode`           | `opencode.json`         | `~/.config/opencode/opencode.json`                                                                              |
 | VS Code                | `vscode`             | `.vscode/mcp.json`      | `~/Library/Application Support/Code/User/mcp.json`                                                              |
@@ -25,12 +26,13 @@ MCP servers can be installed to any of these agents. Project paths are relative 
 
 ## Aliases
 
-| Alias                 | Resolves to  |
-| --------------------- | ------------ |
-| `codeium`, `cascade`  | `windsurf`   |
-| `cline-vscode`        | `cline`      |
-| `gemini`              | `gemini-cli` |
-| `github-copilot`      | `vscode`     |
+| Alias                | Resolves to  |
+| -------------------- | ------------ |
+| `codeium`, `cascade` | `windsurf`   |
+| `cline-vscode`       | `cline`      |
+| `gemini`             | `gemini-cli` |
+| `github-copilot`     | `vscode`     |
+| `grok`               | `grok-build` |
 
 ## Troubleshooting
 

--- a/web/content/docs/index.mdx
+++ b/web/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: Introduction
 description: add-mcp adds MCP servers to your favorite coding agents with a single command.
 ---
 
-`add-mcp` is an open-source CLI (and TypeScript SDK) that installs [Model Context Protocol](https://modelcontextprotocol.io) servers into the config files of your coding agents — Claude Code, Codex, Cursor, OpenCode, VS Code, and [10 more](/docs/agents) — with a single command.
+`add-mcp` is an open-source CLI (and TypeScript SDK) that installs [Model Context Protocol](https://modelcontextprotocol.io) servers into the config files of your coding agents — Claude Code, Codex, Cursor, OpenCode, VS Code, Grok Build, and [10 more](/docs/agents) — with a single command.
 
 ```bash
 npx add-mcp https://mcp.context7.com/mcp

--- a/web/pages/index.astro
+++ b/web/pages/index.astro
@@ -113,8 +113,8 @@ const structuredData = JSON.stringify({
     </h1>
     <p class="text-muted-foreground mx-auto mt-5 max-w-2xl text-lg text-pretty">
       One CLI that installs any MCP server into Claude Code, Codex, Cursor,
-      OpenCode, VS Code, and 10 more — the right config file, format, and
-      fields for every agent.
+      OpenCode, VS Code, Grok Build, and 10 more — the right config file,
+      format, and fields for every agent.
     </p>
     <div class="mt-8 flex justify-center">
       <code

--- a/web/pages/index.astro
+++ b/web/pages/index.astro
@@ -19,6 +19,7 @@ const agentNames = [
   "Gemini CLI",
   "GitHub Copilot CLI",
   "Goose",
+  "Grok Build",
   "MCPorter",
   "Windsurf",
   "Zed",


### PR DESCRIPTION
## Motivation

I'm building a personal project and wanted to wire **Neon** into **Grok Build**. xAI ships an official plugin path, but on the Neon side there isn't clear documentation for adding the Neon MCP manually in Grok. That made `add-mcp` the natural place to fix the gap: one command, correct config shape, project or global.

## How this PR was built

I used **Grok Build** (latest) against its own MCP docs to confirm user vs project paths and the native TOML schema, with **Grok 4.5 high** as the model. For the integration shape in this codebase, **Codex** was the closest existing agent (TOML + `mcp_servers`) and served as the reference implementation.

## Summary

- Add **Grok Build** as a supported agent (`grok-build`, alias `grok`)
- Project installs write to `.grok/config.toml`; global installs write to `~/.grok/config.toml`
- Native TOML shape under `[mcp_servers.<name>]`: remote uses `url` + optional `headers` (no `type` field); stdio uses `command` / `args` / `env`
- Document Grok Build in README, docs agents table, and landing/intro copy
- Bump to 1.15.0 with changelog entry

Based on Grok Build’s MCP configuration docs (user scope `~/.grok/config.toml`, project scope `.grok/config.toml`).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test` (unit + e2e, including new Grok Build transform/write tests)
- [x] `npm run build`
- [ ] Manual: `npx add-mcp https://mcp.context7.com/mcp -a grok-build -y` writes `.grok/config.toml`
- [ ] Manual: `npx add-mcp … -a grok -g -y` resolves alias and writes `~/.grok/config.toml`
- [ ] Manual: `npx add-mcp list-agents` lists Grok Build with project + global paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for installing MCP servers in Grok Build.
  - Supports project and global configurations, including remote and local servers.
  - Added the `grok` alias for selecting Grok Build.

- **Documentation**
  - Updated guides, website content, supported-agent listings, and changelog to include Grok Build.
  - Updated package metadata and version to 1.15.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->