### PR TITLE
feat: add cachebro to registry

### DIFF
--- a/registry.overlay.json
+++ b/registry.overlay.json
@@ -2,6 +2,36 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "io.github.glommer/cachebro",
+      "title": "CacheBro",
+      "description": "File cache with diff tracking for AI coding agents. Drop-in MCP server that cuts token usage by ~26%.",
+      "repository": {
+        "url": "https://github.com/glommer/cachebro",
+        "source": "github"
+      },
+      "version": "0.2.2",
+      "packages": [
+        {
+          "registryType": "npm",
+          "registryBaseUrl": "https://registry.npmjs.org",
+          "identifier": "cachebro",
+          "version": "0.2.2",
+          "transport": {
+            "type": "stdio"
+          },
+          "packageArguments": [
+            {
+              "type": "positional",
+              "value": "serve"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "io.github.github/github-mcp-server",
       "title": "GitHub",
       "description": "Official GitHub MCP server",


### PR DESCRIPTION
cachebro is a content caching MCP with diff tracking for AI agents so they don't have to re-read everything and waste tokens, it's developed by @glommer and powered by @tursodatabase.

project repo: https://github.com/glommer/cachebro

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the CacheBro MCP server to the registry, available in version 0.2.2.
  * Configured the server to launch through npm using standard input/output transport.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->