### PR TITLE
feat: add LM Studio agent support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.1.0] - 2026-07-24
+
+- add `lmstudio` support with global installs written to `~/.lmstudio/mcp.json` (`mcpServers`), following Cursor's mcp.json notation for stdio and remote servers; alias: `lm-studio` ([#24](https://github.com/neon-solutions/add-mcp/issues/24))
+
 ## [2.0.0] - 2026-07-22
 
 - **BREAKING:** re-installing a server under an existing name now replaces that server's entire entry instead of deep-merging the new fields into the old entry. Callers that relied on omitted fields surviving a re-install must now pass the complete desired server configuration. This prevents stale fields from producing invalid hybrid configs — most damaging when an old stdio entry (`command`/`args`/`env`) was combined with a new remote install (`type`/`url`). Applies to the TOML, JSON, and YAML writers; unrelated servers and all other config sections are still preserved ([#83](https://github.com/neon-solutions/add-mcp/pull/83))

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Add MCP servers to your favorite coding agents with a single command.
 
-Supports **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **VS Code**, **Grok Build** and [10 more](#supported-agents).
+Supports **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **VS Code**, **Grok Build** and [11 more](#supported-agents).
 
 Docs and registry: [add-mcp.com](https://add-mcp.com)
 
@@ -63,13 +63,14 @@ MCP servers can be installed to any of these agents:
 | Goose                  | `goose`              | `.goose/config.yaml`    | `~/.config/goose/config.yaml`                                                                                   |
 | GitHub Copilot CLI     | `github-copilot-cli` | `.vscode/mcp.json`      | `~/.copilot/mcp-config.json`                                                                                    |
 | Grok Build             | `grok-build`         | `.grok/config.toml`     | `$GROK_HOME/config.toml` (defaults to `~/.grok/config.toml`)                                                    |
+| LM Studio              | `lmstudio`           | -                       | `~/.lmstudio/mcp.json`                                                                                          |
 | MCPorter               | `mcporter`           | `config/mcporter.json`  | `~/.mcporter/mcporter.json` (or existing `~/.mcporter/mcporter.jsonc`)                                          |
 | OpenCode               | `opencode`           | `opencode.json`         | `~/.config/opencode/opencode.json`                                                                              |
 | VS Code                | `vscode`             | `.vscode/mcp.json`      | `~/Library/Application Support/Code/User/mcp.json`                                                              |
 | Windsurf               | `windsurf`           | -                       | `~/.codeium/windsurf/mcp_config.json`                                                                           |
 | Zed                    | `zed`                | `.zed/settings.json`    | `~/Library/Application Support/Zed/settings.json`                                                               |
 
-**Aliases:** `codeium`, `cascade` → `windsurf`, `cline-vscode` → `cline`, `gemini` → `gemini-cli`, `github-copilot` → `vscode`, `grok` → `grok-build`
+**Aliases:** `codeium`, `cascade` → `windsurf`, `cline-vscode` → `cline`, `gemini` → `gemini-cli`, `github-copilot` → `vscode`, `grok` → `grok-build`, `lm-studio` → `lmstudio`
 
 ## Installation Scope
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-mcp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Add MCP servers to your favorite coding agents with a single command.",
   "author": "Andre Landgraf <andre@neon.tech>",
   "license": "Apache-2.0",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -624,10 +624,9 @@ export const agents: Record<AgentType, AgentConfig> = {
     name: "lmstudio",
     displayName: "LM Studio",
     configPath: lmstudioConfigPath,
-    projectDetectPaths: [], // Global only - no project support
+    projectDetectPaths: [],
     configKey: "mcpServers",
     format: "json",
-    // LM Studio follows Cursor's mcp.json notation for both stdio and remote.
     supportedTransports: ["stdio", "http", "sse"],
     supportedFields: [],
     detectGlobalInstall: async () => {

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -76,6 +76,7 @@ const windsurfConfigPath = join(
   "windsurf",
   "mcp_config.json",
 );
+const lmstudioConfigPath = join(home, ".lmstudio", "mcp.json");
 
 /**
  * Build the spec-aligned remote shape shared by clients that consume MCP
@@ -617,6 +618,22 @@ export const agents: Record<AgentType, AgentConfig> = {
     },
     resolveConfigPath: resolveGrokBuildConfigPath,
     transformConfig: transformGrokBuildConfig,
+  },
+
+  lmstudio: {
+    name: "lmstudio",
+    displayName: "LM Studio",
+    configPath: lmstudioConfigPath,
+    projectDetectPaths: [], // Global only - no project support
+    configKey: "mcpServers",
+    format: "json",
+    // LM Studio follows Cursor's mcp.json notation for both stdio and remote.
+    supportedTransports: ["stdio", "http", "sse"],
+    supportedFields: [],
+    detectGlobalInstall: async () => {
+      return existsSync(join(home, ".lmstudio"));
+    },
+    transformConfig: transformCursorConfig,
   },
 
   mcporter: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export type AgentType =
   | "goose"
   | "github-copilot-cli"
   | "grok-build"
+  | "lmstudio"
   | "mcporter"
   | "opencode"
   | "vscode"
@@ -25,6 +26,7 @@ export const agentAliases: Record<string, AgentType> = {
   gemini: "gemini-cli",
   "github-copilot": "vscode",
   grok: "grok-build",
+  "lm-studio": "lmstudio",
 };
 
 export type ConfigFormat = "json" | "yaml" | "toml";

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -60,9 +60,9 @@ function cleanup() {
 // Agent Configuration Tests
 // ============================================
 
-test("getAgentTypes returns all 16 agents", () => {
+test("getAgentTypes returns all 17 agents", () => {
   const types = getAgentTypes();
-  assert.strictEqual(types.length, 16);
+  assert.strictEqual(types.length, 17);
   assert.ok(types.includes("antigravity"));
   assert.ok(types.includes("cline"));
   assert.ok(types.includes("cline-cli"));
@@ -74,6 +74,7 @@ test("getAgentTypes returns all 16 agents", () => {
   assert.ok(types.includes("goose"));
   assert.ok(types.includes("github-copilot-cli"));
   assert.ok(types.includes("grok-build"));
+  assert.ok(types.includes("lmstudio"));
   assert.ok(types.includes("mcporter"));
   assert.ok(types.includes("opencode"));
   assert.ok(types.includes("vscode"));
@@ -164,6 +165,7 @@ test("supportsProjectConfig - returns false for global-only agents", () => {
   assert.strictEqual(supportsProjectConfig("claude-desktop"), false);
   assert.strictEqual(supportsProjectConfig("goose"), false);
   assert.strictEqual(supportsProjectConfig("windsurf"), false);
+  assert.strictEqual(supportsProjectConfig("lmstudio"), false);
 });
 
 test("getProjectCapableAgents returns 10 agents", () => {
@@ -181,15 +183,16 @@ test("getProjectCapableAgents returns 10 agents", () => {
   assert.ok(projectAgents.includes("zed"));
 });
 
-test("getGlobalOnlyAgents returns 6 agents", () => {
+test("getGlobalOnlyAgents returns 7 agents", () => {
   const globalAgents = getGlobalOnlyAgents();
-  assert.strictEqual(globalAgents.length, 6);
+  assert.strictEqual(globalAgents.length, 7);
   assert.ok(globalAgents.includes("antigravity"));
   assert.ok(globalAgents.includes("cline"));
   assert.ok(globalAgents.includes("cline-cli"));
   assert.ok(globalAgents.includes("claude-desktop"));
   assert.ok(globalAgents.includes("goose"));
   assert.ok(globalAgents.includes("windsurf"));
+  assert.ok(globalAgents.includes("lmstudio"));
 });
 
 test("Project + global-only agents equals all agents", () => {
@@ -349,6 +352,7 @@ test("detectProjectAgents - does not detect global-only agents", () => {
   assert.ok(!detected.includes("claude-desktop"));
   assert.ok(!detected.includes("goose"));
   assert.ok(!detected.includes("windsurf"));
+  assert.ok(!detected.includes("lmstudio"));
   assert.ok(!detected.includes("antigravity"));
 });
 
@@ -378,6 +382,7 @@ test("isTransportSupported - most agents support http", () => {
     "github-copilot-cli",
     "goose",
     "grok-build",
+    "lmstudio",
     "mcporter",
     "opencode",
     "vscode",
@@ -406,6 +411,7 @@ test("isTransportSupported - most agents support sse", () => {
     "github-copilot-cli",
     "goose",
     "grok-build",
+    "lmstudio",
     "mcporter",
     "opencode",
     "vscode",

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -95,6 +95,10 @@ function windsurfConfigPath(homeDir: string): string {
   return join(homeDir, ".codeium", "windsurf", "mcp_config.json");
 }
 
+function lmstudioConfigPath(homeDir: string): string {
+  return join(homeDir, ".lmstudio", "mcp.json");
+}
+
 function antigravityConfigPath(homeDir: string): string {
   return join(homeDir, ".gemini", "config", "mcp_config.json");
 }
@@ -850,6 +854,132 @@ test("E2E CLI: windsurf aliases (codeium, cascade) install to windsurf config", 
     const servers = saved.mcpServers as Record<string, unknown>;
     assert.ok(servers.remote, `${alias} should write remote server config`);
   }
+});
+
+test("E2E CLI: remote server to lmstudio succeeds with Cursor-shaped config", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "https://mcp.example.com/mcp",
+      "-a",
+      "lmstudio",
+      "-y",
+      "--name",
+      "remote",
+      "--header",
+      "Authorization: Bearer token",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const configPath = lmstudioConfigPath(homeDir);
+  assert.strictEqual(existsSync(configPath), true);
+
+  const saved = JSON.parse(readFileSync(configPath, "utf-8"));
+  const servers = saved.mcpServers as Record<string, unknown>;
+  const server = servers.remote as Record<string, unknown>;
+  assert.strictEqual(server.url, "https://mcp.example.com/mcp");
+  assert.strictEqual(server.type, undefined);
+  assert.deepStrictEqual(server.headers, {
+    Authorization: "Bearer token",
+  });
+});
+
+test("E2E CLI: --all includes lmstudio for remote server", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    ["https://mcp.example.com/mcp", "--all", "-y"],
+    projectDir,
+    homeDir,
+  );
+
+  assert.strictEqual(result.status, 0, "CLI should succeed");
+
+  const configPath = lmstudioConfigPath(homeDir);
+  assert.strictEqual(existsSync(configPath), true);
+
+  const saved = JSON.parse(readFileSync(configPath, "utf-8"));
+  const servers = saved.mcpServers as Record<string, unknown>;
+  const lmstudioRemoteServer = Object.values(servers).find((value) => {
+    const server = value as Record<string, unknown>;
+    return server.url === "https://mcp.example.com/mcp";
+  });
+  assert.ok(
+    lmstudioRemoteServer,
+    "remote lmstudio server should exist in mcpServers",
+  );
+});
+
+test("E2E CLI: stdio server to lmstudio succeeds", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "@modelcontextprotocol/server-filesystem",
+      "-a",
+      "lmstudio",
+      "-y",
+      "--name",
+      "filesystem",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const configPath = lmstudioConfigPath(homeDir);
+  assert.strictEqual(existsSync(configPath), true);
+
+  const saved = JSON.parse(readFileSync(configPath, "utf-8"));
+  const servers = saved.mcpServers as Record<string, unknown>;
+  assert.ok(servers.filesystem, "filesystem server should be configured");
+
+  const server = servers.filesystem as Record<string, unknown>;
+  assert.strictEqual(server.command, "npx");
+});
+
+test("E2E CLI: lmstudio alias (lm-studio) installs to lmstudio config", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "https://mcp.example.com/mcp",
+      "-a",
+      "lm-studio",
+      "-y",
+      "--name",
+      "remote",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  assert.strictEqual(result.status, 0, "lm-studio alias should succeed");
+
+  const configPath = lmstudioConfigPath(homeDir);
+  assert.strictEqual(existsSync(configPath), true);
+
+  const saved = JSON.parse(readFileSync(configPath, "utf-8"));
+  const servers = saved.mcpServers as Record<string, unknown>;
+  assert.ok(servers.remote, "lm-studio should write remote server config");
 });
 
 test("E2E CLI: local stdio install supports repeated --env", () => {

--- a/web/content/docs/05-agents.mdx
+++ b/web/content/docs/05-agents.mdx
@@ -18,6 +18,7 @@ MCP servers can be installed to any of these agents. Project paths are relative 
 | Goose                  | `goose`              | `.goose/config.yaml`    | `~/.config/goose/config.yaml`                                                                                   |
 | GitHub Copilot CLI     | `github-copilot-cli` | `.vscode/mcp.json`      | `~/.copilot/mcp-config.json`                                                                                    |
 | Grok Build             | `grok-build`         | `.grok/config.toml`     | `$GROK_HOME/config.toml` (defaults to `~/.grok/config.toml`)                                                    |
+| LM Studio              | `lmstudio`           | —                       | `~/.lmstudio/mcp.json`                                                                                          |
 | MCPorter               | `mcporter`           | `config/mcporter.json`  | `~/.mcporter/mcporter.json` (or existing `~/.mcporter/mcporter.jsonc`)                                          |
 | OpenCode               | `opencode`           | `opencode.json`         | `~/.config/opencode/opencode.json`                                                                              |
 | VS Code                | `vscode`             | `.vscode/mcp.json`      | `~/Library/Application Support/Code/User/mcp.json`                                                              |
@@ -33,6 +34,7 @@ MCP servers can be installed to any of these agents. Project paths are relative 
 | `gemini`             | `gemini-cli` |
 | `github-copilot`     | `vscode`     |
 | `grok`               | `grok-build` |
+| `lm-studio`          | `lmstudio`   |
 
 ## Troubleshooting
 

--- a/web/content/docs/index.mdx
+++ b/web/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: Introduction
 description: add-mcp adds MCP servers to your favorite coding agents with a single command.
 ---
 
-`add-mcp` is an open-source CLI (and TypeScript SDK) that installs [Model Context Protocol](https://modelcontextprotocol.io) servers into the config files of your coding agents — Claude Code, Codex, Cursor, OpenCode, VS Code, Grok Build, and [10 more](/docs/agents) — with a single command.
+`add-mcp` is an open-source CLI (and TypeScript SDK) that installs [Model Context Protocol](https://modelcontextprotocol.io) servers into the config files of your coding agents — Claude Code, Codex, Cursor, OpenCode, VS Code, Grok Build, and [11 more](/docs/agents) — with a single command.
 
 ```bash
 npx add-mcp https://mcp.context7.com/mcp

--- a/web/pages/index.astro
+++ b/web/pages/index.astro
@@ -20,6 +20,7 @@ const agentNames = [
   "GitHub Copilot CLI",
   "Goose",
   "Grok Build",
+  "LM Studio",
   "MCPorter",
   "Windsurf",
   "Zed",
@@ -252,7 +253,7 @@ const structuredData = JSON.stringify({
         class="text-muted-foreground mx-auto mt-2 max-w-2xl text-sm text-pretty"
       >
         add-mcp installs any MCP server into Claude Code, Codex, Cursor,
-        OpenCode, VS Code, and 10 more coding agents from the same command.
+        OpenCode, VS Code, and 11 more coding agents from the same command.
       </p>
       <div class="mt-4 flex flex-wrap items-center justify-center gap-2">
         {


### PR DESCRIPTION
## Summary
- Adds `lmstudio` as a global-only agent writing to `~/.lmstudio/mcp.json` (`mcpServers`), matching [LM Studio's Cursor-compatible mcp.json format](https://lmstudio.ai/docs/app/mcp) for both stdio and remote servers
- Adds `lm-studio` alias and covers detection, transport support, CLI installs, and `--all` in unit/e2e tests
- Closes #24

## Test plan
- [x] `bun run typecheck`
- [x] `bun run test` (unit + e2e)
- [ ] Manually: `npx add-mcp https://mcp.example.com/mcp -a lmstudio -y --name remote` and confirm `~/.lmstudio/mcp.json`
- [ ] Manually: `npx add-mcp @modelcontextprotocol/server-filesystem -a lm-studio -y --name filesystem`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LM Studio as a supported MCP agent, including global configuration support at `~/.lmstudio/mcp.json`.
  * Added the `lm-studio` alias and expanded supported remote/stdio installation flows.
* **Documentation**
  * Updated supported-agent lists and alias mappings to include LM Studio.
* **Tests**
  * Extended CLI end-to-end coverage and updated agent inventory/transport support expectations for LM Studio.
* **Chores**
  * Bumped the release version to **2.1.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->