### PR TITLE
fix: recognize OpenCode array command for list/sync/remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.0.1] - 2026-07-24
+
+- fix OpenCode local (stdio) servers being skipped by `list` / `remove` / `sync` identity matching — array `command` entries like `["npx", "-y", "pkg"]` now resolve to the same package identity as other agents, and `sync` reconstructs standard `command` / `args` / `env` (from OpenCode `environment`) for other clients
+
 ## [2.0.0] - 2026-07-22
 
 - **BREAKING:** re-installing a server under an existing name now replaces that server's entire entry instead of deep-merging the new fields into the old entry. Callers that relied on omitted fields surviving a re-install must now pass the complete desired server configuration. This prevents stale fields from producing invalid hybrid configs — most damaging when an old stdio entry (`command`/`args`/`env`) was combined with a new remote install (`type`/`url`). Applies to the TOML, JSON, and YAML writers; unrelated servers and all other config sections are still preserved ([#83](https://github.com/neon-solutions/add-mcp/pull/83))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-mcp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Add MCP servers to your favorite coding agents with a single command.",
   "author": "Andre Landgraf <andre@neon.tech>",
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1179,16 +1179,26 @@ function buildServerConfigFromStored(
     return result;
   }
 
-  const command =
-    typeof config.command === "string"
-      ? config.command
-      : typeof config.cmd === "string"
-        ? config.cmd
-        : undefined;
+  let command: string | undefined;
+  let args: string[] = [];
 
-  const args = Array.isArray(config.args)
-    ? config.args.filter((a): a is string => typeof a === "string")
-    : [];
+  if (typeof config.command === "string") {
+    command = config.command;
+    args = Array.isArray(config.args)
+      ? config.args.filter((a): a is string => typeof a === "string")
+      : [];
+  } else if (typeof config.cmd === "string") {
+    command = config.cmd;
+    args = Array.isArray(config.args)
+      ? config.args.filter((a): a is string => typeof a === "string")
+      : [];
+  } else if (Array.isArray(config.command)) {
+    const parts = config.command.filter(
+      (part): part is string => typeof part === "string",
+    );
+    command = parts[0];
+    args = parts.slice(1);
+  }
 
   const env =
     config.env && typeof config.env === "object"

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -33,7 +33,6 @@ export interface AgentServers {
 export function extractServerIdentity(
   serverConfig: Record<string, unknown>,
 ): string {
-  // Remote: Gemini CLI gives legacy httpUrl priority when both URL fields exist.
   for (const key of ["httpUrl", "url", "uri", "serverUrl"]) {
     const value = serverConfig[key];
     if (typeof value === "string" && value.length > 0) {
@@ -41,27 +40,31 @@ export function extractServerIdentity(
     }
   }
 
-  // Stdio: reconstruct from command/cmd + args
-  const command =
-    typeof serverConfig.command === "string"
-      ? serverConfig.command
-      : typeof serverConfig.cmd === "string"
-        ? serverConfig.cmd
-        : undefined;
+  let command: string | undefined;
+  let rawArgs: string[] = [];
+
+  if (typeof serverConfig.command === "string") {
+    command = serverConfig.command;
+    rawArgs = Array.isArray(serverConfig.args)
+      ? serverConfig.args.filter((a): a is string => typeof a === "string")
+      : [];
+  } else if (typeof serverConfig.cmd === "string") {
+    command = serverConfig.cmd;
+    rawArgs = Array.isArray(serverConfig.args)
+      ? serverConfig.args.filter((a): a is string => typeof a === "string")
+      : [];
+  } else if (Array.isArray(serverConfig.command)) {
+    const parts = serverConfig.command.filter(
+      (part): part is string => typeof part === "string",
+    );
+    command = parts[0];
+    rawArgs = parts.slice(1);
+  }
 
   if (!command) {
     return "";
   }
 
-  const rawArgs = Array.isArray(serverConfig.args)
-    ? serverConfig.args.filter((a): a is string => typeof a === "string")
-    : Array.isArray(serverConfig.command)
-      ? (serverConfig.command as unknown[])
-          .slice(1)
-          .filter((a): a is string => typeof a === "string")
-      : [];
-
-  // Detect npx -y <package> pattern
   if (command === "npx" || command === "bunx") {
     const yIndex = rawArgs.indexOf("-y");
     const pkgIndex = yIndex >= 0 ? yIndex + 1 : 0;
@@ -69,11 +72,6 @@ export function extractServerIdentity(
     if (pkg && !pkg.startsWith("-")) {
       return pkg;
     }
-  }
-
-  // OpenCode uses command as array: ["node", "server.js"]
-  if (Array.isArray(serverConfig.command)) {
-    return (serverConfig.command as string[]).join(" ");
   }
 
   if (rawArgs.length > 0) {

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -1385,6 +1385,47 @@ test("sync: reconstructs required fields when syncing Cursor -> Claude Code", ()
   );
 });
 
+test("sync: reconstructs OpenCode local array command into standard stdio", () => {
+  const homeDir = createTempDir();
+  const projectDir = createTempDir();
+
+  writeFileSync(
+    join(projectDir, "opencode.json"),
+    JSON.stringify({
+      mcp: {
+        postgres: {
+          type: "local",
+          command: ["npx", "-y", "mcp-server-postgres"],
+          enabled: true,
+          environment: { DATABASE_URL: "postgres://localhost/db" },
+        },
+      },
+    }),
+  );
+
+  const cursorDir = join(projectDir, ".cursor");
+  mkdirSync(cursorDir, { recursive: true });
+  const cursorConfigPath = join(cursorDir, "mcp.json");
+  writeFileSync(cursorConfigPath, JSON.stringify({ mcpServers: {} }));
+
+  const result = runCli(["sync", "-y"], projectDir, homeDir);
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const cursorConfig = JSON.parse(readFileSync(cursorConfigPath, "utf-8"));
+  const server = cursorConfig.mcpServers.postgres as Record<string, unknown>;
+  assert.ok(server, "Cursor should receive the OpenCode local server");
+  assert.strictEqual(server.command, "npx");
+  assert.deepStrictEqual(server.args, ["-y", "mcp-server-postgres"]);
+  assert.deepStrictEqual(server.env, {
+    DATABASE_URL: "postgres://localhost/db",
+  });
+});
+
 test("sync: preserves Gemini CLI httpUrl and headers", () => {
   const homeDir = createTempDir();
   const projectDir = createTempDir();

--- a/tests/reader.test.ts
+++ b/tests/reader.test.ts
@@ -151,6 +151,43 @@ test("extractServerIdentity: prefers url over command", () => {
   assert.strictEqual(identity, "https://example.com/mcp");
 });
 
+test("extractServerIdentity: OpenCode array command with npx -y package", () => {
+  const identity = extractServerIdentity({
+    type: "local",
+    command: ["npx", "-y", "mcp-server-postgres"],
+    enabled: true,
+    environment: {},
+  });
+  assert.strictEqual(identity, "mcp-server-postgres");
+});
+
+test("extractServerIdentity: OpenCode array command with bunx package", () => {
+  const identity = extractServerIdentity({
+    type: "local",
+    command: ["bunx", "-y", "@org/mcp-server"],
+    enabled: true,
+  });
+  assert.strictEqual(identity, "@org/mcp-server");
+});
+
+test("extractServerIdentity: OpenCode array command without package manager", () => {
+  const identity = extractServerIdentity({
+    type: "local",
+    command: ["node", "server.js", "--port", "3000"],
+    enabled: true,
+  });
+  assert.strictEqual(identity, "node server.js --port 3000");
+});
+
+test("extractServerIdentity: OpenCode array command with single entry", () => {
+  const identity = extractServerIdentity({
+    type: "local",
+    command: ["my-server"],
+    enabled: true,
+  });
+  assert.strictEqual(identity, "my-server");
+});
+
 // ── readServersForAgent ──────────────────────────────────────────────────
 
 test("readServersForAgent: reads JSON config for cursor", () => {
@@ -240,6 +277,32 @@ test("readServersForAgent: reads VS Code config with 'servers' key", () => {
 
   assert.strictEqual(result.servers.length, 1);
   assert.strictEqual(result.servers[0]!.serverName, "myserver");
+});
+
+test("readServersForAgent: reads OpenCode local array command identity", () => {
+  const tempDir = createTempDir();
+  writeFileSync(
+    join(tempDir, "opencode.json"),
+    JSON.stringify({
+      mcp: {
+        postgres: {
+          type: "local",
+          command: ["npx", "-y", "mcp-server-postgres"],
+          enabled: true,
+          environment: { DATABASE_URL: "postgres://localhost/db" },
+        },
+      },
+    }),
+  );
+
+  const result = readServersForAgent("opencode", {
+    scope: "local",
+    cwd: tempDir,
+  });
+
+  assert.strictEqual(result.servers.length, 1);
+  assert.strictEqual(result.servers[0]!.serverName, "postgres");
+  assert.strictEqual(result.servers[0]!.identity, "mcp-server-postgres");
 });
 
 // ── findMatchingServers ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- OpenCode local servers use `command: ["npx", "-y", "pkg"]`; identity extraction returned `""`, so `list` / `remove` / `sync` skipped them (`if (!server.identity) continue`)
- Array commands now resolve the same package identity as string `command` + `args`, and `sync` reconstructs standard `command` / `args` / `env` from OpenCode's `environment` field

## Test plan
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] Install a package to OpenCode, then `add-mcp sync -y` into Cursor and confirm `command`/`args`/`env` land correctly