### PR TITLE
fix: handle Gemini CLI httpUrl across list, remove, and sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.14.1] - 2026-07-22
+
+- recognize Gemini CLI's legacy `httpUrl` field across `list`, `remove`, and `sync`, preserving the endpoint and headers when syncing the server to other agents. Co-authored with @preciousimo ([#33](https://github.com/neon-solutions/add-mcp/issues/33), [#79](https://github.com/neon-solutions/add-mcp/pull/79))
+
 ## [1.14.0] - 2026-07-06
 
 - move the default `find` / `search` registry to its new home at `https://add-mcp.com/registry/api/v1/servers` (label: "add-mcp registry"). The previous `mcp.agent-tooling.dev` URL keeps working; saved configs referencing it are migrated automatically on the next `find` / `search` run (custom labels are preserved, duplicates are deduped).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-mcp",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Add MCP servers to your favorite coding agents with a single command.",
   "author": "Andre Landgraf <andre@neon.tech>",
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1145,18 +1145,23 @@ function normalizeTransportType(
 function buildServerConfigFromStored(
   config: Record<string, unknown>,
 ): import("./types.js").McpServerConfig {
+  const httpUrl =
+    typeof config.httpUrl === "string" && config.httpUrl.length > 0
+      ? config.httpUrl
+      : undefined;
   const url =
-    typeof config.url === "string"
+    httpUrl ??
+    (typeof config.url === "string"
       ? config.url
       : typeof config.uri === "string"
         ? config.uri
         : typeof config.serverUrl === "string"
           ? config.serverUrl
-          : undefined;
+          : undefined);
 
   if (url) {
     const result: import("./types.js").McpServerConfig = {
-      type: normalizeTransportType(config.type),
+      type: httpUrl ? "http" : normalizeTransportType(config.type),
       url,
     };
 

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -33,8 +33,8 @@ export interface AgentServers {
 export function extractServerIdentity(
   serverConfig: Record<string, unknown>,
 ): string {
-  // Remote: check url, uri, serverUrl
-  for (const key of ["url", "uri", "serverUrl"]) {
+  // Remote: Gemini CLI gives legacy httpUrl priority when both URL fields exist.
+  for (const key of ["httpUrl", "url", "uri", "serverUrl"]) {
     const value = serverConfig[key];
     if (typeof value === "string" && value.length > 0) {
       return value;

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -1066,6 +1066,43 @@ test("list: shows servers for detected agents in project", () => {
   assert.match(output, /context7/);
 });
 
+test("list: shows Gemini CLI httpUrl and honors its precedence", () => {
+  const homeDir = createTempDir();
+  const projectDir = createTempDir();
+
+  const geminiDir = join(projectDir, ".gemini");
+  mkdirSync(geminiDir, { recursive: true });
+  writeFileSync(
+    join(geminiDir, "settings.json"),
+    JSON.stringify({
+      mcpServers: {
+        context7: {
+          httpUrl: "https://mcp.context7.com/mcp",
+          headers: { CONTEXT7_API_KEY: "test" },
+        },
+        migrating: {
+          httpUrl: "https://legacy.example.com/mcp",
+          url: "https://new.example.com/mcp",
+          type: "http",
+        },
+      },
+    }),
+  );
+
+  const result = runCli(["list", "-a", "gemini-cli"], projectDir, homeDir);
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.match(output, /context7.*https:\/\/mcp\.context7\.com\/mcp/);
+  assert.match(output, /migrating.*https:\/\/legacy\.example\.com\/mcp/);
+  assert.doesNotMatch(output, /https:\/\/new\.example\.com\/mcp/);
+});
+
 test("list: shows 'no servers configured' when agent detected but empty", () => {
   const homeDir = createTempDir();
   const projectDir = createTempDir();
@@ -1168,6 +1205,40 @@ test("remove: matches by URL identity with -y", () => {
 
   const config = JSON.parse(readFileSync(configPath, "utf-8"));
   assert.strictEqual(config.mcpServers["my-neon"], undefined);
+});
+
+test("remove: matches Gemini CLI httpUrl identity with -y", () => {
+  const homeDir = createTempDir();
+  const projectDir = createTempDir();
+
+  const geminiDir = join(projectDir, ".gemini");
+  mkdirSync(geminiDir, { recursive: true });
+  const configPath = join(geminiDir, "settings.json");
+  writeFileSync(
+    configPath,
+    JSON.stringify({
+      mcpServers: {
+        context7: {
+          httpUrl: "https://mcp.context7.com/mcp",
+        },
+      },
+    }),
+  );
+
+  const result = runCli(
+    ["remove", "https://mcp.context7.com/mcp", "-y"],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const config = JSON.parse(readFileSync(configPath, "utf-8"));
+  assert.strictEqual(config.mcpServers.context7, undefined);
 });
 
 test("remove: prints message when no matches found", () => {
@@ -1306,6 +1377,55 @@ test("sync: reconstructs required fields when syncing Cursor -> Claude Code", ()
     claudeConfig.mcpServers.neon.url,
     "https://mcp.neon.tech/mcp",
   );
+});
+
+test("sync: preserves Gemini CLI httpUrl and headers", () => {
+  const homeDir = createTempDir();
+  const projectDir = createTempDir();
+
+  const geminiDir = join(projectDir, ".gemini");
+  mkdirSync(geminiDir, { recursive: true });
+  writeFileSync(
+    join(geminiDir, "settings.json"),
+    JSON.stringify({
+      mcpServers: {
+        context7: {
+          httpUrl: "https://mcp.context7.com/mcp",
+          headers: {
+            CONTEXT7_API_KEY: "test",
+            Accept: "application/json, text/event-stream",
+          },
+        },
+      },
+    }),
+  );
+
+  const cursorDir = join(projectDir, ".cursor");
+  mkdirSync(cursorDir, { recursive: true });
+  const cursorConfigPath = join(cursorDir, "mcp.json");
+  writeFileSync(
+    cursorConfigPath,
+    JSON.stringify({
+      mcpServers: {},
+    }),
+  );
+
+  const result = runCli(["sync", "-y"], projectDir, homeDir);
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const cursorConfig = JSON.parse(readFileSync(cursorConfigPath, "utf-8"));
+  assert.deepStrictEqual(cursorConfig.mcpServers.context7, {
+    url: "https://mcp.context7.com/mcp",
+    headers: {
+      CONTEXT7_API_KEY: "test",
+      Accept: "application/json, text/event-stream",
+    },
+  });
 });
 
 test("sync: skips servers with header conflicts", () => {

--- a/tests/reader.test.ts
+++ b/tests/reader.test.ts
@@ -81,6 +81,23 @@ test("extractServerIdentity: Antigravity serverUrl field", () => {
   assert.strictEqual(identity, "https://mcp.example.com/api");
 });
 
+test("extractServerIdentity: Gemini CLI httpUrl field", () => {
+  const identity = extractServerIdentity({
+    httpUrl: "https://mcp.context7.com/mcp",
+    headers: { CONTEXT7_API_KEY: "test" },
+  });
+  assert.strictEqual(identity, "https://mcp.context7.com/mcp");
+});
+
+test("extractServerIdentity: Gemini CLI httpUrl takes priority over url", () => {
+  const identity = extractServerIdentity({
+    httpUrl: "https://legacy.example.com/mcp",
+    url: "https://new.example.com/mcp",
+    type: "http",
+  });
+  assert.strictEqual(identity, "https://legacy.example.com/mcp");
+});
+
 test("extractServerIdentity: npx package detection", () => {
   const identity = extractServerIdentity({
     command: "npx",


### PR DESCRIPTION
## Summary

- recognize Gemini CLI's legacy `httpUrl` field when listing and removing configured servers
- match Gemini CLI's `httpUrl`-before-`url` precedence when both fields are present
- normalize stored `httpUrl` entries into canonical streamable HTTP configs during `sync`, preserving headers instead of writing an empty server
- add unit and real CLI coverage for `list`, `remove`, and cross-agent `sync`
- bump the package to `1.14.1` and add release notes

Closes #33.
Supersedes #79.

## Root cause

The shared server identity extractor did not recognize Gemini CLI's `httpUrl` field, so `list` omitted the endpoint and URL-based removal could not match it. Adding only the missing identity key also made `sync` discover these entries, but the stored-config converter did not understand `httpUrl`; it would write an invalid `{ "args": [] }` server into another client while reporting success.

This change handles the field consistently across identity extraction and stored-config conversion.

## Credit

Co-authored with @preciousimo, whose work in #79 provided the original extractor fix and regression test. Thank you to @shen774411223d for the detailed report in #33 and to @preciousimo for implementing the initial fix.

The signed commit includes:

`Co-authored-by: Precious Imoniakemu <preciousimoniakemu@gmail.com>`

## Verification

- `bun run build`
- `bun run typecheck`
- `bun run test` — 336 passed, 0 failed
- `bun run registry:verify` — 1,326 entries verified
- Prettier check for all changed files
- `bun run fallow -- --summary` — complexity passes; the command remains non-zero on its repository-wide dead-code and duplication advisory thresholds (Fallow is local-only and not a CI gate)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Gemini CLI’s legacy `httpUrl` field across server listing, removal, and synchronization.
  * Preserved endpoint details and request headers when syncing Gemini CLI configurations to other agents.
  * Prioritized `httpUrl` when multiple endpoint fields are available.

* **Bug Fixes**
  * Corrected server identification and URL mapping for Gemini CLI configurations.

* **Chores**
  * Bumped the package version to 1.14.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->