### PR TITLE
feat: add LM Studio agent support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- add `lm-studio` support with global installs written to `~/.lmstudio/mcp.json` (`mcpServers`)
+
 ## [1.14.0] - 2026-07-06
 
 - move the default `find` / `search` registry to its new home at `https://add-mcp.com/registry/api/v1/servers` (label: "add-mcp registry"). The previous `mcp.agent-tooling.dev` URL keeps working; saved configs referencing it are migrated automatically on the next `find` / `search` run (custom labels are preserved, duplicates are deduped).

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "github-copilot-cli",
     "gemini-cli",
     "goose",
+    "lm-studio",
     "mcporter",
     "opencode",
     "vscode",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -71,6 +71,7 @@ const windsurfConfigPath = join(
   "windsurf",
   "mcp_config.json",
 );
+const lmStudioConfigPath = join(home, ".lmstudio", "mcp.json");
 
 /**
  * Build the spec-aligned remote shape shared by clients that consume MCP
@@ -619,6 +620,21 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, ".codeium", "windsurf"));
     },
     transformConfig: transformAntigravityConfig,
+  },
+
+  "lm-studio": {
+    name: "lm-studio",
+    displayName: "LM Studio",
+    configPath: lmStudioConfigPath,
+    projectDetectPaths: [], // Global only - no project support
+    configKey: "mcpServers",
+    format: "json",
+    supportedTransports: ["stdio", "http", "sse"],
+    supportedFields: [],
+    detectGlobalInstall: async () => {
+      return existsSync(join(home, ".lmstudio"));
+    },
+    transformConfig: transformStandardConfig,
   },
 
   zed: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export type AgentType =
   | "gemini-cli"
   | "goose"
   | "github-copilot-cli"
+  | "lm-studio"
   | "mcporter"
   | "opencode"
   | "vscode"

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -60,9 +60,9 @@ function cleanup() {
 // Agent Configuration Tests
 // ============================================
 
-test("getAgentTypes returns all 15 agents", () => {
+test("getAgentTypes returns all 16 agents", () => {
   const types = getAgentTypes();
-  assert.strictEqual(types.length, 15);
+  assert.strictEqual(types.length, 16);
   assert.ok(types.includes("antigravity"));
   assert.ok(types.includes("cline"));
   assert.ok(types.includes("cline-cli"));
@@ -77,6 +77,7 @@ test("getAgentTypes returns all 15 agents", () => {
   assert.ok(types.includes("opencode"));
   assert.ok(types.includes("vscode"));
   assert.ok(types.includes("windsurf"));
+  assert.ok(types.includes("lm-studio"));
   assert.ok(types.includes("zed"));
 });
 
@@ -161,6 +162,7 @@ test("supportsProjectConfig - returns false for global-only agents", () => {
   assert.strictEqual(supportsProjectConfig("claude-desktop"), false);
   assert.strictEqual(supportsProjectConfig("goose"), false);
   assert.strictEqual(supportsProjectConfig("windsurf"), false);
+  assert.strictEqual(supportsProjectConfig("lm-studio"), false);
 });
 
 test("getProjectCapableAgents returns 9 agents", () => {
@@ -177,15 +179,16 @@ test("getProjectCapableAgents returns 9 agents", () => {
   assert.ok(projectAgents.includes("zed"));
 });
 
-test("getGlobalOnlyAgents returns 6 agents", () => {
+test("getGlobalOnlyAgents returns 7 agents", () => {
   const globalAgents = getGlobalOnlyAgents();
-  assert.strictEqual(globalAgents.length, 6);
+  assert.strictEqual(globalAgents.length, 7);
   assert.ok(globalAgents.includes("antigravity"));
   assert.ok(globalAgents.includes("cline"));
   assert.ok(globalAgents.includes("cline-cli"));
   assert.ok(globalAgents.includes("claude-desktop"));
   assert.ok(globalAgents.includes("goose"));
   assert.ok(globalAgents.includes("windsurf"));
+  assert.ok(globalAgents.includes("lm-studio"));
 });
 
 test("Project + global-only agents equals all agents", () => {
@@ -337,6 +340,7 @@ test("detectProjectAgents - does not detect global-only agents", () => {
   assert.ok(!detected.includes("claude-desktop"));
   assert.ok(!detected.includes("goose"));
   assert.ok(!detected.includes("windsurf"));
+  assert.ok(!detected.includes("lm-studio"));
   assert.ok(!detected.includes("antigravity"));
 });
 
@@ -369,6 +373,7 @@ test("isTransportSupported - most agents support http", () => {
     "opencode",
     "vscode",
     "windsurf",
+    "lm-studio",
     "zed",
   ];
 
@@ -396,6 +401,7 @@ test("isTransportSupported - most agents support sse", () => {
     "opencode",
     "vscode",
     "windsurf",
+    "lm-studio",
     "zed",
   ];
 

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -89,6 +89,10 @@ function windsurfConfigPath(homeDir: string): string {
   return join(homeDir, ".codeium", "windsurf", "mcp_config.json");
 }
 
+function lmStudioConfigPath(homeDir: string): string {
+  return join(homeDir, ".lmstudio", "mcp.json");
+}
+
 function antigravityConfigPath(homeDir: string): string {
   return join(homeDir, ".gemini", "config", "mcp_config.json");
 }
@@ -844,6 +848,77 @@ test("E2E CLI: windsurf aliases (codeium, cascade) install to windsurf config", 
     const servers = saved.mcpServers as Record<string, unknown>;
     assert.ok(servers.remote, `${alias} should write remote server config`);
   }
+});
+
+test("E2E CLI: remote server to lm-studio succeeds with url config", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "https://mcp.example.com/mcp",
+      "-a",
+      "lm-studio",
+      "-y",
+      "--name",
+      "remote",
+      "--header",
+      "Authorization: Bearer token",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const configPath = lmStudioConfigPath(homeDir);
+  assert.strictEqual(existsSync(configPath), true);
+
+  const saved = JSON.parse(readFileSync(configPath, "utf-8"));
+  const servers = saved.mcpServers as Record<string, unknown>;
+  const server = servers.remote as Record<string, unknown>;
+  assert.strictEqual(server.url, "https://mcp.example.com/mcp");
+  assert.deepStrictEqual(server.headers, {
+    Authorization: "Bearer token",
+  });
+});
+
+test("E2E CLI: stdio server to lm-studio succeeds", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "@modelcontextprotocol/server-filesystem",
+      "-a",
+      "lm-studio",
+      "-y",
+      "--name",
+      "filesystem",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const configPath = lmStudioConfigPath(homeDir);
+  assert.strictEqual(existsSync(configPath), true);
+
+  const saved = JSON.parse(readFileSync(configPath, "utf-8"));
+  const servers = saved.mcpServers as Record<string, unknown>;
+  assert.ok(servers.filesystem, "filesystem server should be configured");
+
+  const server = servers.filesystem as Record<string, unknown>;
+  assert.strictEqual(server.command, "npx");
 });
 
 test("E2E CLI: local stdio install supports repeated --env", () => {


### PR DESCRIPTION
## Summary
- Closes #24
- Adds `lm-studio` as a global-only agent writing to `~/.lmstudio/mcp.json`
- Uses Cursor-compatible `mcpServers` JSON (`url` / `command` shape)

## Test plan
- [x] `bun run test`
- [x] `bun run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LM Studio as a supported integration.
  * Global installations now write MCP server configurations to `~/.lmstudio/mcp.json`.
  * Supports configuring remote HTTP MCP servers (including custom headers) and local stdio MCP servers.

* **Documentation**
  * Updated the unreleased changelog to include LM Studio support.
  * Updated package keywords to include “lm-studio”.

* **Tests**
  * Extended unit and e2e CLI tests to cover LM Studio agent detection and transport/config generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->