### PR TITLE
Track registry website searches by source

### DIFF
--- a/registry/README.md
+++ b/registry/README.md
@@ -61,14 +61,14 @@ DATABASE_URL=postgres://...
 ANALYTICS_SALT=replace-with-a-stable-random-secret
 ```
 
-When enabled, the registry creates an `api_requests` table if it does not already exist. It stores request metadata such as method, path, status, duration, search term, pagination flags, user agent, referrer, and a salted hash of the client IP address. Raw IP addresses are not stored.
+When enabled, the registry stores request metadata such as method, path, status, duration, search term, search source (`web`, `cli`, or `api`), pagination flags, user agent, referrer, and a salted hash of the client IP address. Raw IP addresses are not stored. Apply the checked-in Drizzle migrations before deploying schema changes.
 
 ### Search-based popularity
 
 When `DATABASE_URL` is set, recorded search terms power additional features:
 
 - The default (unfiltered) server listing in the UI and API is sorted by search popularity instead of alphabetically. A search term counts towards every server it matches, and overly generic terms (matching more than 25 servers) are ignored.
-- The home page shows registry stats (total searches all time and this week) and trending search terms.
+- The home page shows combined website, CLI, and API search stats (total searches all time and this week) and trending search terms.
 - Server cards show per-server search counts.
 
 Without a database, the registry falls back to alphabetical sorting and hides the analytics UI.

--- a/registry/drizzle/0002_new_riptide.sql
+++ b/registry/drizzle/0002_new_riptide.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "api_requests" ADD COLUMN "search_source" text DEFAULT 'api' NOT NULL;--> statement-breakpoint
+CREATE INDEX "api_requests_search_source_created_at_idx" ON "api_requests" USING btree ("search_source","created_at" DESC NULLS LAST);

--- a/registry/drizzle/meta/0002_snapshot.json
+++ b/registry/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,193 @@
+{
+  "id": "f043fe7c-90f7-4496-a27b-9a40cf96858f",
+  "prevId": "d884606e-3108-41d6-a11d-7d7b1e14f55d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_requests": {
+      "name": "api_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search": {
+          "name": "search",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_source": {
+          "name": "search_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'api'"
+        },
+        "limit_value": {
+          "name": "limit_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cursor_present": {
+          "name": "cursor_present",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referrer": {
+          "name": "referrer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "api_requests_created_at_idx": {
+          "name": "api_requests_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_requests_search_idx": {
+          "name": "api_requests_search_idx",
+          "columns": [
+            {
+              "expression": "search",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"api_requests\".\"search\" is not null and \"api_requests\".\"search\" <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_requests_route_created_at_idx": {
+          "name": "api_requests_route_created_at_idx",
+          "columns": [
+            {
+              "expression": "route",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_requests_search_source_created_at_idx": {
+          "name": "api_requests_search_source_created_at_idx",
+          "columns": [
+            {
+              "expression": "search_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/registry/drizzle/meta/_journal.json
+++ b/registry/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1783296112161,
       "tag": "0001_make_search_index_partial",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1784778313628,
+      "tag": "0002_new_riptide",
+      "breakpoints": true
     }
   ]
 }

--- a/registry/src/components/search/server-search-input-client.tsx
+++ b/registry/src/components/search/server-search-input-client.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import { Loader2Icon, SearchIcon, XIcon } from "lucide-react";
 import { debounce, parseAsInteger, parseAsString, useQueryState } from "nuqs";
 
 import { Input } from "@/components/ui/input";
+import { withBasePath } from "@/lib/base-path";
 import { cn } from "@/lib/utils";
 
 type ServerSearchInputClientProps = {
@@ -37,6 +38,8 @@ export function ServerSearchInputClient({
   // Local state keeps typing responsive; the query state (and server
   // round-trip) follows debounced behind it.
   const [value, setValue] = useState(search);
+  const mounted = useRef(false);
+  const lastTrackedSearch = useRef(search.trim().toLowerCase());
 
   function handleChange(next: string) {
     setValue(next);
@@ -50,6 +53,31 @@ export function ServerSearchInputClient({
     setLastSearch(search);
     setValue(search);
   }
+
+  useEffect(() => {
+    if (!mounted.current) {
+      mounted.current = true;
+      return;
+    }
+
+    const normalized = value.trim().toLowerCase();
+    if (!normalized || normalized === lastTrackedSearch.current) {
+      lastTrackedSearch.current = normalized;
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      lastTrackedSearch.current = normalized;
+      void fetch(withBasePath("/api/v1/searches"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ search: normalized }),
+        keepalive: true,
+      }).catch(() => undefined);
+    }, 300);
+
+    return () => window.clearTimeout(timeout);
+  }, [value]);
 
   return (
     <div className={cn("relative", className)}>

--- a/registry/src/lib/analytics/postgres.ts
+++ b/registry/src/lib/analytics/postgres.ts
@@ -2,12 +2,14 @@ import { createHash } from "node:crypto";
 
 import { apiRequests } from "../db/schema";
 import { getAnalyticsDb } from "./db";
+import type { SearchSource } from "./search-source";
 
 type ApiRequestAnalytics = {
   method: string;
   path: string;
   status: number;
   search?: string;
+  searchSource: SearchSource;
   limit?: string;
   cursorPresent: boolean;
   userAgent?: string;
@@ -59,6 +61,7 @@ export async function recordApiRequest(
       route: routeForPath(event.path),
       status: event.status,
       search: event.search?.trim() || null,
+      searchSource: event.searchSource,
       limitValue: parseLimit(event.limit),
       cursorPresent: event.cursorPresent,
       userAgent: event.userAgent || null,

--- a/registry/src/lib/analytics/search-source.ts
+++ b/registry/src/lib/analytics/search-source.ts
@@ -1,0 +1,11 @@
+export const SEARCH_SOURCES = ["api", "cli", "web"] as const;
+
+export type SearchSource = (typeof SEARCH_SOURCES)[number];
+
+/**
+ * Only the add-mcp CLI may self-identify through the public listing endpoint.
+ * Website searches are assigned by the dedicated same-origin event endpoint.
+ */
+export function apiSearchSource(value: string | undefined): SearchSource {
+  return value === "cli" ? "cli" : "api";
+}

--- a/registry/src/lib/analytics/search-stats.ts
+++ b/registry/src/lib/analytics/search-stats.ts
@@ -64,8 +64,12 @@ async function fetchSearchStats(): Promise<SearchStats | null> {
       from api_requests
       where search is not null
         and trim(search) <> ''
-        and route = '/api/v1/servers'
-        and status < 500
+        and (
+          (route = '/api/v1/servers' and method = 'GET')
+          or (route = '/api/v1/searches' and method = 'POST')
+        )
+        and status >= 200
+        and status < 400
       group by lower(trim(search))
       order by all_time desc
     `),
@@ -77,8 +81,12 @@ async function fetchSearchStats(): Promise<SearchStats | null> {
       from api_requests
       where search is not null
         and trim(search) <> ''
-        and route = '/api/v1/servers'
-        and status < 500
+        and (
+          (route = '/api/v1/servers' and method = 'GET')
+          or (route = '/api/v1/searches' and method = 'POST')
+        )
+        and status >= 200
+        and status < 400
         and created_at >= now() - make_interval(days => ${DAILY_WINDOW_DAYS})
       group by 1, 2
     `),

--- a/registry/src/lib/api-app.ts
+++ b/registry/src/lib/api-app.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 
 import { getPopularityScores } from "./analytics/popularity";
 import { recordApiRequest } from "./analytics/postgres";
+import { apiSearchSource, type SearchSource } from "./analytics/search-source";
 import { basePath, stripBasePath } from "./base-path";
 import { loadRegistryFromFile } from "./load-registry";
 import { queryServers } from "./query-servers";
@@ -18,7 +19,17 @@ const querySchema = z.object({
   cursor: z.string().optional(),
   limit: z.string().optional(),
 });
+const webSearchEventSchema = z.object({
+  search: z.string().trim().min(1).max(200),
+});
 const healthResponseSchema = z.object({ status: z.literal("ok") });
+
+type ApiEnv = {
+  Variables: {
+    analyticsSearch?: string;
+    analyticsSearchSource?: SearchSource;
+  };
+};
 
 function getSourcePath(): string {
   return (
@@ -37,7 +48,7 @@ async function getRegistryEntries(): Promise<ServerEntry[]> {
 
 // Next strips the configured basePath before invoking route handlers, so the
 // Hono app always mounts at /api regardless of NEXT_PUBLIC_BASE_PATH.
-export const apiApp = new Hono().basePath("/api");
+export const apiApp = new Hono<ApiEnv>().basePath("/api");
 
 apiApp.use(async (c, next) => {
   const startedAt = performance.now();
@@ -49,7 +60,9 @@ apiApp.use(async (c, next) => {
     path: stripBasePath(c.req.path),
     method: c.req.method,
     status: c.res.status,
-    search: c.req.query("search"),
+    search: c.get("analyticsSearch") ?? c.req.query("search"),
+    searchSource:
+      c.get("analyticsSearchSource") ?? apiSearchSource(c.req.query("source")),
     limit: c.req.query("limit"),
     cursorPresent: Boolean(c.req.query("cursor")),
     userAgent: c.req.header("user-agent"),
@@ -116,6 +129,14 @@ apiApp.get(
         schema: { type: "string" },
         description: "Maximum number of servers per page.",
       },
+      {
+        in: "query",
+        name: "source",
+        required: false,
+        schema: { type: "string", enum: ["cli"] },
+        description:
+          "Identifies searches initiated by the add-mcp CLI for analytics attribution.",
+      },
     ],
     responses: {
       200: {
@@ -147,6 +168,59 @@ apiApp.get(
       const detail = error instanceof Error ? error.message : "Invalid query";
       throw new HTTPException(400, { message: detail });
     }
+  },
+);
+
+apiApp.post(
+  "/v1/searches",
+  describeRoute({
+    tags: ["analytics"],
+    summary: "Record a registry website search",
+    description:
+      "Records an active search from the registry website. Search statistics combine these events with API and CLI searches.",
+    requestBody: {
+      required: true,
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            required: ["search"],
+            properties: {
+              search: {
+                type: "string",
+                minLength: 1,
+                maxLength: 200,
+              },
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      204: {
+        description: "Search recorded.",
+      },
+      400: {
+        description: "Invalid search event.",
+      },
+    },
+  }),
+  async (c) => {
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      throw new HTTPException(400, { message: "Invalid JSON body." });
+    }
+
+    const parsed = webSearchEventSchema.safeParse(body);
+    if (!parsed.success) {
+      throw new HTTPException(400, { message: "Invalid search event." });
+    }
+
+    c.set("analyticsSearch", parsed.data.search);
+    c.set("analyticsSearchSource", "web");
+    return c.body(null, 204);
   },
 );
 

--- a/registry/src/lib/db/schema.ts
+++ b/registry/src/lib/db/schema.ts
@@ -21,6 +21,7 @@ export const apiRequests = pgTable(
     route: text("route").notNull(),
     status: integer("status").notNull(),
     search: text("search"),
+    searchSource: text("search_source").notNull().default("api"),
     limitValue: integer("limit_value"),
     cursorPresent: boolean("cursor_present").notNull().default(false),
     userAgent: text("user_agent"),
@@ -35,6 +36,10 @@ export const apiRequests = pgTable(
       .where(sql`${table.search} is not null and ${table.search} <> ''`),
     index("api_requests_route_created_at_idx").on(
       table.route,
+      table.createdAt.desc(),
+    ),
+    index("api_requests_search_source_created_at_idx").on(
+      table.searchSource,
       table.createdAt.desc(),
     ),
   ],

--- a/registry/tests/api.e2e.test.ts
+++ b/registry/tests/api.e2e.test.ts
@@ -30,6 +30,27 @@ describe("mcp-registry api", () => {
     expect(body.servers[0]?.server.name).toBe("io.github.example/filesystem");
   });
 
+  it("accepts website search events", async () => {
+    const response = await apiApp.request("http://localhost/api/v1/searches", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ search: "  Neon  " }),
+    });
+
+    expect(response.status).toBe(204);
+    expect(await response.text()).toBe("");
+  });
+
+  it("rejects empty website search events", async () => {
+    const response = await apiApp.request("http://localhost/api/v1/searches", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ search: "   " }),
+    });
+
+    expect(response.status).toBe(400);
+  });
+
   it("generates openapi spec", async () => {
     const response = await apiApp.request("http://localhost/api/openapi.json");
     expect(response.status).toBe(200);
@@ -43,5 +64,6 @@ describe("mcp-registry api", () => {
     expect(body.openapi).toBe("3.1.0");
     expect(body.info.title).toBe("add-mcp registry API");
     expect(body.paths["/api/v1/servers"]).toBeTruthy();
+    expect(body.paths["/api/v1/searches"]).toBeTruthy();
   });
 });

--- a/registry/tests/search-source.test.ts
+++ b/registry/tests/search-source.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { apiSearchSource } from "../src/lib/analytics/search-source";
+
+describe("apiSearchSource", () => {
+  it("identifies add-mcp CLI searches", () => {
+    expect(apiSearchSource("cli")).toBe("cli");
+  });
+
+  it("keeps missing and untrusted sources in the generic API bucket", () => {
+    expect(apiSearchSource(undefined)).toBe("api");
+    expect(apiSearchSource("web")).toBe("api");
+    expect(apiSearchSource("other")).toBe("api");
+  });
+});

--- a/src/find.ts
+++ b/src/find.ts
@@ -292,6 +292,7 @@ function buildRegistryRequestUrl(registryUrl: string, query: string): string {
   });
   if (query.length > 0) {
     params.set("search", query);
+    params.set("source", "cli");
   }
   const url = new URL(registryUrl);
   for (const [key, value] of params.entries()) {

--- a/tests/find.test.ts
+++ b/tests/find.test.ts
@@ -180,13 +180,18 @@ function toApiServerShape(entry: RegistryServerEntry) {
 
 test("searchRegistry maps API response entries", async () => {
   const originalFetch = globalThis.fetch;
-  globalThis.fetch = (async () =>
-    ({
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = new URL(String(input));
+    assert.strictEqual(url.searchParams.get("search"), "supabase");
+    assert.strictEqual(url.searchParams.get("source"), "cli");
+
+    return {
       ok: true,
       json: async () => ({
         servers: officialServersFixture.map(toApiServerShape),
       }),
-    }) as Response) as typeof fetch;
+    } as Response;
+  }) as typeof fetch;
 
   try {
     const result = await searchRegistry("supabase", [
@@ -612,6 +617,11 @@ test("searchRegistry fetches entries for blank query (browse mode)", async () =>
       url.includes("search="),
       false,
       "browse request should not include search param",
+    );
+    assert.strictEqual(
+      url.includes("source="),
+      false,
+      "browse request should not include analytics source",
     );
     return {
       ok: true,

--- a/web/content/docs/04-registry.mdx
+++ b/web/content/docs/04-registry.mdx
@@ -11,10 +11,10 @@ npx add-mcp find neon
 
 ## Built-in registries
 
-| Registry                        | Base URL                                                | Description                                                                     |
-| ------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Registry                        | Base URL                                                | Description                                                                                        |
+| ------------------------------- | ------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
 | **add-mcp registry**            | `https://add-mcp.com/registry/api/v1/servers`           | MCP servers discovered by integrations.sh, exposed through a registry-compatible API. The default. |
-| **Official Anthropic registry** | `https://registry.modelcontextprotocol.io/v0.1/servers` | The community-driven MCP server registry maintained by Anthropic — the broadest catalog. |
+| **Official Anthropic registry** | `https://registry.modelcontextprotocol.io/v0.1/servers` | The community-driven MCP server registry maintained by Anthropic — the broadest catalog.           |
 
 The first `find`/`search` run automatically saves the default registry to `~/.config/add-mcp/config.json` (respects `XDG_CONFIG_HOME`) and reuses it on every subsequent search.
 
@@ -57,6 +57,7 @@ Any server that implements the registry API can be used. The CLI sends a `GET` r
 | `search`  | The user's search keyword (lowercased) |
 | `version` | `latest`                               |
 | `limit`   | `100`                                  |
+| `source`  | `cli`                                  |
 
 The endpoint must return JSON in this shape:
 
@@ -98,3 +99,7 @@ curl "https://add-mcp.com/registry/api/v1/servers?search=neon&limit=10"
 ```
 
 The full OpenAPI spec is served at [`/registry/api/openapi.json`](/registry/api/openapi.json). The registry server is open source and self-hostable: [agent-tooling/mcp-registry](https://github.com/agent-tooling/mcp-registry).
+
+## Search analytics
+
+The hosted add-mcp registry records search terms from the website and registry API. The add-mcp CLI identifies its searches separately, so usage can be analyzed by website, CLI, or generic API traffic. The public all-time and weekly totals, trending terms, rankings, and per-server search counts combine every source.


### PR DESCRIPTION
## What changed

- record active registry search-bar queries through a dedicated same-origin event endpoint
- store search origin as `web`, `cli`, or fallback `api`
- tag add-mcp CLI registry searches with `source=cli`
- combine every source in the existing all-time, weekly, trending, ranking, and per-server statistics
- add the additive Drizzle migration and document the analytics behavior

## Why

CLI searches already reached the registry API and fed the public search statistics, but website searches filtered the registry directly and were invisible to analytics. This keeps source-level attribution available without splitting the public website totals.

## Validation

- `bun run registry:verify`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `pnpm --dir registry run fmt:check`
- `pnpm --dir registry run typecheck`
- `pnpm --dir registry run test`
- `pnpm --dir registry run build`
- `bun --cwd web run build`

The migration is additive: existing rows default to `api`, and a source/time index supports source-specific analysis.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added website search analytics and attribution across website, API, and CLI searches.
  * Added a search tracking endpoint and improved homepage popularity statistics.
  * CLI searches are now identified separately from other registry searches.

* **Documentation**
  * Expanded registry documentation with search analytics details and the new source parameter.
  * Added deployment guidance for applying analytics-related schema updates.

* **Tests**
  * Added coverage for website search tracking, source attribution, and request parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->