### PR TITLE
feat: install OCI registry packages from find

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.1.0] - 2026-08-02
+
+- let `find` / `search` install OCI registry packages with `docker run`; required environment variables are forwarded into the container.
+
 ## [2.0.0] - 2026-07-22
 
 - **BREAKING:** re-installing a server under an existing name now replaces that server's entire entry instead of deep-merging the new fields into the old entry. Callers that relied on omitted fields surviving a re-install must now pass the complete desired server configuration. This prevents stale fields from producing invalid hybrid configs — most damaging when an old stdio entry (`command`/`args`/`env`) was combined with a new remote install (`type`/`url`). Applies to the TOML, JSON, and YAML writers; unrelated servers and all other config sections are still preserved ([#83](https://github.com/neon-solutions/add-mcp/pull/83))

--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ Transport for `find`/`search` is inferred from registry metadata. The CLI prefer
 
 When a server offers both remote and stdio package options, interactive mode lets you choose one (remote is the default). With `-y`, it auto-selects remote.
 
+Stdio registry packages can use npm or OCI (`docker run`). Install Docker before selecting an OCI package.
+
 If a selected remote server defines URL variables or header inputs:
 
 - required values must be provided

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-mcp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Add MCP servers to your favorite coding agents with a single command.",
   "author": "Andre Landgraf <andre@neon.tech>",
   "license": "Apache-2.0",

--- a/src/find.ts
+++ b/src/find.ts
@@ -80,6 +80,16 @@ export interface FindInstallPlan {
   args?: string[];
 }
 
+type InstallableRegistryPackageDefinition = RegistryPackageDefinition & {
+  registryType: "npm" | "oci";
+};
+
+interface ResolvedPackageInputs {
+  env?: Record<string, string>;
+  headers?: Record<string, string>;
+  args?: string[];
+}
+
 export interface PromptField {
   key: string;
   label: string;
@@ -259,18 +269,34 @@ interface RegistryServerListItem {
   };
 }
 
+function isInstallablePackage(
+  pkg: RegistryPackageDefinition,
+): pkg is InstallableRegistryPackageDefinition {
+  return pkg.registryType === "npm" || pkg.registryType === "oci";
+}
+
+function pickInstallablePackage(
+  packages: RegistryPackageDefinition[],
+): InstallableRegistryPackageDefinition | undefined {
+  for (const registryType of ["npm", "oci"] as const) {
+    const pkg = packages.find(
+      (candidate) => candidate.registryType === registryType,
+    );
+    if (pkg && isInstallablePackage(pkg)) return pkg;
+  }
+  return undefined;
+}
+
 function toEntry(item: RegistryServerListItem): RegistryServerEntry | null {
   const server = item?.server;
   if (!server?.name || !server?.description || !server?.version) {
     return null;
   }
 
-  const npmPackage = (server.packages ?? []).find(
-    (pkg) => pkg.registryType === "npm",
-  );
+  const installablePackage = pickInstallablePackage(server.packages ?? []);
 
   const hasRemotes = Array.isArray(server.remotes) && server.remotes.length > 0;
-  if (!npmPackage && !hasRemotes) {
+  if (!installablePackage && !hasRemotes) {
     return null;
   }
 
@@ -281,7 +307,7 @@ function toEntry(item: RegistryServerListItem): RegistryServerEntry | null {
     version: server.version,
     repositoryUrl: server.repository?.url,
     remotes: server.remotes,
-    package: npmPackage,
+    package: installablePackage,
   };
 }
 
@@ -385,6 +411,22 @@ function pickRemote(
 
 function formatPackageTarget(pkg: RegistryPackageDefinition): string {
   return pkg.identifier;
+}
+
+function buildPackageInstallTarget(
+  pkg: InstallableRegistryPackageDefinition,
+  resolved: ResolvedPackageInputs,
+): { target: string; args?: string[] } {
+  if (pkg.registryType === "npm") {
+    return { target: pkg.identifier, args: resolved.args };
+  }
+
+  const args = ["--rm", "-i"];
+  for (const name of Object.keys(resolved.env ?? {})) {
+    args.push("-e", name);
+  }
+  args.push(pkg.identifier, ...(resolved.args ?? []));
+  return { target: "docker run", args };
 }
 
 function transportLabel(entry: RegistryServerEntry): string {
@@ -531,11 +573,9 @@ async function resolveInteractiveRemote(
   };
 }
 
-function resolveNonInteractivePackage(pkg: RegistryPackageDefinition): {
-  env?: Record<string, string>;
-  headers?: Record<string, string>;
-  args?: string[];
-} {
+function resolveNonInteractivePackage(
+  pkg: RegistryPackageDefinition,
+): ResolvedPackageInputs {
   const env: Record<string, string> = {};
   for (const field of packageVariableFields(pkg.environmentVariables)) {
     if (field.isRequired) {
@@ -564,11 +604,7 @@ function resolveNonInteractivePackage(pkg: RegistryPackageDefinition): {
 
 async function resolveInteractivePackage(
   pkg: RegistryPackageDefinition,
-): Promise<{
-  env?: Record<string, string>;
-  headers?: Record<string, string>;
-  args?: string[];
-} | null> {
+): Promise<ResolvedPackageInputs | null> {
   const promptPackageArg: PackageArgPrompt = async (info) =>
     p.text({
       message: `${info.label} ${info.isRequired ? "(required)" : "(optional)"}`,
@@ -609,7 +645,8 @@ export async function buildInstallPlanForEntry(
   options: FindCommandOptions,
 ): Promise<FindInstallPlan | null> {
   const remote = pickRemote(entry, options.preferredTransport);
-  const pkg = entry.package ?? null;
+  const pkg =
+    entry.package && isInstallablePackage(entry.package) ? entry.package : null;
   const hasRemote = remote !== null;
   const hasPackage = pkg !== null;
 
@@ -647,12 +684,14 @@ export async function buildInstallPlanForEntry(
       : await resolveInteractivePackage(pkg);
     if (!resolved) return null;
 
+    const installTarget = buildPackageInstallTarget(pkg, resolved);
+
     return {
-      target: formatPackageTarget(pkg),
+      target: installTarget.target,
       serverName: resolveServerName(entry),
       env: resolved.env,
       headers: resolved.headers,
-      args: resolved.args,
+      args: installTarget.args,
     };
   }
 

--- a/tests/find.test.ts
+++ b/tests/find.test.ts
@@ -699,6 +699,44 @@ test("buildInstallPlanForEntry returns package target for package-only entry", a
   assert.strictEqual(plan?.args, undefined);
 });
 
+test("buildInstallPlanForEntry runs OCI packages with Docker and forwards env", async () => {
+  const plan = await buildInstallPlanForEntry(
+    {
+      name: "io.github.hashicorp/terraform-mcp-server",
+      description: "Terraform MCP server",
+      version: "0.5.0",
+      package: {
+        registryType: "oci",
+        identifier: "hashicorp/terraform-mcp-server:0.5.0",
+        version: "0.5.0",
+        transport: { type: "stdio" },
+        environmentVariables: [
+          { name: "TFE_TOKEN", isRequired: true, isSecret: true },
+        ],
+        packageArguments: [
+          { type: "named", name: "--log-level", value: "debug" },
+        ],
+      },
+    },
+    { yes: true },
+  );
+
+  assert.ok(plan);
+  assert.strictEqual(plan?.target, "docker run");
+  assert.deepStrictEqual(plan?.env, {
+    TFE_TOKEN: "<your-variable-value-here>",
+  });
+  assert.deepStrictEqual(plan?.args, [
+    "--rm",
+    "-i",
+    "-e",
+    "TFE_TOKEN",
+    "hashicorp/terraform-mcp-server:0.5.0",
+    "--log-level",
+    "debug",
+  ]);
+});
+
 test("buildInstallPlanForEntry includes only required package env/header/args placeholders in -y mode", async () => {
   const plan = await buildInstallPlanForEntry(
     {
@@ -993,7 +1031,7 @@ test("buildInstallPlanForEntry falls back to available remote when preferred tra
   assert.strictEqual(plan?.transport, "http");
 });
 
-test("searchRegistry filters out non-installable entries (no npm package and no remotes)", async () => {
+test("searchRegistry keeps supported package runtimes and filters unsupported entries", async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (async () =>
     ({
@@ -1017,6 +1055,21 @@ test("searchRegistry filters out non-installable entries (no npm package and no 
           },
           {
             server: {
+              name: "com.example/nuget-only",
+              description: "Unsupported NuGet-only server",
+              version: "1.0.0",
+              packages: [
+                {
+                  registryType: "nuget",
+                  identifier: "Example.Mcp",
+                  version: "1.0.0",
+                  transport: { type: "stdio" },
+                },
+              ],
+            },
+          },
+          {
+            server: {
               name: "com.example/metadata-only",
               description: "Just metadata, no transports",
               version: "0.1.0",
@@ -1028,6 +1081,12 @@ test("searchRegistry filters out non-installable entries (no npm package and no 
               description: "NPM server",
               version: "1.0.0",
               packages: [
+                {
+                  registryType: "oci",
+                  identifier: "ghcr.io/example/hybrid:1.0.0",
+                  version: "1.0.0",
+                  transport: { type: "stdio" },
+                },
                 {
                   registryType: "npm",
                   identifier: "@example/mcp-server",
@@ -1083,12 +1142,17 @@ test("searchRegistry filters out non-installable entries (no npm package and no 
       },
     ]);
     const names = result.entries.map((e) => e.name);
-    assert.strictEqual(result.entries.length, 3);
+    assert.strictEqual(result.entries.length, 4);
     assert.strictEqual(names.includes("com.example/npm-server"), true);
     assert.strictEqual(names.includes("com.example/remote-only"), true);
     assert.strictEqual(names.includes("com.example/hybrid"), true);
-    assert.strictEqual(names.includes("com.example/oci-only"), false);
+    assert.strictEqual(names.includes("com.example/oci-only"), true);
+    assert.strictEqual(names.includes("com.example/nuget-only"), false);
     assert.strictEqual(names.includes("com.example/metadata-only"), false);
+    const npmEntry = result.entries.find(
+      (e) => e.name === "com.example/npm-server",
+    )!;
+    assert.strictEqual(npmEntry.package?.registryType, "npm");
     const hybrid = result.entries.find((e) => e.name === "com.example/hybrid")!;
     assert.strictEqual(hybrid.package?.identifier, "@example/hybrid");
     assert.strictEqual(

--- a/web/content/docs/02-cli/02-find.mdx
+++ b/web/content/docs/02-cli/02-find.mdx
@@ -45,6 +45,8 @@ npx add-mcp find github --all --gitignore
 
 Transport is inferred from registry metadata. The CLI prefers HTTP remotes when available and only falls back to SSE when HTTP isn't available for the selected install context. When a server offers both remote and stdio package options, interactive mode lets you choose one (remote is the default); with `-y`, it auto-selects remote.
 
+Stdio registry packages can use npm or OCI (`docker run`). Install Docker before selecting an OCI package.
+
 If a selected remote server defines URL variables or header inputs:
 
 - required values must be provided,


### PR DESCRIPTION
## What changed

- let `find` / `search` retain package-only OCI registry entries while preserving npm as the first package choice
- translate OCI entries into `docker run --rm -i` stdio installs
- forward resolved package environment variables into the container with `-e NAME`
- keep registry `packageArguments` after the image identifier, where the container entrypoint receives them
- document the required Docker runtime and add the repository-required feature release note/version bump

## Why

The add-mcp registry already exposes OCI-only entries such as Terraform, but `toEntry()` only retained npm packages. The API returned the server while the CLI silently filtered it out, so users could neither see nor install it through `find`.

For the current Terraform entry, non-interactive Codex installation now writes the equivalent of:

```toml
[mcp_servers.terraform]
command = "docker"
args = ["run", "--rm", "-i", "-e", "TFE_TOKEN", "hashicorp/terraform-mcp-server:0.5.0"]

[mcp_servers.terraform.env]
TFE_TOKEN = "<your-variable-value-here>"
```

This PR intentionally adds no registry entry. It is complementary to #82, which covers PyPI packages; this change is limited to OCI execution and Docker environment forwarding.

## Validation

- `bun run typecheck`
- `bun x tsx tests/find.test.ts` - 41 passed
- Linux Node 22 + Bun 1.3.14: `bun install --frozen-lockfile`, `bun run typecheck`, `bun run build`, and `bun run test` - all 358 tests passed
- live registry smoke test: `find terraform -a codex -y` produced the Docker config shown above
- `fallow audit --changed-since upstream/main` - no findings in the six changed files; inherited repository findings were excluded by the audit gate

On native Windows, the existing global-home CLI E2E cases still require the `USERPROFILE` / `APPDATA` isolation covered independently by #82; the full Linux suite is green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing OCI registry packages through Docker.
  * OCI installations now pass required environment variables and package arguments to the container.
  * Package selection supports npm and OCI formats while excluding unsupported package types.

* **Documentation**
  * Updated CLI documentation, README, and changelog with OCI installation requirements and usage details.

* **Tests**
  * Added coverage for OCI installation commands, environment variables, arguments, and package filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->