### PR TITLE
feat: install PyPI registry packages from find

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [2.4.0] - 2026-08-24
 
-- make `find` / `search` discover and install PyPI registry packages through `uvx`, preserving runtime arguments before the version-pinned package and package arguments after it; npm remains preferred when both package formats are available.
+- make `find` / `search` discover and install PyPI registry packages through `uvx`, preserving runtime argument boundaries (including values with spaces) before the version-pinned package and package arguments after it; npm remains preferred when both package formats are available.
 
 ## [2.3.0] - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.4.0] - 2026-08-24
+
+- make `find` / `search` discover and install PyPI registry packages through `uvx`, preserving runtime arguments before the version-pinned package and package arguments after it; npm remains preferred when both package formats are available.
+
 ## [2.3.0] - 2026-08-23
 
 - add `--bearer-token-env <name>` for remote servers. fx writes it as `bearer_token_env`. Other agents drop it with a warning. When the same run also passes `--header Authorization`, fx omits that header, warns, and keeps `bearer_token_env`; other agents keep the header. Authorization without `--bearer-token-env` still fails on fx. Empty, whitespace, and non-identifier names fail in the CLI and the SDK.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [2.4.0] - 2026-08-24
 
 - make `find` / `search` discover and install PyPI registry packages through `uvx`, preserving runtime argument boundaries (including values with spaces) before the version-pinned package and package arguments after it; npm remains preferred when both package formats are available.
+- keep direct CLI installation summaries meaningful when no registry source type is present, instead of displaying `Type: undefined`.
 
 ## [2.3.0] - 2026-08-23
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-mcp",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Add MCP servers to your favorite coding agents with a single command.",
   "author": "Andre Landgraf <andre@neon.tech>",
   "license": "Apache-2.0",

--- a/src/find.ts
+++ b/src/find.ts
@@ -42,6 +42,9 @@ export interface RegistryPackageDefinition {
   registryType: "npm" | "pypi" | "oci" | "nuget" | "mcpb";
   identifier: string;
   version?: string;
+  runtimeHint?: string;
+  /** Arguments passed to the package runtime before the package identifier. */
+  runtimeArguments?: RegistryPackageArgumentDefinition[];
   environmentVariables?: RegistryNamedVariableDefinition[];
   headers?: RegistryHeaderDefinition[];
   /** MCP registry / server.json package CLI arguments (positional vs named). */
@@ -265,12 +268,17 @@ function toEntry(item: RegistryServerListItem): RegistryServerEntry | null {
     return null;
   }
 
-  const npmPackage = (server.packages ?? []).find(
-    (pkg) => pkg.registryType === "npm",
+  const packages = server.packages ?? [];
+  const npmPackage = packages.find((pkg) => pkg.registryType === "npm");
+  const pypiPackage = packages.find(
+    (pkg) =>
+      pkg.registryType === "pypi" &&
+      (!pkg.runtimeHint || pkg.runtimeHint.trim().toLowerCase() === "uvx"),
   );
+  const installablePackage = npmPackage ?? pypiPackage;
 
   const hasRemotes = Array.isArray(server.remotes) && server.remotes.length > 0;
-  if (!npmPackage && !hasRemotes) {
+  if (!installablePackage && !hasRemotes) {
     return null;
   }
 
@@ -281,7 +289,7 @@ function toEntry(item: RegistryServerListItem): RegistryServerEntry | null {
     version: server.version,
     repositoryUrl: server.repository?.url,
     remotes: server.remotes,
-    package: npmPackage,
+    package: installablePackage,
   };
 }
 
@@ -385,6 +393,21 @@ function pickRemote(
 
 function formatPackageTarget(pkg: RegistryPackageDefinition): string {
   return pkg.identifier;
+}
+
+function buildPackageSource(
+  pkg: RegistryPackageDefinition,
+  runtimeArgv: string[],
+): string {
+  if (pkg.registryType !== "pypi") {
+    return pkg.identifier;
+  }
+
+  const version = pkg.version?.trim();
+  const packageSpecifier = version
+    ? `${pkg.identifier}@${version}`
+    : pkg.identifier;
+  return ["uvx", ...runtimeArgv, packageSpecifier].join(" ");
 }
 
 function transportLabel(entry: RegistryServerEntry): string {
@@ -532,6 +555,7 @@ async function resolveInteractiveRemote(
 }
 
 function resolveNonInteractivePackage(pkg: RegistryPackageDefinition): {
+  target: string;
   env?: Record<string, string>;
   headers?: Record<string, string>;
   args?: string[];
@@ -550,21 +574,27 @@ function resolveNonInteractivePackage(pkg: RegistryPackageDefinition): {
     }
   }
 
-  const argv = buildPackageArgumentsArgvNonInteractive(
+  const runtimeArgv = buildPackageArgumentsArgvNonInteractive(
+    pkg.registryType === "pypi" ? (pkg.runtimeArguments ?? []) : [],
+    buildPlaceholderValue("variable"),
+  );
+  const packageArgv = buildPackageArgumentsArgvNonInteractive(
     definitionsFromPackage(pkg),
     buildPlaceholderValue("variable"),
   );
 
   return {
+    target: buildPackageSource(pkg, runtimeArgv),
     env: Object.keys(env).length > 0 ? env : undefined,
     headers: Object.keys(headers).length > 0 ? headers : undefined,
-    args: argv.length > 0 ? argv : undefined,
+    args: packageArgv.length > 0 ? packageArgv : undefined,
   };
 }
 
 async function resolveInteractivePackage(
   pkg: RegistryPackageDefinition,
 ): Promise<{
+  target: string;
   env?: Record<string, string>;
   headers?: Record<string, string>;
   args?: string[];
@@ -587,20 +617,28 @@ async function resolveInteractivePackage(
   );
   if (headerResult.cancelled) return null;
 
-  const argvResult = await buildPackageArgumentsArgvInteractive(
+  const runtimeArgvResult = await buildPackageArgumentsArgvInteractive(
+    pkg.registryType === "pypi" ? (pkg.runtimeArguments ?? []) : [],
+    promptPackageArg,
+  );
+  if (runtimeArgvResult.cancelled) return null;
+
+  const packageArgvResult = await buildPackageArgumentsArgvInteractive(
     definitionsFromPackage(pkg),
     promptPackageArg,
   );
-  if (argvResult.cancelled) return null;
+  if (packageArgvResult.cancelled) return null;
 
   return {
+    target: buildPackageSource(pkg, runtimeArgvResult.argv),
     env:
       Object.keys(envResult.values).length > 0 ? envResult.values : undefined,
     headers:
       Object.keys(headerResult.values).length > 0
         ? headerResult.values
         : undefined,
-    args: argvResult.argv.length > 0 ? argvResult.argv : undefined,
+    args:
+      packageArgvResult.argv.length > 0 ? packageArgvResult.argv : undefined,
   };
 }
 
@@ -648,7 +686,7 @@ export async function buildInstallPlanForEntry(
     if (!resolved) return null;
 
     return {
-      target: formatPackageTarget(pkg),
+      target: resolved.target,
       serverName: resolveServerName(entry),
       env: resolved.env,
       headers: resolved.headers,

--- a/src/find.ts
+++ b/src/find.ts
@@ -3,7 +3,7 @@ import {
   DEFAULT_FIND_REGISTRY_LABEL,
   DEFAULT_FIND_REGISTRY_URL,
 } from "./config.js";
-import type { TransportType } from "./types.js";
+import type { SourceType, TransportType } from "./types.js";
 import {
   type PackageArgPrompt,
   type RegistryPackageArgumentDefinition,
@@ -76,6 +76,7 @@ export interface FindCommandOptions {
 
 export interface FindInstallPlan {
   target: string;
+  sourceType?: SourceType;
   serverName: string;
   transport?: TransportType;
   headers?: Record<string, string>;
@@ -395,19 +396,29 @@ function formatPackageTarget(pkg: RegistryPackageDefinition): string {
   return pkg.identifier;
 }
 
+interface PackageSource {
+  target: string;
+  sourceType?: SourceType;
+  args: string[];
+}
+
 function buildPackageSource(
   pkg: RegistryPackageDefinition,
   runtimeArgv: string[],
-): string {
+): PackageSource {
   if (pkg.registryType !== "pypi") {
-    return pkg.identifier;
+    return { target: pkg.identifier, args: [] };
   }
 
   const version = pkg.version?.trim();
   const packageSpecifier = version
     ? `${pkg.identifier}@${version}`
     : pkg.identifier;
-  return ["uvx", ...runtimeArgv, packageSpecifier].join(" ");
+  return {
+    target: "uvx",
+    sourceType: "command",
+    args: [...runtimeArgv, packageSpecifier],
+  };
 }
 
 function transportLabel(entry: RegistryServerEntry): string {
@@ -556,6 +567,7 @@ async function resolveInteractiveRemote(
 
 function resolveNonInteractivePackage(pkg: RegistryPackageDefinition): {
   target: string;
+  sourceType?: SourceType;
   env?: Record<string, string>;
   headers?: Record<string, string>;
   args?: string[];
@@ -582,12 +594,15 @@ function resolveNonInteractivePackage(pkg: RegistryPackageDefinition): {
     definitionsFromPackage(pkg),
     buildPlaceholderValue("variable"),
   );
+  const source = buildPackageSource(pkg, runtimeArgv);
+  const args = [...source.args, ...packageArgv];
 
   return {
-    target: buildPackageSource(pkg, runtimeArgv),
+    target: source.target,
+    sourceType: source.sourceType,
     env: Object.keys(env).length > 0 ? env : undefined,
     headers: Object.keys(headers).length > 0 ? headers : undefined,
-    args: packageArgv.length > 0 ? packageArgv : undefined,
+    args: args.length > 0 ? args : undefined,
   };
 }
 
@@ -595,6 +610,7 @@ async function resolveInteractivePackage(
   pkg: RegistryPackageDefinition,
 ): Promise<{
   target: string;
+  sourceType?: SourceType;
   env?: Record<string, string>;
   headers?: Record<string, string>;
   args?: string[];
@@ -628,17 +644,19 @@ async function resolveInteractivePackage(
     promptPackageArg,
   );
   if (packageArgvResult.cancelled) return null;
+  const source = buildPackageSource(pkg, runtimeArgvResult.argv);
+  const args = [...source.args, ...packageArgvResult.argv];
 
   return {
-    target: buildPackageSource(pkg, runtimeArgvResult.argv),
+    target: source.target,
+    sourceType: source.sourceType,
     env:
       Object.keys(envResult.values).length > 0 ? envResult.values : undefined,
     headers:
       Object.keys(headerResult.values).length > 0
         ? headerResult.values
         : undefined,
-    args:
-      packageArgvResult.argv.length > 0 ? packageArgvResult.argv : undefined,
+    args: args.length > 0 ? args : undefined,
   };
 }
 
@@ -687,6 +705,7 @@ export async function buildInstallPlanForEntry(
 
     return {
       target: resolved.target,
+      sourceType: resolved.sourceType,
       serverName: resolveServerName(entry),
       env: resolved.env,
       headers: resolved.headers,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1350,6 +1350,7 @@ async function main(
   }
   const isRemote = isRemoteSource(parsed);
   const sourceLabel = isRemote ? "remote" : "local";
+  const summarySourceType = sourceType ?? sourceLabel;
   spinner.stop(`Source: ${chalk.cyan(parsed.value)} (${sourceLabel})`);
 
   const headerValues = options.header ?? [];
@@ -1800,7 +1801,7 @@ async function main(
   // Show summary
   const summaryLines: string[] = [];
   summaryLines.push(`${chalk.cyan("Server:")} ${serverName}`);
-  summaryLines.push(`${chalk.cyan("Type:")} ${sourceType}`);
+  summaryLines.push(`${chalk.cyan("Type:")} ${summarySourceType}`);
   if (autoApproveTools) {
     summaryLines.push(
       `${chalk.cyan("Auto-approve:")} ${

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { program } from "commander";
 import * as p from "@clack/prompts";
 import chalk from "chalk";
 import { homedir } from "os";
-import type { AgentType, TransportType } from "./types.js";
+import type { AgentType, SourceType, TransportType } from "./types.js";
 import { agentAliases } from "./types.js";
 import {
   agents,
@@ -543,7 +543,7 @@ async function runFindCommand(
     args: installPlan.args ?? options.args,
   };
 
-  await main(installPlan.target, mergedOptions);
+  await main(installPlan.target, mergedOptions, installPlan.sourceType);
 }
 
 program
@@ -1295,7 +1295,11 @@ function listAgents(): void {
   console.log();
 }
 
-async function main(target: string | undefined, options: Options) {
+async function main(
+  target: string | undefined,
+  options: Options,
+  sourceType?: SourceType,
+) {
   // --all just selects all agents, doesn't imply --yes or --global
   // Use --yes to skip prompts, --global to install globally
 
@@ -1341,9 +1345,12 @@ async function main(target: string | undefined, options: Options) {
   // Parse the source
   spinner.start("Parsing source...");
   const parsed = parseSource(target);
+  if (sourceType) {
+    parsed.type = sourceType;
+  }
   const isRemote = isRemoteSource(parsed);
-  const sourceType = isRemote ? "remote" : "local";
-  spinner.stop(`Source: ${chalk.cyan(parsed.value)} (${sourceType})`);
+  const sourceLabel = isRemote ? "remote" : "local";
+  spinner.stop(`Source: ${chalk.cyan(parsed.value)} (${sourceLabel})`);
 
   const headerValues = options.header ?? [];
   const headerResult = parseHeaders(headerValues);

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -126,6 +126,27 @@ function seedFindRegistries(homeDir: string) {
   );
 }
 
+test("E2E CLI: direct installs show a defined summary type", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    ["https://mcp.example.com/mcp", "-a", "cursor", "-y"],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.match(output, /Type:\s+remote/);
+  assert.doesNotMatch(output, /Type:\s+undefined/);
+});
+
 // Regression: https://github.com/neon-solutions/add-mcp/issues/29
 test("E2E CLI: absolute path with spaces is preserved as single command", () => {
   const projectDir = createTempDir();

--- a/tests/find.test.ts
+++ b/tests/find.test.ts
@@ -718,8 +718,9 @@ test("buildInstallPlanForEntry builds a version-pinned PyPI uvx command", async 
   );
 
   assert.ok(plan);
-  assert.strictEqual(plan?.target, "uvx python-mcp@1.2.3");
-  assert.strictEqual(plan?.args, undefined);
+  assert.strictEqual(plan?.target, "uvx");
+  assert.strictEqual(plan?.sourceType, "command");
+  assert.deepStrictEqual(plan?.args, ["python-mcp@1.2.3"]);
 });
 
 test("buildInstallPlanForEntry orders PyPI runtime and package arguments", async () => {
@@ -747,15 +748,70 @@ test("buildInstallPlanForEntry orders PyPI runtime and package arguments", async
   );
 
   assert.ok(plan);
-  assert.strictEqual(plan?.target, "uvx --with mcp>=1.29,<3 python-mcp@1.2.3");
-  assert.deepStrictEqual(plan?.args, ["mcp", "serve"]);
+  assert.strictEqual(plan?.target, "uvx");
+  assert.strictEqual(plan?.sourceType, "command");
+  assert.deepStrictEqual(plan?.args, [
+    "--with",
+    "mcp>=1.29,<3",
+    "python-mcp@1.2.3",
+    "mcp",
+    "serve",
+  ]);
 
-  const config = buildServerConfig(parseSource(plan!.target), {
+  const parsed = parseSource(plan!.target);
+  parsed.type = plan!.sourceType!;
+  const config = buildServerConfig(parsed, {
     args: plan!.args,
   });
   assert.deepStrictEqual(config, {
     command: "uvx",
     args: ["--with", "mcp>=1.29,<3", "python-mcp@1.2.3", "mcp", "serve"],
+  });
+});
+
+test("buildInstallPlanForEntry preserves spaces inside PyPI runtime argument values", async () => {
+  const plan = await buildInstallPlanForEntry(
+    {
+      name: "com.example/python-mcp",
+      description: "Python MCP server with a selected interpreter",
+      version: "1.2.3",
+      package: {
+        registryType: "pypi",
+        identifier: "python-mcp",
+        version: "1.2.3",
+        runtimeHint: "uvx",
+        runtimeArguments: [
+          {
+            type: "named",
+            name: "--python",
+            value: "C:\\Program Files\\Python\\python.exe",
+          },
+        ],
+        transport: { type: "stdio" },
+      },
+    },
+    { yes: true },
+  );
+
+  assert.ok(plan);
+  assert.strictEqual(plan.target, "uvx");
+  assert.strictEqual(plan.sourceType, "command");
+  assert.deepStrictEqual(plan.args, [
+    "--python",
+    "C:\\Program Files\\Python\\python.exe",
+    "python-mcp@1.2.3",
+  ]);
+
+  const parsed = parseSource(plan.target);
+  parsed.type = plan.sourceType!;
+  const config = buildServerConfig(parsed, { args: plan.args });
+  assert.deepStrictEqual(config, {
+    command: "uvx",
+    args: [
+      "--python",
+      "C:\\Program Files\\Python\\python.exe",
+      "python-mcp@1.2.3",
+    ],
   });
 });
 

--- a/tests/find.test.ts
+++ b/tests/find.test.ts
@@ -16,6 +16,8 @@ import {
   searchRegistry,
 } from "../src/find.js";
 import type { RegistryServerEntry } from "../src/find.js";
+import { buildServerConfig } from "../src/installer.js";
+import { parseSource } from "../src/source-parser.js";
 
 let passed = 0;
 let failed = 0;
@@ -699,6 +701,64 @@ test("buildInstallPlanForEntry returns package target for package-only entry", a
   assert.strictEqual(plan?.args, undefined);
 });
 
+test("buildInstallPlanForEntry builds a version-pinned PyPI uvx command", async () => {
+  const plan = await buildInstallPlanForEntry(
+    {
+      name: "com.example/python-mcp",
+      description: "Python MCP server",
+      version: "1.2.3",
+      package: {
+        registryType: "pypi",
+        identifier: "python-mcp",
+        version: "1.2.3",
+        transport: { type: "stdio" },
+      },
+    },
+    { yes: true },
+  );
+
+  assert.ok(plan);
+  assert.strictEqual(plan?.target, "uvx python-mcp@1.2.3");
+  assert.strictEqual(plan?.args, undefined);
+});
+
+test("buildInstallPlanForEntry orders PyPI runtime and package arguments", async () => {
+  const plan = await buildInstallPlanForEntry(
+    {
+      name: "com.example/python-mcp",
+      description: "Python MCP server with runtime dependencies",
+      version: "1.2.3",
+      package: {
+        registryType: "pypi",
+        identifier: "python-mcp",
+        version: "1.2.3",
+        runtimeHint: "uvx",
+        runtimeArguments: [
+          { type: "named", name: "--with", value: "mcp>=1.29,<3" },
+        ],
+        packageArguments: [
+          { type: "positional", value: "mcp" },
+          { type: "positional", value: "serve" },
+        ],
+        transport: { type: "stdio" },
+      },
+    },
+    { yes: true },
+  );
+
+  assert.ok(plan);
+  assert.strictEqual(plan?.target, "uvx --with mcp>=1.29,<3 python-mcp@1.2.3");
+  assert.deepStrictEqual(plan?.args, ["mcp", "serve"]);
+
+  const config = buildServerConfig(parseSource(plan!.target), {
+    args: plan!.args,
+  });
+  assert.deepStrictEqual(config, {
+    command: "uvx",
+    args: ["--with", "mcp>=1.29,<3", "python-mcp@1.2.3", "mcp", "serve"],
+  });
+});
+
 test("buildInstallPlanForEntry includes only required package env/header/args placeholders in -y mode", async () => {
   const plan = await buildInstallPlanForEntry(
     {
@@ -993,7 +1053,7 @@ test("buildInstallPlanForEntry falls back to available remote when preferred tra
   assert.strictEqual(plan?.transport, "http");
 });
 
-test("searchRegistry filters out non-installable entries (no npm package and no remotes)", async () => {
+test("searchRegistry keeps npm and uvx-compatible PyPI packages", async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (async () =>
     ({
@@ -1039,6 +1099,38 @@ test("searchRegistry filters out non-installable entries (no npm package and no 
           },
           {
             server: {
+              name: "com.example/pypi-server",
+              description: "PyPI server",
+              version: "1.0.0",
+              packages: [
+                {
+                  registryType: "pypi",
+                  identifier: "example-mcp-server",
+                  version: "1.0.0",
+                  runtimeHint: "uvx",
+                  transport: { type: "stdio" },
+                },
+              ],
+            },
+          },
+          {
+            server: {
+              name: "com.example/unsupported-pypi-runtime",
+              description: "PyPI server requiring an unsupported runtime",
+              version: "1.0.0",
+              packages: [
+                {
+                  registryType: "pypi",
+                  identifier: "custom-python-mcp",
+                  version: "1.0.0",
+                  runtimeHint: "custom-runner",
+                  transport: { type: "stdio" },
+                },
+              ],
+            },
+          },
+          {
+            server: {
               name: "com.example/remote-only",
               description: "Remote-only server",
               version: "1.0.0",
@@ -1056,6 +1148,13 @@ test("searchRegistry filters out non-installable entries (no npm package and no 
               description: "Has both npm and remote",
               version: "1.0.0",
               packages: [
+                {
+                  registryType: "pypi",
+                  identifier: "example-hybrid",
+                  version: "1.0.0",
+                  runtimeHint: "uvx",
+                  transport: { type: "stdio" },
+                },
                 {
                   registryType: "npm",
                   identifier: "@example/hybrid",
@@ -1083,12 +1182,22 @@ test("searchRegistry filters out non-installable entries (no npm package and no 
       },
     ]);
     const names = result.entries.map((e) => e.name);
-    assert.strictEqual(result.entries.length, 3);
+    assert.strictEqual(result.entries.length, 4);
     assert.strictEqual(names.includes("com.example/npm-server"), true);
+    assert.strictEqual(names.includes("com.example/pypi-server"), true);
     assert.strictEqual(names.includes("com.example/remote-only"), true);
     assert.strictEqual(names.includes("com.example/hybrid"), true);
     assert.strictEqual(names.includes("com.example/oci-only"), false);
+    assert.strictEqual(
+      names.includes("com.example/unsupported-pypi-runtime"),
+      false,
+    );
     assert.strictEqual(names.includes("com.example/metadata-only"), false);
+    assert.strictEqual(
+      result.entries.find((entry) => entry.name === "com.example/hybrid")
+        ?.package?.registryType,
+      "npm",
+    );
     const hybrid = result.entries.find((e) => e.name === "com.example/hybrid")!;
     assert.strictEqual(hybrid.package?.identifier, "@example/hybrid");
     assert.strictEqual(


### PR DESCRIPTION
## What changed

- let `find` / `search` retain package-only PyPI entries while preserving npm as the first package choice
- translate compatible PyPI entries into version-pinned `uvx` commands
- place registry `runtimeArguments` before the package specifier and `packageArguments` after it
- accept the standard `uvx` runtime hint (or an omitted hint) and keep unknown PyPI runtimes filtered instead of executing an unsupported command
- add focused discovery, precedence, command-ordering, and final config-shape tests
- add the repository-required 2.4.0 feature note/version bump

## Why

The registry schema and local verifier already accept PyPI packages, and the checked-in registry includes package-only PyPI entries. However, `toEntry()` selected only npm packages, so those servers were silently removed from CLI results.

A registry package shaped like:

```text
runtimeArguments -> package identifier + exact version -> packageArguments
```

now produces the equivalent of:

```text
uvx --with mcp>=1.29,<3 python-mcp@1.2.3 mcp serve
```

The package portion is kept separate from package arguments until the final MCP client config is built, preserving the registry-defined ordering.

## Scope cleanup

The original branch also bundled a Talamus catalog entry and an unrelated Windows E2E home-isolation change. This reconstruction is based on current upstream `main` and removes both, leaving a generic four-file PyPI/UVX capability patch. A project listing can be proposed separately after the capability lands.

## Validation

- `bun run typecheck`
- `bun run build`
- `bun run registry:verify` — 1,326 entries verified
- `bun run test:unit` — 285 passed
- `bun x tsx tests/e2e/install.test.ts` — 62 passed
- `bun x tsx tests/find.test.ts` — 42 passed
- `bun x prettier --check CHANGELOG.md package.json src/find.ts tests/find.test.ts`
- `bun x fallow audit --changed-since upstream/main` — no findings in changed files (repository baseline findings excluded by the audit gate)

### Native Windows baseline

The full `bun run test` reaches the CLI E2E harness but currently reports 23 home-path failures on an unchanged `upstream/main` checkout as well. Those tests set `HOME`, while native Windows path resolution uses `USERPROFILE` / `APPDATA` for several global agents. That pre-existing harness issue is intentionally not mixed into this PR; the core/unit/install checks above are green, and Linux CI remains the authoritative full-suite check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for installing compatible PyPI packages through `uvx`.
  - Preserved runtime and package argument ordering, including values containing spaces.
  - Improved package discovery with clearer source filtering and support for additional tools.

- **Bug Fixes**
  - Maintained correct npm package selection for packages available from multiple sources.
  - Fixed direct remote installations displaying an undefined source type.
  - Improved source labeling and installation summaries for discovered packages.

- **Documentation**
  - Added release notes for the 2.4.0 improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->