### PR TITLE
fix: replace server entry on re-install instead of deep-merging (Codex config corruption)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.14.1] - 2026-07-21
+
+- replace an existing server entry wholesale when re-installing under the same name, instead of deep-merging the new config into the old one. Previously, stale fields from a prior install survived the merge — most damaging when an old stdio entry (`command`/`args`/`env`) was combined with a new remote install (`type`/`url`), producing a hybrid entry that Codex rejects wholesale with `invalid configuration: url is not supported for stdio`, breaking every chat until the config is edited by hand. Applies to the TOML, JSON, and YAML writers; everything else in the config file still merges as before ([#83](https://github.com/neon-solutions/add-mcp/pull/83))
+
 ## [1.14.0] - 2026-07-06
 
 - move the default `find` / `search` registry to its new home at `https://add-mcp.com/registry/api/v1/servers` (label: "add-mcp registry"). The previous `mcp.agent-tooling.dev` URL keeps working; saved configs referencing it are migrated automatically on the next `find` / `search` run (custom labels are preserved, duplicates are deduped).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-mcp",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Add MCP servers to your favorite coding agents with a single command.",
   "author": "Andre Landgraf <andre@neon.tech>",
   "license": "Apache-2.0",
@@ -25,8 +25,8 @@
     "fmt": "prettier --write .",
     "build": "tsup src/index.ts src/lib.ts --format esm --dts --clean",
     "dev": "tsx src/index.ts",
-    "test": "tsx tests/source-parser.test.ts && tsx tests/agents.test.ts && tsx tests/config.test.ts && tsx tests/installer.test.ts && tsx tests/find.test.ts && tsx tests/package-arguments.test.ts && tsx tests/template.test.ts && tsx tests/reader.test.ts && tsx tests/formats-remove.test.ts && tsx tests/lib.test.ts && tsx tests/e2e/install.test.ts && tsx tests/e2e/cli.test.ts",
-    "test:unit": "tsx tests/source-parser.test.ts && tsx tests/agents.test.ts && tsx tests/config.test.ts && tsx tests/installer.test.ts && tsx tests/find.test.ts && tsx tests/package-arguments.test.ts && tsx tests/template.test.ts && tsx tests/reader.test.ts && tsx tests/formats-remove.test.ts && tsx tests/lib.test.ts",
+    "test": "tsx tests/source-parser.test.ts && tsx tests/agents.test.ts && tsx tests/config.test.ts && tsx tests/installer.test.ts && tsx tests/find.test.ts && tsx tests/package-arguments.test.ts && tsx tests/template.test.ts && tsx tests/reader.test.ts && tsx tests/formats-remove.test.ts && tsx tests/formats-utils.test.ts && tsx tests/lib.test.ts && tsx tests/e2e/install.test.ts && tsx tests/e2e/cli.test.ts",
+    "test:unit": "tsx tests/source-parser.test.ts && tsx tests/agents.test.ts && tsx tests/config.test.ts && tsx tests/installer.test.ts && tsx tests/find.test.ts && tsx tests/package-arguments.test.ts && tsx tests/template.test.ts && tsx tests/reader.test.ts && tsx tests/formats-remove.test.ts && tsx tests/formats-utils.test.ts && tsx tests/lib.test.ts",
     "registry:sort": "tsx scripts/sort-registry.ts",
     "registry:sync": "node scripts/sync-integrations-sh.mjs",
     "registry:verify": "tsx scripts/verify-registry.ts",

--- a/src/formats/index.ts
+++ b/src/formats/index.ts
@@ -17,7 +17,7 @@ import {
 } from "./toml.js";
 
 export { setNestedValue } from "./json.js";
-export { deepMerge, getNestedValue } from "./utils.js";
+export { deepMerge, dropReplacedServers, getNestedValue } from "./utils.js";
 
 export function readConfig(filePath: string, format: ConfigFormat): ConfigFile {
   switch (format) {
@@ -64,10 +64,10 @@ export function writeConfig(
       writeJsonConfig(filePath, config, configKey);
       break;
     case "yaml":
-      writeYamlConfig(filePath, config);
+      writeYamlConfig(filePath, config, configKey);
       break;
     case "toml":
-      writeTomlConfig(filePath, config);
+      writeTomlConfig(filePath, config, configKey);
       break;
     default:
       throw new Error(`Unsupported config format: ${format}`);

--- a/src/formats/json.ts
+++ b/src/formats/json.ts
@@ -2,7 +2,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { dirname } from "path";
 import * as jsonc from "jsonc-parser";
 import type { ConfigFile } from "../types.js";
-import { deepMerge, getNestedValue } from "./utils.js";
+import { deepMerge, dropReplacedServers, getNestedValue } from "./utils.js";
 
 function detectIndent(text: string): {
   tabSize: number;
@@ -61,6 +61,7 @@ export function writeJsonConfig(
     existingConfig = jsonc.parse(originalContent) as ConfigFile;
   }
 
+  dropReplacedServers(existingConfig, config, configKey);
   const mergedConfig = deepMerge(existingConfig, config);
 
   if (originalContent) {

--- a/src/formats/toml.ts
+++ b/src/formats/toml.ts
@@ -2,7 +2,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { dirname } from "path";
 import * as TOML from "@iarna/toml";
 import type { ConfigFile } from "../types.js";
-import { deepMerge } from "./utils.js";
+import { deepMerge, dropReplacedServers } from "./utils.js";
 
 export function readTomlConfig(filePath: string): ConfigFile {
   if (!existsSync(filePath)) {
@@ -43,7 +43,11 @@ export function removeTomlConfigKey(
   writeFileSync(filePath, content);
 }
 
-export function writeTomlConfig(filePath: string, config: ConfigFile): void {
+export function writeTomlConfig(
+  filePath: string,
+  config: ConfigFile,
+  configKey: string,
+): void {
   const dir = dirname(filePath);
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
@@ -54,6 +58,7 @@ export function writeTomlConfig(filePath: string, config: ConfigFile): void {
     existingConfig = readTomlConfig(filePath);
   }
 
+  dropReplacedServers(existingConfig, config, configKey);
   const mergedConfig = deepMerge(existingConfig, config);
   const content = TOML.stringify(mergedConfig as TOML.JsonMap);
 

--- a/src/formats/utils.ts
+++ b/src/formats/utils.ts
@@ -26,6 +26,38 @@ export function deepMerge(target: ConfigFile, source: ConfigFile): ConfigFile {
   return result;
 }
 
+/**
+ * Deletes from `existing` any server entries that `incoming` is about to
+ * write under `configKey`, so re-installing a server replaces its entry
+ * wholesale instead of deep-merging into the old one. Without this, stale
+ * fields from a previous install survive the merge — e.g. an old stdio
+ * `command`/`args`/`env` alongside a new remote `url`, which Codex rejects
+ * as an invalid config ("url is not supported for stdio").
+ */
+export function dropReplacedServers(
+  existing: ConfigFile,
+  incoming: ConfigFile,
+  configKey: string,
+): void {
+  const incomingServers = getNestedValue(incoming, configKey);
+  const existingServers = getNestedValue(existing, configKey);
+
+  if (
+    !incomingServers ||
+    typeof incomingServers !== "object" ||
+    Array.isArray(incomingServers) ||
+    !existingServers ||
+    typeof existingServers !== "object" ||
+    Array.isArray(existingServers)
+  ) {
+    return;
+  }
+
+  for (const name of Object.keys(incomingServers)) {
+    delete (existingServers as ConfigFile)[name];
+  }
+}
+
 export function getNestedValue(obj: ConfigFile, path: string): unknown {
   const keys = path.split(".");
   let current: unknown = obj;

--- a/src/formats/yaml.ts
+++ b/src/formats/yaml.ts
@@ -2,7 +2,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { dirname } from "path";
 import yaml from "js-yaml";
 import type { ConfigFile } from "../types.js";
-import { deepMerge } from "./utils.js";
+import { deepMerge, dropReplacedServers } from "./utils.js";
 
 export function readYamlConfig(filePath: string): ConfigFile {
   if (!existsSync(filePath)) {
@@ -47,7 +47,11 @@ export function removeYamlConfigKey(
   writeFileSync(filePath, content);
 }
 
-export function writeYamlConfig(filePath: string, config: ConfigFile): void {
+export function writeYamlConfig(
+  filePath: string,
+  config: ConfigFile,
+  configKey: string,
+): void {
   const dir = dirname(filePath);
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
@@ -58,6 +62,7 @@ export function writeYamlConfig(filePath: string, config: ConfigFile): void {
     existingConfig = readYamlConfig(filePath);
   }
 
+  dropReplacedServers(existingConfig, config, configKey);
   const mergedConfig = deepMerge(existingConfig, config);
 
   const content = yaml.dump(mergedConfig, {

--- a/tests/e2e/install.test.ts
+++ b/tests/e2e/install.test.ts
@@ -537,6 +537,48 @@ test("E2E: Write YAML config file (Goose format)", () => {
   assert.strictEqual(serverEntry.type, "stdio");
 });
 
+test("E2E: Re-install replaces server entry instead of merging (Goose YAML)", () => {
+  const tempDir = createTempDir();
+  const gooseConfigPath = join(tempDir, ".config", "goose", "config.yaml");
+  const gooseAgent = agents.goose;
+
+  // First install: local stdio server
+  const stdioParsed = parseSource("mcp-server-postgres");
+  const stdioConfig = buildServerConfig(stdioParsed, {
+    env: { DATABASE_URL: "postgres://localhost" },
+  });
+  const stdioTransformed = gooseAgent.transformConfig!("postgres", stdioConfig);
+  writeConfig(
+    gooseConfigPath,
+    buildConfigWithKey("extensions", "postgres", stdioTransformed),
+    "yaml",
+    "extensions",
+  );
+
+  // Second install under the same name: remote http server
+  const remoteParsed = parseSource("https://mcp.example.com/api");
+  const remoteConfig = buildServerConfig(remoteParsed);
+  const remoteTransformed = gooseAgent.transformConfig!(
+    "postgres",
+    remoteConfig,
+  );
+  writeConfig(
+    gooseConfigPath,
+    buildConfigWithKey("extensions", "postgres", remoteTransformed),
+    "yaml",
+    "extensions",
+  );
+
+  const savedConfig = readYamlConfig(gooseConfigPath);
+  const extensions = savedConfig.extensions as Record<string, unknown>;
+  const serverEntry = extensions.postgres as Record<string, unknown>;
+  assert.strictEqual(serverEntry.type, "streamable_http");
+  assert.strictEqual(serverEntry.uri, "https://mcp.example.com/api");
+  assert.strictEqual("cmd" in serverEntry, false);
+  assert.strictEqual("args" in serverEntry, false);
+  assert.strictEqual("envs" in serverEntry, false);
+});
+
 // ============================================
 // E2E Tests: Zed (transformed format)
 // ============================================
@@ -761,6 +803,73 @@ test("E2E: Write TOML config file (Codex format)", () => {
   const serverEntry = mcpServers.postgres as Record<string, unknown>;
   assert.strictEqual(serverEntry.command, "npx");
   assert.deepStrictEqual(serverEntry.args, ["-y", "mcp-server-postgres"]);
+});
+
+test("E2E: Re-install replaces server entry instead of merging (Codex TOML)", () => {
+  const tempDir = createTempDir();
+
+  // First install: local stdio server (the pre-1.x firecrawl setup shape)
+  const stdioParsed = parseSource("firecrawl-mcp");
+  const stdioConfig = buildServerConfig(stdioParsed, {
+    env: { FIRECRAWL_API_KEY: "fc-test" },
+  });
+  const first = installServerForAgent("firecrawl", stdioConfig, "codex", {
+    local: true,
+    cwd: tempDir,
+  });
+  assert.strictEqual(first.success, true);
+
+  // Second install under the same name: remote http server
+  const remoteParsed = parseSource("https://mcp.firecrawl.dev/fc-test/v2/mcp");
+  const remoteConfig = buildServerConfig(remoteParsed);
+  const second = installServerForAgent("firecrawl", remoteConfig, "codex", {
+    local: true,
+    cwd: tempDir,
+  });
+  assert.strictEqual(second.success, true);
+
+  // The entry must be purely remote: leftover stdio keys make Codex reject
+  // the whole config with "url is not supported for stdio".
+  const savedConfig = readTomlConfig(join(tempDir, ".codex", "config.toml"));
+  const mcpServers = savedConfig.mcp_servers as Record<string, unknown>;
+  const serverEntry = mcpServers.firecrawl as Record<string, unknown>;
+  assert.strictEqual(
+    serverEntry.url,
+    "https://mcp.firecrawl.dev/fc-test/v2/mcp",
+  );
+  assert.strictEqual("command" in serverEntry, false);
+  assert.strictEqual("args" in serverEntry, false);
+  assert.strictEqual("env" in serverEntry, false);
+});
+
+test("E2E: Re-install replaces server entry instead of merging (JSON)", () => {
+  const tempDir = createTempDir();
+
+  const stdioParsed = parseSource("mcp-server-postgres");
+  const stdioConfig = buildServerConfig(stdioParsed, {
+    env: { DATABASE_URL: "postgres://localhost" },
+  });
+  const first = installServerForAgent("postgres", stdioConfig, "cursor", {
+    local: true,
+    cwd: tempDir,
+  });
+  assert.strictEqual(first.success, true);
+
+  const remoteParsed = parseSource("https://mcp.example.com/api");
+  const remoteConfig = buildServerConfig(remoteParsed);
+  const second = installServerForAgent("postgres", remoteConfig, "cursor", {
+    local: true,
+    cwd: tempDir,
+  });
+  assert.strictEqual(second.success, true);
+
+  const savedConfig = readJsonConfig(join(tempDir, ".cursor", "mcp.json"));
+  const servers = savedConfig.mcpServers as Record<string, unknown>;
+  const serverEntry = servers.postgres as Record<string, unknown>;
+  assert.strictEqual(serverEntry.url, "https://mcp.example.com/api");
+  assert.strictEqual("command" in serverEntry, false);
+  assert.strictEqual("args" in serverEntry, false);
+  assert.strictEqual("env" in serverEntry, false);
 });
 
 // ============================================

--- a/tests/formats-utils.test.ts
+++ b/tests/formats-utils.test.ts
@@ -7,7 +7,11 @@
  */
 
 import assert from "node:assert";
-import { deepMerge, getNestedValue } from "../src/formats/index.js";
+import {
+  deepMerge,
+  dropReplacedServers,
+  getNestedValue,
+} from "../src/formats/index.js";
 
 let passed = 0;
 let failed = 0;
@@ -84,6 +88,65 @@ test("getNestedValue returns undefined when path hits non-object", () => {
   };
 
   assert.strictEqual(getNestedValue(obj, "a.b"), undefined);
+});
+
+test("dropReplacedServers removes incoming server names so merge replaces them", () => {
+  const existing = {
+    mcp_servers: {
+      firecrawl: {
+        command: "npx",
+        args: ["-y", "firecrawl-mcp"],
+        env: { FIRECRAWL_API_KEY: "fc-test" },
+      },
+      other: { url: "https://other.example.com/mcp" },
+    },
+  };
+  const incoming = {
+    mcp_servers: {
+      firecrawl: { type: "http", url: "https://mcp.firecrawl.dev/v2/mcp" },
+    },
+  };
+
+  dropReplacedServers(existing, incoming, "mcp_servers");
+  const merged = deepMerge(existing, incoming);
+
+  assert.deepStrictEqual(
+    (merged.mcp_servers as Record<string, unknown>).firecrawl,
+    { type: "http", url: "https://mcp.firecrawl.dev/v2/mcp" },
+  );
+  assert.deepStrictEqual(
+    (merged.mcp_servers as Record<string, unknown>).other,
+    { url: "https://other.example.com/mcp" },
+  );
+});
+
+test("dropReplacedServers walks dotted config keys", () => {
+  const existing = {
+    a: { servers: { example: { command: "npx", args: ["-y", "example"] } } },
+  };
+  const incoming = {
+    a: { servers: { example: { url: "https://example.com/mcp" } } },
+  };
+
+  dropReplacedServers(existing, incoming, "a.servers");
+  const merged = deepMerge(existing, incoming);
+
+  assert.deepStrictEqual(
+    ((merged.a as Record<string, unknown>).servers as Record<string, unknown>)
+      .example,
+    { url: "https://example.com/mcp" },
+  );
+});
+
+test("dropReplacedServers is a no-op when the config key is missing", () => {
+  const existing = { unrelated: true };
+  const incoming = {
+    mcp_servers: { example: { url: "https://example.com/mcp" } },
+  };
+
+  dropReplacedServers(existing, incoming, "mcp_servers");
+
+  assert.deepStrictEqual(existing, { unrelated: true });
 });
 
 console.log(`\n${passed} passed, ${failed} failed`);


### PR DESCRIPTION
## Problem

Installing a server under a name that already exists in an agent's config file **deep-merges** the new entry into the old one instead of replacing it, so stale fields from the previous install survive.

The worst case is stdio → remote: an old stdio entry's `command`/`args`/`env` survive alongside the new `type`/`url`. For Codex this is fatal — it rejects the whole config with:

```
invalid configuration: url is not supported for stdio
in `mcp_servers.firecrawl`
```

which breaks **every** chat ("Error creating chat") until the user hand-edits `~/.codex/config.toml`. This happened in the wild via `firecrawl setup mcp` (which shells out to `add-mcp`) on a machine that had an older stdio `firecrawl-mcp` entry.

## Repro (v1.14.0)

```bash
mkdir /tmp/codex-home
cat > /tmp/codex-home/config.toml <<'EOF'
[mcp_servers.firecrawl]
command = "npx"
args = [ "-y", "firecrawl-mcp" ]

  [mcp_servers.firecrawl.env]
  FIRECRAWL_API_KEY = "fc-test"
EOF

CODEX_HOME=/tmp/codex-home npx -y add-mcp "https://mcp.firecrawl.dev/fc-test/v2/mcp" \
  --name firecrawl --transport http -g -a codex -y

cat /tmp/codex-home/config.toml
```

Result — a hybrid entry Codex cannot load:

```toml
[mcp_servers.firecrawl]
command = "npx"
args = [ "-y", "firecrawl-mcp" ]
type = "http"
url = "https://mcp.firecrawl.dev/fc-test/v2/mcp"

  [mcp_servers.firecrawl.env]
  FIRECRAWL_API_KEY = "fc-test"
```

The same merge-instead-of-replace behavior exists in the JSON and YAML writers; JSON-based agents just happen to tolerate the leftover keys rather than failing hard.

## Why replace (not merge, skip, or prompt)

This matches the intended semantics discussed in #12, where replace was described as the default for name conflicts:

> replace (current behavior) as default so it's "backwards compatible"

In practice the code deep-merged rather than replaced, which is what this PR fixes — no CLI surface or behavior contract changes, just making name-conflict installs actually produce the new entry. An `--on-conflict merge|skip|overwrite` flag as sketched in #12 could still be layered on top later; this PR just makes the default sound.

## Fix

Add `dropReplacedServers(existing, incoming, configKey)` in `src/formats/utils.ts`: before the `deepMerge`, delete from the existing config any server names the incoming config is about to write. Server entries are now replaced atomically, while everything else in the file (other servers, unrelated settings, JSONC comments via the existing `jsonc.modify` path) still merges/preserves exactly as before. Wired into all three writers (`toml.ts`, `yaml.ts`, `json.ts`); `writeConfig` now passes `configKey` through to the YAML/TOML writers.

After the fix, the repro above produces:

```toml
[mcp_servers.firecrawl]
type = "http"
url = "https://mcp.firecrawl.dev/fc-test/v2/mcp"
```

## Tests & housekeeping

- Two e2e regression tests (`tests/e2e/install.test.ts`): stdio→remote re-install for Codex/TOML and Cursor/JSON, asserting no `command`/`args`/`env` survive. Both fail on `main` and pass with this change.
- Three unit tests for `dropReplacedServers` in `tests/formats-utils.test.ts` (replacement + sibling-server preservation, dotted config keys, missing-key no-op).
- `tests/formats-utils.test.ts` existed but was never registered in the `test`/`test:unit` scripts, so its tests didn't run in CI — registered it (its pre-existing tests pass).
- CHANGELOG entry and patch version bump to 1.14.1.
- `typecheck`, full `test` suite, and `build` all pass; touched files are Prettier-clean.
