### PR TITLE
fix: show Gemini CLI httpUrl in list output

### DIFF
--- a/src/reader.ts
+++ b/src/reader.ts
@@ -33,8 +33,8 @@ export interface AgentServers {
 export function extractServerIdentity(
   serverConfig: Record<string, unknown>,
 ): string {
-  // Remote: check url, uri, serverUrl
-  for (const key of ["url", "uri", "serverUrl"]) {
+  // Remote: check url, httpUrl, uri, serverUrl
+  for (const key of ["url", "httpUrl", "uri", "serverUrl"]) {
     const value = serverConfig[key];
     if (typeof value === "string" && value.length > 0) {
       return value;

--- a/tests/reader.test.ts
+++ b/tests/reader.test.ts
@@ -81,6 +81,14 @@ test("extractServerIdentity: Antigravity serverUrl field", () => {
   assert.strictEqual(identity, "https://mcp.example.com/api");
 });
 
+test("extractServerIdentity: Gemini CLI httpUrl field", () => {
+  const identity = extractServerIdentity({
+    httpUrl: "https://mcp.context7.com/mcp",
+    headers: { CONTEXT7_API_KEY: "test" },
+  });
+  assert.strictEqual(identity, "https://mcp.context7.com/mcp");
+});
+
 test("extractServerIdentity: npx package detection", () => {
   const identity = extractServerIdentity({
     command: "npx",


### PR DESCRIPTION
## Summary
- Fixes #33
- `extractServerIdentity` now recognizes Gemini CLI's `httpUrl` field so `add-mcp list` shows the endpoint for streamable HTTP servers

## Test plan
- [x] `bun run test:unit` (new `extractServerIdentity: Gemini CLI httpUrl field` test passes)
- [x] `bun run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote-server identity detection to recognize the `httpUrl` field (including configurations that include headers).

* **Tests**
  * Added a unit test to confirm identity extraction works correctly for Gemini CLI-style configurations using `httpUrl`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->