### PR TITLE
feat: detect jsonc file and resolve that over json for OpenCode

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -429,6 +429,33 @@ function resolveMcporterConfigPath(
   return globalJsonPath;
 }
 
+function resolveOpenCodeConfigPath(
+  agent: AgentConfig,
+  options: { local: boolean; cwd: string },
+): string {
+  if (options.local) {
+    const candidates = [
+      join(options.cwd, "opencode.jsonc"),
+      join(options.cwd, "opencode.json"),
+      join(options.cwd, ".opencode", "opencode.jsonc"),
+      join(options.cwd, ".opencode", "opencode.json"),
+    ];
+    for (const path of candidates) {
+      if (existsSync(path)) return path;
+    }
+    return join(options.cwd, "opencode.jsonc");
+  }
+
+  const candidates = [
+    join(home, ".config", "opencode", "opencode.jsonc"),
+    join(home, ".config", "opencode", "opencode.json"),
+  ];
+  for (const path of candidates) {
+    if (existsSync(path)) return path;
+  }
+  return join(home, ".config", "opencode", "opencode.jsonc");
+}
+
 function resolveGrokBuildConfigPath(
   agent: AgentConfig,
   options: { local: boolean; cwd: string },
@@ -639,9 +666,9 @@ export const agents: Record<AgentType, AgentConfig> = {
   opencode: {
     name: "opencode",
     displayName: "OpenCode",
-    configPath: join(home, ".config", "opencode", "opencode.json"),
-    localConfigPath: "opencode.json",
-    projectDetectPaths: ["opencode.json", ".opencode"],
+    configPath: join(home, ".config", "opencode", "opencode.jsonc"),
+    localConfigPath: "opencode.jsonc",
+    projectDetectPaths: ["opencode.jsonc", "opencode.json", ".opencode"],
     configKey: "mcp",
     format: "json",
     supportedTransports: ["stdio", "http", "sse"],
@@ -649,6 +676,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     detectGlobalInstall: async () => {
       return existsSync(join(home, ".config", "opencode"));
     },
+    resolveConfigPath: resolveOpenCodeConfigPath,
     transformConfig: transformOpenCodeConfig,
   },
 

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -281,6 +281,66 @@ test("detectProjectAgents - detects .opencode directory", () => {
   assert.ok(detected.includes("opencode"));
 });
 
+test("detectProjectAgents - detects opencode.jsonc file", () => {
+  const tempDir = createTempDir();
+  writeFileSync(join(tempDir, "opencode.jsonc"), "{}");
+
+  const detected = detectProjectAgents(tempDir);
+  assert.ok(detected.includes("opencode"));
+});
+
+test("resolveConfigPath local - prefers existing opencode.jsonc over .json", () => {
+  const tempDir = createTempDir();
+  writeFileSync(join(tempDir, "opencode.jsonc"), "{}");
+  writeFileSync(join(tempDir, "opencode.json"), "{}");
+
+  const resolver = agents.opencode.resolveConfigPath!;
+  const result = resolver(agents.opencode, { local: true, cwd: tempDir });
+  assert.equal(result, join(tempDir, "opencode.jsonc"));
+});
+
+test("resolveConfigPath local - falls through to .opencode/opencode.jsonc", () => {
+  const tempDir = createTempDir();
+  mkdirSync(join(tempDir, ".opencode"));
+  writeFileSync(join(tempDir, ".opencode", "opencode.jsonc"), "{}");
+
+  const resolver = agents.opencode.resolveConfigPath!;
+  const result = resolver(agents.opencode, { local: true, cwd: tempDir });
+  assert.equal(result, join(tempDir, ".opencode", "opencode.jsonc"));
+});
+
+test("resolveConfigPath local - falls through to .opencode/opencode.json", () => {
+  const tempDir = createTempDir();
+  mkdirSync(join(tempDir, ".opencode"));
+  writeFileSync(join(tempDir, ".opencode", "opencode.json"), "{}");
+
+  const resolver = agents.opencode.resolveConfigPath!;
+  const result = resolver(agents.opencode, { local: true, cwd: tempDir });
+  assert.equal(result, join(tempDir, ".opencode", "opencode.json"));
+});
+
+test("resolveConfigPath local - defaults to opencode.jsonc when nothing exists", () => {
+  const tempDir = createTempDir();
+
+  const resolver = agents.opencode.resolveConfigPath!;
+  const result = resolver(agents.opencode, { local: true, cwd: tempDir });
+  assert.equal(result, join(tempDir, "opencode.jsonc"));
+});
+
+test("resolveConfigPath global - prefers existing opencode.jsonc over .json", () => {
+  const resolver = agents.opencode.resolveConfigPath!;
+  const result = resolver(agents.opencode, { local: false, cwd: "" });
+  assert.equal(
+    result,
+    join(
+      process.env.HOME || "/home/user",
+      ".config",
+      "opencode",
+      "opencode.jsonc",
+    ),
+  );
+});
+
 test("detectProjectAgents - detects .gemini directory", () => {
   const tempDir = createTempDir();
   mkdirSync(join(tempDir, ".gemini"));

--- a/tests/e2e/install.test.ts
+++ b/tests/e2e/install.test.ts
@@ -10,7 +10,13 @@
  */
 
 import assert from "node:assert";
-import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import {
+  mkdtempSync,
+  rmSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import yaml from "js-yaml";
@@ -224,7 +230,7 @@ test("E2E: Install to GitHub Copilot CLI (local) writes VS Code schema", () => {
   assert.ok(servers.company);
 });
 
-test("E2E: Install to OpenCode (local) - transformed format", () => {
+test("E2E: Install to OpenCode (local) - transformed format (jsonc default)", () => {
   const tempDir = createTempDir();
   const parsed = parseSource("https://mcp.openai.com/api");
   const config = buildServerConfig(parsed);
@@ -236,7 +242,7 @@ test("E2E: Install to OpenCode (local) - transformed format", () => {
 
   assert.strictEqual(result.success, true);
 
-  const configPath = join(tempDir, "opencode.json");
+  const configPath = join(tempDir, "opencode.jsonc");
   const savedConfig = readJsonConfig(configPath);
   const mcp = savedConfig.mcp as Record<string, unknown>;
 
@@ -259,7 +265,7 @@ test("E2E: Install local server to OpenCode - transformed format", () => {
 
   assert.strictEqual(result.success, true);
 
-  const configPath = join(tempDir, "opencode.json");
+  const configPath = join(tempDir, "opencode.jsonc");
   const savedConfig = readJsonConfig(configPath);
   const mcp = savedConfig.mcp as Record<string, unknown>;
 
@@ -290,7 +296,7 @@ test("E2E: Install local server to OpenCode maps env to environment", () => {
 
   assert.strictEqual(result.success, true);
 
-  const configPath = join(tempDir, "opencode.json");
+  const configPath = join(tempDir, "opencode.jsonc");
   const savedConfig = readJsonConfig(configPath);
   const mcp = savedConfig.mcp as Record<string, unknown>;
 
@@ -299,6 +305,81 @@ test("E2E: Install local server to OpenCode maps env to environment", () => {
     API_KEY: "secret",
     DATABASE_URL: "postgres://localhost/test",
   });
+});
+
+test("E2E: Install to OpenCode - prefers existing opencode.json over new .jsonc", () => {
+  const tempDir = createTempDir();
+  writeFileSync(join(tempDir, "opencode.json"), "{}");
+
+  const parsed = parseSource("mcp-server-postgres");
+  const config = buildServerConfig(parsed);
+
+  const result = installServerForAgent("postgres", config, "opencode", {
+    local: true,
+    cwd: tempDir,
+  });
+
+  assert.strictEqual(result.success, true);
+  assert.strictEqual(existsSync(join(tempDir, "opencode.jsonc")), false);
+
+  const savedConfig = readJsonConfig(join(tempDir, "opencode.json"));
+  const mcp = savedConfig.mcp as Record<string, unknown>;
+  assert.strictEqual((mcp.postgres as Record<string, unknown>).type, "local");
+});
+
+test("E2E: Install to OpenCode - prefers existing opencode.jsonc over .json", () => {
+  const tempDir = createTempDir();
+  writeFileSync(join(tempDir, "opencode.jsonc"), "{}");
+
+  const parsed = parseSource("mcp-server-postgres");
+  const config = buildServerConfig(parsed);
+
+  const result = installServerForAgent("postgres", config, "opencode", {
+    local: true,
+    cwd: tempDir,
+  });
+
+  assert.strictEqual(result.success, true);
+  assert.strictEqual(existsSync(join(tempDir, "opencode.json")), false);
+
+  const savedConfig = readJsonConfig(join(tempDir, "opencode.jsonc"));
+  const mcp = savedConfig.mcp as Record<string, unknown>;
+  assert.strictEqual((mcp.postgres as Record<string, unknown>).type, "local");
+});
+
+test("E2E: Install to OpenCode - preserves existing config structure (jsonc)", () => {
+  const tempDir = createTempDir();
+  writeFileSync(
+    join(tempDir, "opencode.jsonc"),
+    `{
+  // my tools
+  "mcp": {
+    "existing-server": {
+      "type": "local",
+      "command": ["node", "server.js"],
+      "enabled": false
+    }
+  }
+}`,
+  );
+
+  const parsed = parseSource("mcp-server-postgres");
+  const config = buildServerConfig(parsed);
+
+  const result = installServerForAgent("postgres", config, "opencode", {
+    local: true,
+    cwd: tempDir,
+  });
+
+  assert.strictEqual(result.success, true);
+
+  const raw = readFileSync(join(tempDir, "opencode.jsonc"), "utf-8");
+  assert.ok(raw.includes("// my tools"), "comment should be preserved");
+  assert.ok(
+    raw.includes('"existing-server"'),
+    "existing server should be preserved",
+  );
+  assert.ok(raw.includes('"postgres"'), "new server should be added");
 });
 
 test("E2E: Install to Gemini CLI (local)", () => {


### PR DESCRIPTION
This PR improves three things when resolving for OpenCode:
1. detect `opencode.jsonc` over `opencode.json`
2. if config is not found, create `opencode.jsonc` instead of `json` as that's the preferred format by OpenCode and ranks higher in the parsing order.
3. for local/project installation, check if `./opencode` exists, after verifying that `opencode.json/jsonc` config at root is missing.



fixes #95 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting and using OpenCode JSONC configuration files.
  * Configuration resolution now checks local and global locations, preferring existing JSONC or JSON files.
  * Existing comments and settings are preserved when updating JSONC configurations.

* **Bug Fixes**
  * Improved fallback behavior when preferred configuration paths are unavailable.

* **Tests**
  * Added coverage for project detection, path preference, fallback resolution, and JSONC updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->