### PR TITLE
feat: add Kilo Code, Kimi Code, and Kiro CLI support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.1.0] - 2026-08-12
+
+- add `kilo-code` support with project installs to `kilo.json` and global installs to `~/.config/kilo/kilo.json`, using Kilo Code's `mcp` config key, `local`/`remote` server types, and per-server `timeout`. Existing `.kilo/kilo.json`, `.kilocode/kilo.json`, and `kilo.jsonc` files are reused instead of creating a second config; aliases: `kilo`, `kilocode`.
+- add `kiro-cli` support with project installs to `.kiro/settings/mcp.json` and global installs to `~/.kiro/settings/mcp.json` (the same files the Kiro IDE reads), covering stdio and remote servers plus a native millisecond `timeout`; alias: `kiro`. Co-authored with @donatoaz ([#36](https://github.com/neon-solutions/add-mcp/pull/36))
+- add `kimi-code` support with project installs to `.kimi-code/mcp.json` and global installs to `$KIMI_CODE_HOME/mcp.json` (default `~/.kimi-code/mcp.json`), using Kimi Code's `mcpServers` key, explicit `transport` field, and `toolTimeoutMs`; alias: `kimi`.
+- fix `list`, `find`, `remove`, and `sync` for OpenCode-style servers that store the command and its arguments as a single array, which previously read as an empty entry and could not be matched or synced to other agents.
+
 ## [2.0.0] - 2026-07-22
 
 - **BREAKING:** re-installing a server under an existing name now replaces that server's entire entry instead of deep-merging the new fields into the old entry. Callers that relied on omitted fields surviving a re-install must now pass the complete desired server configuration. This prevents stale fields from producing invalid hybrid configs — most damaging when an old stdio entry (`command`/`args`/`env`) was combined with a new remote install (`type`/`url`). Applies to the TOML, JSON, and YAML writers; unrelated servers and all other config sections are still preserved ([#83](https://github.com/neon-solutions/add-mcp/pull/83))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [2.1.0] - 2026-08-12
 
-- add `kilo-code` support with project installs to `kilo.json` and global installs to `~/.config/kilo/kilo.json`, using Kilo Code's `mcp` config key, `local`/`remote` server types, and per-server `timeout`. Existing `.kilo/kilo.json`, `.kilocode/kilo.json`, and `kilo.jsonc` files are reused instead of creating a second config; aliases: `kilo`, `kilocode`.
+- add `kilo-code` support with project installs to `kilo.json` and global installs to `~/.config/kilo/kilo.json`, using Kilo Code's `mcp` config key, `local`/`remote` server types, and per-server `timeout`. Existing `.kilo/`, `.kilocode/`, and root `kilo.jsonc` configs are reused instead of creating a second config; aliases: `kilo`, `kilocode`.
 - add `kiro-cli` support with project installs to `.kiro/settings/mcp.json` and global installs to `~/.kiro/settings/mcp.json` (the same files the Kiro IDE reads), covering stdio and remote servers plus a native millisecond `timeout`; alias: `kiro`. Co-authored with @donatoaz ([#36](https://github.com/neon-solutions/add-mcp/pull/36))
 - add `kimi-code` support with project installs to `.kimi-code/mcp.json` and global installs to `$KIMI_CODE_HOME/mcp.json` (default `~/.kimi-code/mcp.json`), using Kimi Code's `mcpServers` key, explicit `transport` field, and `toolTimeoutMs`; alias: `kimi`.
 - fix `list`, `find`, `remove`, and `sync` for OpenCode-style servers that store the command and its arguments as a single array, which previously read as an empty entry and could not be matched or synced to other agents.

--- a/README.md
+++ b/README.md
@@ -50,27 +50,27 @@ The first `find`/`search` run automatically saves the add-mcp registry to `~/.co
 
 MCP servers can be installed to any of these agents:
 
-| Agent                  | `--agent`            | Project Path              | Global Path                                                                                                     |
-| ---------------------- | -------------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| Antigravity            | `antigravity`        | -                         | `~/.gemini/config/mcp_config.json` (shared by Antigravity, Antigravity IDE, and Antigravity CLI)                |
-| Cline VSCode Extension | `cline`              | -                         | `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` |
-| Cline CLI              | `cline-cli`          | -                         | `~/.cline/data/settings/cline_mcp_settings.json`                                                                |
-| Claude Code            | `claude-code`        | `.mcp.json`               | `~/.claude.json`                                                                                                |
-| Claude Desktop         | `claude-desktop`     | -                         | `~/Library/Application Support/Claude/claude_desktop_config.json`                                               |
-| Codex                  | `codex`              | `.codex/config.toml`      | `~/.codex/config.toml`                                                                                          |
-| Cursor                 | `cursor`             | `.cursor/mcp.json`        | `~/.cursor/mcp.json`                                                                                            |
-| Gemini CLI             | `gemini-cli`         | `.gemini/settings.json`   | `~/.gemini/settings.json`                                                                                       |
-| Goose                  | `goose`              | `.goose/config.yaml`      | `~/.config/goose/config.yaml`                                                                                   |
-| GitHub Copilot CLI     | `github-copilot-cli` | `.vscode/mcp.json`        | `~/.copilot/mcp-config.json`                                                                                    |
-| Grok Build             | `grok-build`         | `.grok/config.toml`       | `$GROK_HOME/config.toml` (defaults to `~/.grok/config.toml`)                                                    |
-| Kilo Code              | `kilo-code`          | `kilo.json`               | `~/.config/kilo/kilo.json` (existing `.kilo/kilo.json` or `kilo.jsonc` files are reused)                        |
-| Kimi Code              | `kimi-code`          | `.kimi-code/mcp.json`     | `$KIMI_CODE_HOME/mcp.json` (defaults to `~/.kimi-code/mcp.json`)                                                |
-| Kiro CLI               | `kiro-cli`           | `.kiro/settings/mcp.json` | `~/.kiro/settings/mcp.json` (shared with the Kiro IDE)                                                          |
-| MCPorter               | `mcporter`           | `config/mcporter.json`    | `~/.mcporter/mcporter.json` (or existing `~/.mcporter/mcporter.jsonc`)                                          |
-| OpenCode               | `opencode`           | `opencode.json`           | `~/.config/opencode/opencode.json`                                                                              |
-| VS Code                | `vscode`             | `.vscode/mcp.json`        | `~/Library/Application Support/Code/User/mcp.json`                                                              |
-| Windsurf               | `windsurf`           | -                         | `~/.codeium/windsurf/mcp_config.json`                                                                           |
-| Zed                    | `zed`                | `.zed/settings.json`      | `~/Library/Application Support/Zed/settings.json`                                                               |
+| Agent                  | `--agent`            | Project Path                                                                  | Global Path                                                                                                     |
+| ---------------------- | -------------------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Antigravity            | `antigravity`        | -                                                                             | `~/.gemini/config/mcp_config.json` (shared by Antigravity, Antigravity IDE, and Antigravity CLI)                |
+| Cline VSCode Extension | `cline`              | -                                                                             | `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` |
+| Cline CLI              | `cline-cli`          | -                                                                             | `~/.cline/data/settings/cline_mcp_settings.json`                                                                |
+| Claude Code            | `claude-code`        | `.mcp.json`                                                                   | `~/.claude.json`                                                                                                |
+| Claude Desktop         | `claude-desktop`     | -                                                                             | `~/Library/Application Support/Claude/claude_desktop_config.json`                                               |
+| Codex                  | `codex`              | `.codex/config.toml`                                                          | `~/.codex/config.toml`                                                                                          |
+| Cursor                 | `cursor`             | `.cursor/mcp.json`                                                            | `~/.cursor/mcp.json`                                                                                            |
+| Gemini CLI             | `gemini-cli`         | `.gemini/settings.json`                                                       | `~/.gemini/settings.json`                                                                                       |
+| Goose                  | `goose`              | `.goose/config.yaml`                                                          | `~/.config/goose/config.yaml`                                                                                   |
+| GitHub Copilot CLI     | `github-copilot-cli` | `.vscode/mcp.json`                                                            | `~/.copilot/mcp-config.json`                                                                                    |
+| Grok Build             | `grok-build`         | `.grok/config.toml`                                                           | `$GROK_HOME/config.toml` (defaults to `~/.grok/config.toml`)                                                    |
+| Kilo Code              | `kilo-code`          | `kilo.json` (or existing `.kilo/`, `.kilocode/`, or root `kilo.jsonc` config) | `~/.config/kilo/kilo.json` (or existing `~/.config/kilo/kilo.jsonc`)                                            |
+| Kimi Code              | `kimi-code`          | `.kimi-code/mcp.json`                                                         | `$KIMI_CODE_HOME/mcp.json` (defaults to `~/.kimi-code/mcp.json`)                                                |
+| Kiro CLI               | `kiro-cli`           | `.kiro/settings/mcp.json`                                                     | `~/.kiro/settings/mcp.json` (shared with the Kiro IDE)                                                          |
+| MCPorter               | `mcporter`           | `config/mcporter.json`                                                        | `~/.mcporter/mcporter.json` (or existing `~/.mcporter/mcporter.jsonc`)                                          |
+| OpenCode               | `opencode`           | `opencode.json`                                                               | `~/.config/opencode/opencode.json`                                                                              |
+| VS Code                | `vscode`             | `.vscode/mcp.json`                                                            | `~/Library/Application Support/Code/User/mcp.json`                                                              |
+| Windsurf               | `windsurf`           | -                                                                             | `~/.codeium/windsurf/mcp_config.json`                                                                           |
+| Zed                    | `zed`                | `.zed/settings.json`                                                          | `~/Library/Application Support/Zed/settings.json`                                                               |
 
 **Aliases:** `codeium`, `cascade` → `windsurf`, `cline-vscode` → `cline`, `gemini` → `gemini-cli`, `github-copilot` → `vscode`, `grok` → `grok-build`, `kilo`, `kilocode` → `kilo-code`, `kimi` → `kimi-code`, `kiro` → `kiro-cli`
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Add MCP servers to your favorite coding agents with a single command.
 
-Supports **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **VS Code**, **Grok Build** and [10 more](#supported-agents).
+Supports **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **VS Code**, **Grok Build** and [13 more](#supported-agents).
 
 Docs and registry: [add-mcp.com](https://add-mcp.com)
 
@@ -50,26 +50,31 @@ The first `find`/`search` run automatically saves the add-mcp registry to `~/.co
 
 MCP servers can be installed to any of these agents:
 
-| Agent                  | `--agent`            | Project Path            | Global Path                                                                                                     |
-| ---------------------- | -------------------- | ----------------------- | --------------------------------------------------------------------------------------------------------------- |
-| Antigravity            | `antigravity`        | -                       | `~/.gemini/config/mcp_config.json` (shared by Antigravity, Antigravity IDE, and Antigravity CLI)                |
-| Cline VSCode Extension | `cline`              | -                       | `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` |
-| Cline CLI              | `cline-cli`          | -                       | `~/.cline/data/settings/cline_mcp_settings.json`                                                                |
-| Claude Code            | `claude-code`        | `.mcp.json`             | `~/.claude.json`                                                                                                |
-| Claude Desktop         | `claude-desktop`     | -                       | `~/Library/Application Support/Claude/claude_desktop_config.json`                                               |
-| Codex                  | `codex`              | `.codex/config.toml`    | `~/.codex/config.toml`                                                                                          |
-| Cursor                 | `cursor`             | `.cursor/mcp.json`      | `~/.cursor/mcp.json`                                                                                            |
-| Gemini CLI             | `gemini-cli`         | `.gemini/settings.json` | `~/.gemini/settings.json`                                                                                       |
-| Goose                  | `goose`              | `.goose/config.yaml`    | `~/.config/goose/config.yaml`                                                                                   |
-| GitHub Copilot CLI     | `github-copilot-cli` | `.vscode/mcp.json`      | `~/.copilot/mcp-config.json`                                                                                    |
-| Grok Build             | `grok-build`         | `.grok/config.toml`     | `$GROK_HOME/config.toml` (defaults to `~/.grok/config.toml`)                                                    |
-| MCPorter               | `mcporter`           | `config/mcporter.json`  | `~/.mcporter/mcporter.json` (or existing `~/.mcporter/mcporter.jsonc`)                                          |
-| OpenCode               | `opencode`           | `opencode.json`         | `~/.config/opencode/opencode.json`                                                                              |
-| VS Code                | `vscode`             | `.vscode/mcp.json`      | `~/Library/Application Support/Code/User/mcp.json`                                                              |
-| Windsurf               | `windsurf`           | -                       | `~/.codeium/windsurf/mcp_config.json`                                                                           |
-| Zed                    | `zed`                | `.zed/settings.json`    | `~/Library/Application Support/Zed/settings.json`                                                               |
+| Agent                  | `--agent`            | Project Path              | Global Path                                                                                                     |
+| ---------------------- | -------------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Antigravity            | `antigravity`        | -                         | `~/.gemini/config/mcp_config.json` (shared by Antigravity, Antigravity IDE, and Antigravity CLI)                |
+| Cline VSCode Extension | `cline`              | -                         | `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` |
+| Cline CLI              | `cline-cli`          | -                         | `~/.cline/data/settings/cline_mcp_settings.json`                                                                |
+| Claude Code            | `claude-code`        | `.mcp.json`               | `~/.claude.json`                                                                                                |
+| Claude Desktop         | `claude-desktop`     | -                         | `~/Library/Application Support/Claude/claude_desktop_config.json`                                               |
+| Codex                  | `codex`              | `.codex/config.toml`      | `~/.codex/config.toml`                                                                                          |
+| Cursor                 | `cursor`             | `.cursor/mcp.json`        | `~/.cursor/mcp.json`                                                                                            |
+| Gemini CLI             | `gemini-cli`         | `.gemini/settings.json`   | `~/.gemini/settings.json`                                                                                       |
+| Goose                  | `goose`              | `.goose/config.yaml`      | `~/.config/goose/config.yaml`                                                                                   |
+| GitHub Copilot CLI     | `github-copilot-cli` | `.vscode/mcp.json`        | `~/.copilot/mcp-config.json`                                                                                    |
+| Grok Build             | `grok-build`         | `.grok/config.toml`       | `$GROK_HOME/config.toml` (defaults to `~/.grok/config.toml`)                                                    |
+| Kilo Code              | `kilo-code`          | `kilo.json`               | `~/.config/kilo/kilo.json` (existing `.kilo/kilo.json` or `kilo.jsonc` files are reused)                        |
+| Kimi Code              | `kimi-code`          | `.kimi-code/mcp.json`     | `$KIMI_CODE_HOME/mcp.json` (defaults to `~/.kimi-code/mcp.json`)                                                |
+| Kiro CLI               | `kiro-cli`           | `.kiro/settings/mcp.json` | `~/.kiro/settings/mcp.json` (shared with the Kiro IDE)                                                          |
+| MCPorter               | `mcporter`           | `config/mcporter.json`    | `~/.mcporter/mcporter.json` (or existing `~/.mcporter/mcporter.jsonc`)                                          |
+| OpenCode               | `opencode`           | `opencode.json`           | `~/.config/opencode/opencode.json`                                                                              |
+| VS Code                | `vscode`             | `.vscode/mcp.json`        | `~/Library/Application Support/Code/User/mcp.json`                                                              |
+| Windsurf               | `windsurf`           | -                         | `~/.codeium/windsurf/mcp_config.json`                                                                           |
+| Zed                    | `zed`                | `.zed/settings.json`      | `~/Library/Application Support/Zed/settings.json`                                                               |
 
-**Aliases:** `codeium`, `cascade` → `windsurf`, `cline-vscode` → `cline`, `gemini` → `gemini-cli`, `github-copilot` → `vscode`, `grok` → `grok-build`
+**Aliases:** `codeium`, `cascade` → `windsurf`, `cline-vscode` → `cline`, `gemini` → `gemini-cli`, `github-copilot` → `vscode`, `grok` → `grok-build`, `kilo`, `kilocode` → `kilo-code`, `kimi` → `kimi-code`, `kiro` → `kiro-cli`
+
+Kimi Code only loads a project-level `.kimi-code/mcp.json` after you trust the folder in the CLI, so a project install may not take effect until then.
 
 ## Installation Scope
 
@@ -197,11 +202,11 @@ Not every MCP client understands every field. `add-mcp` keeps one canonical
 server config and each agent declares which optional fields it supports, mapping
 them into that client's native shape:
 
-| Field              | Flag                                | Supported by            | Mapped to                                                |
-| ------------------ | ----------------------------------- | ----------------------- | -------------------------------------------------------- |
-| Timeout            | `--timeout`                         | Claude Code, Gemini CLI | `timeout` (milliseconds)                                 |
-| OAuth scopes       | `--scopes`                          | Cursor, Gemini CLI      | Cursor `auth.scopes`, Gemini `oauth.scopes`              |
-| Tool auto-approval | `--auto-approve` / `--approve-tool` | Codex, Claude Code      | Codex approval modes; Claude Code permission allow rules |
+| Field              | Flag                                | Supported by                                                        | Mapped to                                                                                    |
+| ------------------ | ----------------------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Timeout            | `--timeout`                         | Claude Code, Gemini CLI, Grok Build, Kilo Code, Kimi Code, Kiro CLI | `timeout` (milliseconds); Grok Build `tool_timeout_sec` (seconds), Kimi Code `toolTimeoutMs` |
+| OAuth scopes       | `--scopes`                          | Cursor, Gemini CLI                                                  | Cursor `auth.scopes`, Gemini `oauth.scopes`                                                  |
+| Tool auto-approval | `--auto-approve` / `--approve-tool` | Codex, Claude Code                                                  | Codex approval modes; Claude Code permission allow rules                                     |
 
 When you target an agent that does not support a field, `add-mcp` drops it from
 that agent's config and prints a warning (e.g. _"request timeout is not

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-mcp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Add MCP servers to your favorite coding agents with a single command.",
   "author": "Andre Landgraf <andre@neon.tech>",
   "license": "Apache-2.0",
@@ -51,6 +51,10 @@
     "goose",
     "grok",
     "grok-build",
+    "kilo-code",
+    "kimi-code",
+    "kiro",
+    "kiro-cli",
     "mcporter",
     "opencode",
     "vscode",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -798,7 +798,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     displayName: "Kilo Code",
     configPath: join(getKiloConfigDir(), "kilo.json"),
     localConfigPath: "kilo.json",
-    projectDetectPaths: [".kilo", ".kilocode", "kilo.json"],
+    projectDetectPaths: [".kilo", ".kilocode", "kilo.json", "kilo.jsonc"],
     configKey: "mcp",
     format: "json",
     supportedTransports: ["stdio", "http", "sse"],

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -12,6 +12,18 @@ function getGrokHome(): string {
   return process.env.GROK_HOME || defaultGrokHome;
 }
 
+function getKimiCodeHome(): string {
+  return process.env.KIMI_CODE_HOME || join(home, ".kimi-code");
+}
+
+/**
+ * Kilo Code resolves its global config through xdg-basedir on every platform,
+ * so Windows uses `~/.config/kilo` rather than `%APPDATA%`.
+ */
+function getKiloConfigDir(): string {
+  return join(process.env.XDG_CONFIG_HOME || join(home, ".config"), "kilo");
+}
+
 function shortenPath(fullPath: string): string {
   if (fullPath.startsWith(home)) {
     return fullPath.replace(home, "~");
@@ -69,6 +81,17 @@ const clineExtensionConfigPath = join(
 const copilotConfigPath = join(
   process.env.XDG_CONFIG_HOME || join(home, ".copilot"),
   "mcp-config.json",
+);
+/**
+ * Kilo Code's VS Code extension storage, used for detection only. The
+ * `mcp_settings.json` it contains is a legacy location the extension still
+ * reads, but new servers belong in the modern `kilo.json`, which the extension
+ * and the standalone CLI share.
+ */
+const kiloVscodeStoragePath = join(
+  vscodePath,
+  "globalStorage",
+  "kilocode.kilo-code",
 );
 const windsurfConfigPath = join(
   home,
@@ -188,10 +211,15 @@ function transformZedConfig(
   };
 }
 
+/**
+ * OpenCode's shape: a `local`/`remote` discriminator, the command and its args
+ * as a single array, and env under `environment`. Shared with Kilo Code, which
+ * forked OpenCode's config schema.
+ */
 function transformOpenCodeConfig(
   _serverName: string,
   config: McpServerConfig,
-): unknown {
+): Record<string, unknown> {
   if (config.url) {
     return {
       type: "remote",
@@ -207,6 +235,80 @@ function transformOpenCodeConfig(
     enabled: true,
     environment: config.env || {},
   };
+}
+
+/**
+ * Kilo Code matches OpenCode's schema and additionally accepts a per-server
+ * request `timeout` in milliseconds.
+ * See https://kilocode.ai/docs/features/mcp/using-mcp-in-kilo-code.
+ */
+function transformKiloCodeConfig(
+  serverName: string,
+  config: McpServerConfig,
+): unknown {
+  const entry = transformOpenCodeConfig(serverName, config);
+
+  if (typeof config.timeout === "number") {
+    entry.timeout = config.timeout;
+  }
+
+  return entry;
+}
+
+/** Largest value Kimi Code's MCP timeout schema accepts. */
+const KIMI_MAX_TIMEOUT_MS = 2_147_483_647;
+
+/**
+ * Kimi Code validates its MCP config as a whole and fails closed: one entry it
+ * rejects disables every MCP server, including servers defined elsewhere. Drop
+ * a timeout that falls outside the schema's bounds rather than risk that.
+ */
+function kimiToolTimeoutMs(timeout: number | undefined): number | undefined {
+  if (typeof timeout !== "number" || !Number.isInteger(timeout)) {
+    return undefined;
+  }
+  if (timeout < 1 || timeout > KIMI_MAX_TIMEOUT_MS) {
+    return undefined;
+  }
+  return timeout;
+}
+
+/**
+ * Kimi Code stores servers under `mcpServers` with an explicit `transport`
+ * discriminator and maps a request timeout to `toolTimeoutMs`.
+ * See https://www.kimi.com/code/docs/en/kimi-code-cli/customization/mcp.html.
+ */
+function transformKimiCodeConfig(
+  _serverName: string,
+  config: McpServerConfig,
+): unknown {
+  let entry: Record<string, unknown>;
+
+  if (config.url) {
+    entry = {
+      transport: config.type === "sse" ? "sse" : "http",
+      url: config.url,
+    };
+    if (config.headers && Object.keys(config.headers).length > 0) {
+      entry.headers = config.headers;
+    }
+  } else {
+    entry = {
+      transport: "stdio",
+      command: config.command,
+      args: config.args || [],
+    };
+    if (config.env && Object.keys(config.env).length > 0) {
+      entry.env = config.env;
+    }
+  }
+
+  const toolTimeoutMs = kimiToolTimeoutMs(config.timeout);
+  if (toolTimeoutMs !== undefined) {
+    entry.toolTimeoutMs = toolTimeoutMs;
+  }
+
+  return entry;
 }
 
 /**
@@ -287,6 +389,36 @@ function transformGrokBuildConfig(
   }
 
   return buildStandardLocal(config);
+}
+
+/**
+ * Kiro infers a server's transport from which fields are present — `command`
+ * for stdio, `url` for remote (streamable HTTP with an SSE fallback) — and
+ * ignores `type` entirely, so no transport field is emitted. Its own
+ * `kiro-cli mcp add` writes the same shape. `timeout` is in milliseconds.
+ * See https://kiro.dev/docs/mcp/configuration.
+ */
+function transformKiroCliConfig(
+  _serverName: string,
+  config: McpServerConfig,
+): unknown {
+  if (!config.url) {
+    return buildStandardLocal(config);
+  }
+
+  const remoteConfig: Record<string, unknown> = {
+    url: config.url,
+  };
+
+  if (config.headers && Object.keys(config.headers).length > 0) {
+    remoteConfig.headers = config.headers;
+  }
+
+  if (typeof config.timeout === "number") {
+    remoteConfig.timeout = config.timeout;
+  }
+
+  return remoteConfig;
 }
 
 function transformCursorConfig(
@@ -438,6 +570,48 @@ function resolveGrokBuildConfigPath(
   }
 
   return join(getGrokHome(), "config.toml");
+}
+
+function resolveKimiCodeConfigPath(
+  agent: AgentConfig,
+  options: { local: boolean; cwd: string },
+): string {
+  if (options.local && agent.localConfigPath) {
+    return join(options.cwd, agent.localConfigPath);
+  }
+
+  return join(getKimiCodeHome(), "mcp.json");
+}
+
+/**
+ * Kilo Code reads its config from several candidate filenames, preferring
+ * `.kilo/` over the legacy `.kilocode/` and the project root last. Write to the
+ * first candidate that already exists so an existing config keeps winning,
+ * matching how `kilo mcp add` picks its target.
+ */
+function resolveKiloCodeConfigPath(
+  _agent: AgentConfig,
+  options: { local: boolean; cwd: string },
+): string {
+  const baseDir = options.local ? options.cwd : getKiloConfigDir();
+  const candidates = options.local
+    ? [
+        join(".kilo", "kilo.jsonc"),
+        join(".kilo", "kilo.json"),
+        join(".kilocode", "kilo.jsonc"),
+        join(".kilocode", "kilo.json"),
+        "kilo.jsonc",
+      ]
+    : ["kilo.jsonc"];
+
+  for (const candidate of candidates) {
+    const candidatePath = join(baseDir, candidate);
+    if (existsSync(candidatePath)) {
+      return candidatePath;
+    }
+  }
+
+  return join(baseDir, "kilo.json");
 }
 
 export const agents: Record<AgentType, AgentConfig> = {
@@ -617,6 +791,59 @@ export const agents: Record<AgentType, AgentConfig> = {
     },
     resolveConfigPath: resolveGrokBuildConfigPath,
     transformConfig: transformGrokBuildConfig,
+  },
+
+  "kilo-code": {
+    name: "kilo-code",
+    displayName: "Kilo Code",
+    configPath: join(getKiloConfigDir(), "kilo.json"),
+    localConfigPath: "kilo.json",
+    projectDetectPaths: [".kilo", ".kilocode", "kilo.json"],
+    configKey: "mcp",
+    format: "json",
+    supportedTransports: ["stdio", "http", "sse"],
+    supportedFields: ["timeout"],
+    detectGlobalInstall: async () => {
+      return (
+        existsSync(getKiloConfigDir()) || existsSync(kiloVscodeStoragePath)
+      );
+    },
+    resolveConfigPath: resolveKiloCodeConfigPath,
+    transformConfig: transformKiloCodeConfig,
+  },
+
+  "kimi-code": {
+    name: "kimi-code",
+    displayName: "Kimi Code",
+    configPath: join(getKimiCodeHome(), "mcp.json"),
+    localConfigPath: ".kimi-code/mcp.json",
+    projectDetectPaths: [".kimi-code"],
+    configKey: "mcpServers",
+    format: "json",
+    supportedTransports: ["stdio", "http", "sse"],
+    supportedFields: ["timeout"],
+    detectGlobalInstall: async () => {
+      return existsSync(getKimiCodeHome());
+    },
+    resolveConfigPath: resolveKimiCodeConfigPath,
+    transformConfig: transformKimiCodeConfig,
+  },
+
+  "kiro-cli": {
+    name: "kiro-cli",
+    displayName: "Kiro CLI",
+    // Shared with the Kiro IDE, which reads the same two files.
+    configPath: join(home, ".kiro", "settings", "mcp.json"),
+    localConfigPath: ".kiro/settings/mcp.json",
+    projectDetectPaths: [".kiro"],
+    configKey: "mcpServers",
+    format: "json",
+    supportedTransports: ["stdio", "http", "sse"],
+    supportedFields: ["timeout"],
+    detectGlobalInstall: async () => {
+      return existsSync(join(home, ".kiro"));
+    },
+    transformConfig: transformKiroCliConfig,
   },
 
   mcporter: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ import {
   listInstalledServers,
   findMatchingServers,
   extractServerIdentity,
+  normalizeStoredCommand,
   type AgentServers,
   type InstalledServer,
 } from "./reader.js";
@@ -1181,22 +1182,7 @@ function buildServerConfigFromStored(
     return result;
   }
 
-  // OpenCode-style clients (OpenCode, Kilo Code) store the command and its
-  // arguments as one array.
-  const commandParts = Array.isArray(config.command)
-    ? config.command.filter((a): a is string => typeof a === "string")
-    : undefined;
-
-  const command =
-    typeof config.command === "string"
-      ? config.command
-      : typeof config.cmd === "string"
-        ? config.cmd
-        : commandParts?.[0];
-
-  const args = Array.isArray(config.args)
-    ? config.args.filter((a): a is string => typeof a === "string")
-    : (commandParts?.slice(1) ?? []);
+  const { command, args } = normalizeStoredCommand(config);
 
   const env =
     config.env && typeof config.env === "object"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1161,7 +1161,9 @@ function buildServerConfigFromStored(
 
   if (url) {
     const result: import("./types.js").McpServerConfig = {
-      type: httpUrl ? "http" : normalizeTransportType(config.type),
+      type: httpUrl
+        ? "http"
+        : normalizeTransportType(config.type ?? config.transport),
       url,
     };
 
@@ -1179,16 +1181,22 @@ function buildServerConfigFromStored(
     return result;
   }
 
+  // OpenCode-style clients (OpenCode, Kilo Code) store the command and its
+  // arguments as one array.
+  const commandParts = Array.isArray(config.command)
+    ? config.command.filter((a): a is string => typeof a === "string")
+    : undefined;
+
   const command =
     typeof config.command === "string"
       ? config.command
       : typeof config.cmd === "string"
         ? config.cmd
-        : undefined;
+        : commandParts?.[0];
 
   const args = Array.isArray(config.args)
     ? config.args.filter((a): a is string => typeof a === "string")
-    : [];
+    : (commandParts?.slice(1) ?? []);
 
   const env =
     config.env && typeof config.env === "object"

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -26,6 +26,33 @@ export interface AgentServers {
 }
 
 /**
+ * Normalize a stored stdio entry into its command and arguments. OpenCode-style
+ * clients (OpenCode, Kilo Code) store the command and its arguments as a single
+ * array, so the first element is the command and the rest are the arguments.
+ */
+export function normalizeStoredCommand(serverConfig: Record<string, unknown>): {
+  command: string | undefined;
+  args: string[];
+} {
+  const commandParts = Array.isArray(serverConfig.command)
+    ? serverConfig.command.filter((a): a is string => typeof a === "string")
+    : undefined;
+
+  const command =
+    typeof serverConfig.command === "string"
+      ? serverConfig.command
+      : typeof serverConfig.cmd === "string"
+        ? serverConfig.cmd
+        : commandParts?.[0];
+
+  const args = Array.isArray(serverConfig.args)
+    ? serverConfig.args.filter((a): a is string => typeof a === "string")
+    : (commandParts?.slice(1) ?? []);
+
+  return { command, args };
+}
+
+/**
  * Extract a server's identity (URL or package name) from any agent-specific
  * config shape. Returns the URL for remote servers or the package/command
  * string for stdio servers.
@@ -41,26 +68,11 @@ export function extractServerIdentity(
     }
   }
 
-  // Stdio: reconstruct from command/cmd + args. OpenCode-style clients
-  // (OpenCode, Kilo Code) store the command and its arguments as one array.
-  const commandParts = Array.isArray(serverConfig.command)
-    ? serverConfig.command.filter((a): a is string => typeof a === "string")
-    : undefined;
-
-  const command =
-    typeof serverConfig.command === "string"
-      ? serverConfig.command
-      : typeof serverConfig.cmd === "string"
-        ? serverConfig.cmd
-        : commandParts?.[0];
+  const { command, args: rawArgs } = normalizeStoredCommand(serverConfig);
 
   if (!command) {
     return "";
   }
-
-  const rawArgs = Array.isArray(serverConfig.args)
-    ? serverConfig.args.filter((a): a is string => typeof a === "string")
-    : (commandParts?.slice(1) ?? []);
 
   // Detect npx -y <package> pattern
   if (command === "npx" || command === "bunx") {

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -41,13 +41,18 @@ export function extractServerIdentity(
     }
   }
 
-  // Stdio: reconstruct from command/cmd + args
+  // Stdio: reconstruct from command/cmd + args. OpenCode-style clients
+  // (OpenCode, Kilo Code) store the command and its arguments as one array.
+  const commandParts = Array.isArray(serverConfig.command)
+    ? serverConfig.command.filter((a): a is string => typeof a === "string")
+    : undefined;
+
   const command =
     typeof serverConfig.command === "string"
       ? serverConfig.command
       : typeof serverConfig.cmd === "string"
         ? serverConfig.cmd
-        : undefined;
+        : commandParts?.[0];
 
   if (!command) {
     return "";
@@ -55,11 +60,7 @@ export function extractServerIdentity(
 
   const rawArgs = Array.isArray(serverConfig.args)
     ? serverConfig.args.filter((a): a is string => typeof a === "string")
-    : Array.isArray(serverConfig.command)
-      ? (serverConfig.command as unknown[])
-          .slice(1)
-          .filter((a): a is string => typeof a === "string")
-      : [];
+    : (commandParts?.slice(1) ?? []);
 
   // Detect npx -y <package> pattern
   if (command === "npx" || command === "bunx") {
@@ -69,11 +70,6 @@ export function extractServerIdentity(
     if (pkg && !pkg.startsWith("-")) {
       return pkg;
     }
-  }
-
-  // OpenCode uses command as array: ["node", "server.js"]
-  if (Array.isArray(serverConfig.command)) {
-    return (serverConfig.command as string[]).join(" ");
   }
 
   if (rawArgs.length > 0) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,9 @@ export type AgentType =
   | "goose"
   | "github-copilot-cli"
   | "grok-build"
+  | "kilo-code"
+  | "kimi-code"
+  | "kiro-cli"
   | "mcporter"
   | "opencode"
   | "vscode"
@@ -25,6 +28,10 @@ export const agentAliases: Record<string, AgentType> = {
   gemini: "gemini-cli",
   "github-copilot": "vscode",
   grok: "grok-build",
+  kilo: "kilo-code",
+  kilocode: "kilo-code",
+  kimi: "kimi-code",
+  kiro: "kiro-cli",
 };
 
 export type ConfigFormat = "json" | "yaml" | "toml";

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -60,9 +60,9 @@ function cleanup() {
 // Agent Configuration Tests
 // ============================================
 
-test("getAgentTypes returns all 16 agents", () => {
+test("getAgentTypes returns all 19 agents", () => {
   const types = getAgentTypes();
-  assert.strictEqual(types.length, 16);
+  assert.strictEqual(types.length, 19);
   assert.ok(types.includes("antigravity"));
   assert.ok(types.includes("cline"));
   assert.ok(types.includes("cline-cli"));
@@ -74,6 +74,9 @@ test("getAgentTypes returns all 16 agents", () => {
   assert.ok(types.includes("goose"));
   assert.ok(types.includes("github-copilot-cli"));
   assert.ok(types.includes("grok-build"));
+  assert.ok(types.includes("kilo-code"));
+  assert.ok(types.includes("kimi-code"));
+  assert.ok(types.includes("kiro-cli"));
   assert.ok(types.includes("mcporter"));
   assert.ok(types.includes("opencode"));
   assert.ok(types.includes("vscode"));
@@ -135,6 +138,9 @@ test("supportedFields reflects per-client capabilities", () => {
   ]);
   assert.deepStrictEqual(agents.codex.supportedFields, ["autoApprove"]);
   assert.deepStrictEqual(agents["grok-build"].supportedFields, ["timeout"]);
+  assert.deepStrictEqual(agents["kilo-code"].supportedFields, ["timeout"]);
+  assert.deepStrictEqual(agents["kimi-code"].supportedFields, ["timeout"]);
+  assert.deepStrictEqual(agents["kiro-cli"].supportedFields, ["timeout"]);
   // Clients with no extra field support declare an empty list.
   assert.deepStrictEqual(agents.vscode.supportedFields, []);
   assert.deepStrictEqual(agents["claude-desktop"].supportedFields, []);
@@ -152,6 +158,9 @@ test("supportsProjectConfig - returns true for project-capable agents", () => {
   assert.strictEqual(supportsProjectConfig("gemini-cli"), true);
   assert.strictEqual(supportsProjectConfig("github-copilot-cli"), true);
   assert.strictEqual(supportsProjectConfig("grok-build"), true);
+  assert.strictEqual(supportsProjectConfig("kilo-code"), true);
+  assert.strictEqual(supportsProjectConfig("kimi-code"), true);
+  assert.strictEqual(supportsProjectConfig("kiro-cli"), true);
   assert.strictEqual(supportsProjectConfig("mcporter"), true);
   assert.strictEqual(supportsProjectConfig("codex"), true);
   assert.strictEqual(supportsProjectConfig("zed"), true);
@@ -166,9 +175,9 @@ test("supportsProjectConfig - returns false for global-only agents", () => {
   assert.strictEqual(supportsProjectConfig("windsurf"), false);
 });
 
-test("getProjectCapableAgents returns 10 agents", () => {
+test("getProjectCapableAgents returns 13 agents", () => {
   const projectAgents = getProjectCapableAgents();
-  assert.strictEqual(projectAgents.length, 10);
+  assert.strictEqual(projectAgents.length, 13);
   assert.ok(projectAgents.includes("claude-code"));
   assert.ok(projectAgents.includes("cursor"));
   assert.ok(projectAgents.includes("vscode"));
@@ -176,6 +185,9 @@ test("getProjectCapableAgents returns 10 agents", () => {
   assert.ok(projectAgents.includes("gemini-cli"));
   assert.ok(projectAgents.includes("github-copilot-cli"));
   assert.ok(projectAgents.includes("grok-build"));
+  assert.ok(projectAgents.includes("kilo-code"));
+  assert.ok(projectAgents.includes("kimi-code"));
+  assert.ok(projectAgents.includes("kiro-cli"));
   assert.ok(projectAgents.includes("mcporter"));
   assert.ok(projectAgents.includes("codex"));
   assert.ok(projectAgents.includes("zed"));
@@ -305,6 +317,40 @@ test("detectProjectAgents - detects .grok directory", () => {
   assert.ok(detected.includes("grok-build"));
 });
 
+test("detectProjectAgents - detects .kilo and .kilocode directories", () => {
+  const kiloDir = createTempDir();
+  mkdirSync(join(kiloDir, ".kilo"));
+  assert.ok(detectProjectAgents(kiloDir).includes("kilo-code"));
+
+  const legacyDir = createTempDir();
+  mkdirSync(join(legacyDir, ".kilocode"));
+  assert.ok(detectProjectAgents(legacyDir).includes("kilo-code"));
+});
+
+test("detectProjectAgents - detects kilo.json file", () => {
+  const tempDir = createTempDir();
+  writeFileSync(join(tempDir, "kilo.json"), "{}");
+
+  const detected = detectProjectAgents(tempDir);
+  assert.ok(detected.includes("kilo-code"));
+});
+
+test("detectProjectAgents - detects .kimi-code directory", () => {
+  const tempDir = createTempDir();
+  mkdirSync(join(tempDir, ".kimi-code"));
+
+  const detected = detectProjectAgents(tempDir);
+  assert.ok(detected.includes("kimi-code"));
+});
+
+test("detectProjectAgents - detects .kiro directory", () => {
+  const tempDir = createTempDir();
+  mkdirSync(join(tempDir, ".kiro"));
+
+  const detected = detectProjectAgents(tempDir);
+  assert.ok(detected.includes("kiro-cli"));
+});
+
 test("detectProjectAgents - detects .zed directory", () => {
   const tempDir = createTempDir();
   mkdirSync(join(tempDir, ".zed"));
@@ -378,6 +424,9 @@ test("isTransportSupported - most agents support http", () => {
     "github-copilot-cli",
     "goose",
     "grok-build",
+    "kilo-code",
+    "kimi-code",
+    "kiro-cli",
     "mcporter",
     "opencode",
     "vscode",
@@ -406,6 +455,9 @@ test("isTransportSupported - most agents support sse", () => {
     "github-copilot-cli",
     "goose",
     "grok-build",
+    "kilo-code",
+    "kimi-code",
+    "kiro-cli",
     "mcporter",
     "opencode",
     "vscode",

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -335,6 +335,16 @@ test("detectProjectAgents - detects kilo.json file", () => {
   assert.ok(detected.includes("kilo-code"));
 });
 
+// A project may carry only kilo.jsonc, which resolveKiloCodeConfigPath writes
+// to, so detection has to recognize it too.
+test("detectProjectAgents - detects kilo.jsonc file", () => {
+  const tempDir = createTempDir();
+  writeFileSync(join(tempDir, "kilo.jsonc"), "{}");
+
+  const detected = detectProjectAgents(tempDir);
+  assert.ok(detected.includes("kilo-code"));
+});
+
 test("detectProjectAgents - detects .kimi-code directory", () => {
   const tempDir = createTempDir();
   mkdirSync(join(tempDir, ".kimi-code"));

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -1636,6 +1636,154 @@ test("E2E CLI: Grok project install ignores GROK_HOME", () => {
   assert.strictEqual("type" in server, false);
 });
 
+test("E2E CLI: Kiro alias installs into .kiro/settings/mcp.json", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "https://mcp.example.com/mcp",
+      "-a",
+      "kiro",
+      "-y",
+      "--name",
+      "kiro-remote",
+      "--timeout",
+      "60000",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const configPath = join(projectDir, ".kiro", "settings", "mcp.json");
+  assert.strictEqual(existsSync(configPath), true);
+
+  const saved = JSON.parse(readFileSync(configPath, "utf-8"));
+  const server = saved.mcpServers["kiro-remote"] as Record<string, unknown>;
+  assert.ok(server);
+  assert.strictEqual(server.url, "https://mcp.example.com/mcp");
+  assert.strictEqual(server.timeout, 60000);
+  assert.strictEqual("type" in server, false);
+});
+
+test("E2E CLI: Kimi alias honors KIMI_CODE_HOME for global installs", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+  const kimiHome = createTempDir();
+
+  const result = runCli(
+    [
+      "https://mcp.example.com/mcp",
+      "-a",
+      "kimi",
+      "-g",
+      "-y",
+      "--name",
+      "kimi-remote",
+      "--timeout",
+      "5000",
+    ],
+    projectDir,
+    homeDir,
+    { KIMI_CODE_HOME: kimiHome },
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const configPath = join(kimiHome, "mcp.json");
+  assert.strictEqual(existsSync(configPath), true);
+  assert.strictEqual(
+    existsSync(join(homeDir, ".kimi-code", "mcp.json")),
+    false,
+  );
+
+  const saved = JSON.parse(readFileSync(configPath, "utf-8"));
+  const server = saved.mcpServers["kimi-remote"] as Record<string, unknown>;
+  assert.ok(server);
+  assert.strictEqual(server.transport, "http");
+  assert.strictEqual(server.url, "https://mcp.example.com/mcp");
+  assert.strictEqual(server.toolTimeoutMs, 5000);
+});
+
+test("E2E CLI: Kimi global install falls back to ~/.kimi-code", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "mcp-server-postgres",
+      "-a",
+      "kimi-code",
+      "-g",
+      "-y",
+      "--name",
+      "kimi-local",
+    ],
+    projectDir,
+    homeDir,
+    { KIMI_CODE_HOME: "" },
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const saved = JSON.parse(
+    readFileSync(join(homeDir, ".kimi-code", "mcp.json"), "utf-8"),
+  );
+  const server = saved.mcpServers["kimi-local"] as Record<string, unknown>;
+  assert.ok(server);
+  assert.strictEqual(server.transport, "stdio");
+  assert.strictEqual(server.command, "npx");
+  assert.deepStrictEqual(server.args, ["-y", "mcp-server-postgres"]);
+});
+
+test("E2E CLI: Kilo alias installs into the XDG config dir for global installs", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "https://mcp.example.com/mcp",
+      "-a",
+      "kilo",
+      "-g",
+      "-y",
+      "--name",
+      "kilo-remote",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const configPath = join(homeDir, ".config", "kilo", "kilo.json");
+  assert.strictEqual(existsSync(configPath), true);
+
+  const saved = JSON.parse(readFileSync(configPath, "utf-8"));
+  const server = saved.mcp["kilo-remote"] as Record<string, unknown>;
+  assert.ok(server);
+  assert.strictEqual(server.type, "remote");
+  assert.strictEqual(server.url, "https://mcp.example.com/mcp");
+});
+
 test("E2E CLI: --timeout and --scopes map per agent and warn on drop", () => {
   const projectDir = createTempDir();
   const homeDir = createTempDir();

--- a/tests/e2e/install.test.ts
+++ b/tests/e2e/install.test.ts
@@ -10,7 +10,14 @@
  */
 
 import assert from "node:assert";
-import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import yaml from "js-yaml";
@@ -1050,6 +1057,327 @@ test("E2E: Grok re-installs replace the server and preserve other settings", () 
   assert.strictEqual("tool_timeout_sec" in switched, false);
   assert.strictEqual(kept.url, "https://mcp.example.com/keep");
   assert.deepStrictEqual(saved.models, { default: "grok-build" });
+});
+
+// ============================================
+// E2E Tests: Kiro CLI
+// ============================================
+
+test("E2E: Install to Kiro CLI (local) - stdio", () => {
+  const tempDir = createTempDir();
+  const parsed = parseSource("mcp-server-github");
+  const config = buildServerConfig(parsed, {
+    env: { GITHUB_TOKEN: "secret" },
+  });
+
+  const result = installServerForAgent("github", config, "kiro-cli", {
+    local: true,
+    cwd: tempDir,
+  });
+
+  assert.strictEqual(result.success, true);
+
+  const configPath = join(tempDir, ".kiro", "settings", "mcp.json");
+  assert.strictEqual(existsSync(configPath), true);
+
+  const savedConfig = readJsonConfig(configPath);
+  const mcpServers = savedConfig.mcpServers as Record<
+    string,
+    Record<string, unknown>
+  >;
+  const serverConfig = mcpServers.github;
+  assert.ok(serverConfig);
+  assert.strictEqual(serverConfig.command, "npx");
+  assert.deepStrictEqual(serverConfig.args, ["-y", "mcp-server-github"]);
+  assert.deepStrictEqual(serverConfig.env, { GITHUB_TOKEN: "secret" });
+});
+
+test("E2E: Install to Kiro CLI (local) - remote omits the transport type", () => {
+  const tempDir = createTempDir();
+  const parsed = parseSource("https://mcp.example.com/api");
+  const config = buildServerConfig(parsed, {
+    headers: { Authorization: "Bearer token" },
+    timeout: 60000,
+  });
+
+  const result = installServerForAgent("example", config, "kiro-cli", {
+    local: true,
+    cwd: tempDir,
+  });
+
+  assert.strictEqual(result.success, true);
+
+  const configPath = join(tempDir, ".kiro", "settings", "mcp.json");
+  assert.strictEqual(existsSync(configPath), true);
+
+  const savedConfig = readJsonConfig(configPath);
+  const mcpServers = savedConfig.mcpServers as Record<
+    string,
+    Record<string, unknown>
+  >;
+  const serverConfig = mcpServers.example;
+  assert.ok(serverConfig);
+  assert.strictEqual(serverConfig.url, "https://mcp.example.com/api");
+  assert.deepStrictEqual(serverConfig.headers, {
+    Authorization: "Bearer token",
+  });
+  // Kiro infers the transport from url vs command and ignores `type`.
+  assert.strictEqual("type" in serverConfig, false);
+  // Kiro's timeout is in milliseconds, so it maps over unchanged.
+  assert.strictEqual(serverConfig.timeout, 60000);
+});
+
+test("E2E: Install to Kiro CLI (global) uses ~/.kiro/settings/mcp.json", () => {
+  const kiroAgent = agents["kiro-cli"];
+  assert.ok(
+    kiroAgent.configPath.endsWith(join(".kiro", "settings", "mcp.json")),
+  );
+  assert.strictEqual(kiroAgent.localConfigPath, ".kiro/settings/mcp.json");
+});
+
+test("E2E: Kiro CLI sse install does not write a type field", () => {
+  const parsed = parseSource("https://mcp.example.com/sse");
+  const config = buildServerConfig(parsed, { transport: "sse" });
+
+  const transformed = agents["kiro-cli"].transformConfig(
+    "example",
+    config,
+  ) as Record<string, unknown>;
+
+  assert.strictEqual(transformed.url, "https://mcp.example.com/sse");
+  assert.strictEqual("type" in transformed, false);
+  assert.strictEqual("transport" in transformed, false);
+});
+
+// ============================================
+// E2E Tests: Kilo Code (OpenCode-style JSON)
+// ============================================
+
+test("E2E: Install remote MCP to Kilo Code (local)", () => {
+  const tempDir = createTempDir();
+  const parsed = parseSource("https://mcp.example.com/mcp");
+  const config = buildServerConfig(parsed, {
+    headers: { Authorization: "Bearer token" },
+    timeout: 4000,
+  });
+
+  const result = installServerForAgent("example", config, "kilo-code", {
+    local: true,
+    cwd: tempDir,
+  });
+
+  assert.strictEqual(result.success, true);
+
+  const configPath = join(tempDir, "kilo.json");
+  assert.strictEqual(existsSync(configPath), true);
+
+  const savedConfig = readJsonConfig(configPath);
+  const mcp = savedConfig.mcp as Record<string, Record<string, unknown>>;
+  const serverConfig = mcp.example;
+  assert.ok(serverConfig);
+  assert.strictEqual(serverConfig.type, "remote");
+  assert.strictEqual(serverConfig.url, "https://mcp.example.com/mcp");
+  assert.strictEqual(serverConfig.enabled, true);
+  assert.deepStrictEqual(serverConfig.headers, {
+    Authorization: "Bearer token",
+  });
+  assert.strictEqual(serverConfig.timeout, 4000);
+});
+
+test("E2E: Install local server to Kilo Code uses command array and environment", () => {
+  const tempDir = createTempDir();
+  const parsed = parseSource("mcp-server-postgres");
+  const config = buildServerConfig(parsed, {
+    env: { DATABASE_URL: "postgres://localhost/test" },
+  });
+
+  const result = installServerForAgent("postgres", config, "kilo-code", {
+    local: true,
+    cwd: tempDir,
+  });
+
+  assert.strictEqual(result.success, true);
+
+  const savedConfig = readJsonConfig(join(tempDir, "kilo.json"));
+  const mcp = savedConfig.mcp as Record<string, Record<string, unknown>>;
+  const serverConfig = mcp.postgres;
+  assert.ok(serverConfig);
+  assert.strictEqual(serverConfig.type, "local");
+  assert.deepStrictEqual(serverConfig.command, [
+    "npx",
+    "-y",
+    "mcp-server-postgres",
+  ]);
+  assert.deepStrictEqual(serverConfig.environment, {
+    DATABASE_URL: "postgres://localhost/test",
+  });
+  assert.strictEqual("timeout" in serverConfig, false);
+});
+
+test("E2E: Kilo Code writes to an existing .kilo/kilo.json instead of the project root", () => {
+  const tempDir = createTempDir();
+  const nestedPath = join(tempDir, ".kilo", "kilo.json");
+  mkdirSync(join(tempDir, ".kilo"), { recursive: true });
+  writeFileSync(nestedPath, JSON.stringify({ mcp: {} }, null, 2));
+
+  const config = buildServerConfig(parseSource("https://mcp.example.com/mcp"));
+  const result = installServerForAgent("example", config, "kilo-code", {
+    local: true,
+    cwd: tempDir,
+  });
+
+  assert.strictEqual(result.success, true);
+  assert.strictEqual(result.path, nestedPath);
+  assert.strictEqual(existsSync(join(tempDir, "kilo.json")), false);
+
+  const savedConfig = readJsonConfig(nestedPath);
+  const mcp = savedConfig.mcp as Record<string, Record<string, unknown>>;
+  assert.ok(mcp.example);
+});
+
+test("E2E: Kilo Code writes to an existing legacy .kilocode/kilo.json", () => {
+  const tempDir = createTempDir();
+  const legacyPath = join(tempDir, ".kilocode", "kilo.json");
+  mkdirSync(join(tempDir, ".kilocode"), { recursive: true });
+  writeFileSync(legacyPath, JSON.stringify({ mcp: {} }, null, 2));
+
+  const config = buildServerConfig(parseSource("https://mcp.example.com/mcp"));
+  const result = installServerForAgent("example", config, "kilo-code", {
+    local: true,
+    cwd: tempDir,
+  });
+
+  assert.strictEqual(result.success, true);
+  assert.strictEqual(result.path, legacyPath);
+  assert.strictEqual(existsSync(join(tempDir, "kilo.json")), false);
+});
+
+test("E2E: Kilo Code preserves comments when updating a kilo.jsonc", () => {
+  const tempDir = createTempDir();
+  const jsoncPath = join(tempDir, "kilo.jsonc");
+  writeFileSync(
+    jsoncPath,
+    '{\n  // keep me\n  "mcp": {\n    "keep": { "type": "remote", "url": "https://keep.example.com/mcp" }\n  }\n}\n',
+  );
+
+  const config = buildServerConfig(parseSource("https://mcp.example.com/mcp"));
+  const result = installServerForAgent("example", config, "kilo-code", {
+    local: true,
+    cwd: tempDir,
+  });
+
+  assert.strictEqual(result.success, true);
+  assert.strictEqual(result.path, jsoncPath);
+
+  const content = readFileSync(jsoncPath, "utf-8");
+  assert.ok(content.includes("// keep me"));
+  assert.ok(content.includes("https://keep.example.com/mcp"));
+  assert.ok(content.includes("https://mcp.example.com/mcp"));
+});
+
+// ============================================
+// E2E Tests: Kimi Code (mcpServers with transport)
+// ============================================
+
+test("E2E: Install remote MCP to Kimi Code (local)", () => {
+  const tempDir = createTempDir();
+  const parsed = parseSource("https://mcp.example.com/mcp");
+  const config = buildServerConfig(parsed, {
+    headers: { Authorization: "Bearer token" },
+    timeout: 5000,
+  });
+
+  const result = installServerForAgent("example", config, "kimi-code", {
+    local: true,
+    cwd: tempDir,
+  });
+
+  assert.strictEqual(result.success, true);
+
+  const configPath = join(tempDir, ".kimi-code", "mcp.json");
+  assert.strictEqual(existsSync(configPath), true);
+
+  const savedConfig = readJsonConfig(configPath);
+  const mcpServers = savedConfig.mcpServers as Record<
+    string,
+    Record<string, unknown>
+  >;
+  const serverConfig = mcpServers.example;
+  assert.ok(serverConfig);
+  assert.strictEqual(serverConfig.transport, "http");
+  assert.strictEqual(serverConfig.url, "https://mcp.example.com/mcp");
+  assert.deepStrictEqual(serverConfig.headers, {
+    Authorization: "Bearer token",
+  });
+  assert.strictEqual(serverConfig.toolTimeoutMs, 5000);
+  assert.strictEqual("type" in serverConfig, false);
+});
+
+test("E2E: Install sse MCP to Kimi Code keeps an explicit transport", () => {
+  const tempDir = createTempDir();
+  const parsed = parseSource("https://mcp.example.com/sse");
+  const config = buildServerConfig(parsed, { transport: "sse" });
+
+  const result = installServerForAgent("example-sse", config, "kimi-code", {
+    local: true,
+    cwd: tempDir,
+  });
+
+  assert.strictEqual(result.success, true);
+
+  const savedConfig = readJsonConfig(join(tempDir, ".kimi-code", "mcp.json"));
+  const mcpServers = savedConfig.mcpServers as Record<
+    string,
+    Record<string, unknown>
+  >;
+  const serverConfig = mcpServers["example-sse"];
+  assert.ok(serverConfig);
+  assert.strictEqual(serverConfig.transport, "sse");
+  assert.strictEqual(serverConfig.url, "https://mcp.example.com/sse");
+});
+
+test("E2E: Install local server to Kimi Code (stdio)", () => {
+  const tempDir = createTempDir();
+  const parsed = parseSource("mcp-server-postgres");
+  const config = buildServerConfig(parsed, {
+    env: { DATABASE_URL: "postgres://localhost/test" },
+  });
+
+  const result = installServerForAgent("postgres", config, "kimi-code", {
+    local: true,
+    cwd: tempDir,
+  });
+
+  assert.strictEqual(result.success, true);
+
+  const savedConfig = readJsonConfig(join(tempDir, ".kimi-code", "mcp.json"));
+  const mcpServers = savedConfig.mcpServers as Record<
+    string,
+    Record<string, unknown>
+  >;
+  const serverConfig = mcpServers.postgres;
+  assert.ok(serverConfig);
+  assert.strictEqual(serverConfig.transport, "stdio");
+  assert.strictEqual(serverConfig.command, "npx");
+  assert.deepStrictEqual(serverConfig.args, ["-y", "mcp-server-postgres"]);
+  assert.deepStrictEqual(serverConfig.env, {
+    DATABASE_URL: "postgres://localhost/test",
+  });
+});
+
+test("E2E: Kimi Code drops a timeout its schema would reject", () => {
+  const parsed = parseSource("https://mcp.example.com/mcp");
+  const config = buildServerConfig(parsed, {
+    timeout: Number.MAX_SAFE_INTEGER,
+  });
+
+  const transformed = agents["kimi-code"].transformConfig(
+    "example",
+    config,
+  ) as Record<string, unknown>;
+
+  assert.strictEqual("toolTimeoutMs" in transformed, false);
+  assert.strictEqual(transformed.url, "https://mcp.example.com/mcp");
 });
 
 // ============================================

--- a/tests/reader.test.ts
+++ b/tests/reader.test.ts
@@ -137,6 +137,24 @@ test("extractServerIdentity: command only, no args", () => {
   assert.strictEqual(identity, "my-server");
 });
 
+test("extractServerIdentity: OpenCode-style command array", () => {
+  const identity = extractServerIdentity({
+    type: "local",
+    command: ["node", "/path/to/server.js", "--port", "3000"],
+    enabled: true,
+  });
+  assert.strictEqual(identity, "node /path/to/server.js --port 3000");
+});
+
+test("extractServerIdentity: OpenCode-style command array with npx package", () => {
+  const identity = extractServerIdentity({
+    type: "local",
+    command: ["npx", "-y", "@neondatabase/mcp-server-neon"],
+    enabled: true,
+  });
+  assert.strictEqual(identity, "@neondatabase/mcp-server-neon");
+});
+
 test("extractServerIdentity: empty config returns empty string", () => {
   const identity = extractServerIdentity({});
   assert.strictEqual(identity, "");

--- a/web/content/docs/02-cli/01-add.mdx
+++ b/web/content/docs/02-cli/01-add.mdx
@@ -77,11 +77,11 @@ Local servers (npm packages, commands) always use **stdio** transport. Most agen
 
 Not every MCP client understands every field. add-mcp keeps one canonical server config; each agent declares which optional fields it supports and maps them into its native shape:
 
-| Field              | Flag                                | Supported by            | Mapped to                                                |
-| ------------------ | ----------------------------------- | ----------------------- | -------------------------------------------------------- |
-| Timeout            | `--timeout`                         | Claude Code, Gemini CLI | `timeout` (milliseconds)                                 |
-| OAuth scopes       | `--scopes`                          | Cursor, Gemini CLI      | Cursor `auth.scopes`, Gemini `oauth.scopes`              |
-| Tool auto-approval | `--auto-approve` / `--approve-tool` | Codex, Claude Code      | Codex approval modes; Claude Code permission allow rules |
+| Field              | Flag                                | Supported by                                                        | Mapped to                                                                                    |
+| ------------------ | ----------------------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Timeout            | `--timeout`                         | Claude Code, Gemini CLI, Grok Build, Kilo Code, Kimi Code, Kiro CLI | `timeout` (milliseconds); Grok Build `tool_timeout_sec` (seconds), Kimi Code `toolTimeoutMs` |
+| OAuth scopes       | `--scopes`                          | Cursor, Gemini CLI                                                  | Cursor `auth.scopes`, Gemini `oauth.scopes`                                                  |
+| Tool auto-approval | `--auto-approve` / `--approve-tool` | Codex, Claude Code                                                  | Codex approval modes; Claude Code permission allow rules                                     |
 
 When a targeted agent doesn't support a field, add-mcp drops it from that agent's config and prints a warning — other agents still receive it.
 

--- a/web/content/docs/03-sdk/01-reference.mdx
+++ b/web/content/docs/03-sdk/01-reference.mdx
@@ -30,11 +30,11 @@ function upsertServer(
 ): InstallResult;
 ```
 
-| Parameter      | Type              | Description                                                        |
-| -------------- | ----------------- | ------------------------------------------------------------------ |
-| `agentType`    | `AgentInput`      | Agent identifier, e.g. `"cursor"`, `"claude-code"`. Validated at runtime. |
-| `serverName`   | `string`          | Key the server is stored under in the agent config.                |
-| `serverConfig` | `McpServerConfig` | Canonical server definition (see below).                           |
+| Parameter      | Type              | Description                                                                            |
+| -------------- | ----------------- | -------------------------------------------------------------------------------------- |
+| `agentType`    | `AgentInput`      | Agent identifier, e.g. `"cursor"`, `"claude-code"`. Validated at runtime.              |
+| `serverName`   | `string`          | Key the server is stored under in the agent config.                                    |
+| `serverConfig` | `McpServerConfig` | Canonical server definition (see below).                                               |
 | `options`      | `InstallOptions`  | `{ local?: boolean; cwd?: string }` — project-level install and its working directory. |
 
 Returns [`InstallResult`](#installresult). Never throws — errors are reported via `result.error`.
@@ -159,6 +159,10 @@ type AgentType =
   | "gemini-cli"
   | "goose"
   | "github-copilot-cli"
+  | "grok-build"
+  | "kilo-code"
+  | "kimi-code"
+  | "kiro-cli"
   | "mcporter"
   | "opencode"
   | "vscode"

--- a/web/content/docs/03-sdk/01-reference.mdx
+++ b/web/content/docs/03-sdk/01-reference.mdx
@@ -114,7 +114,7 @@ interface McpServerConfig {
   env?: Record<string, string>;
 
   // Capability-gated optional fields
-  timeout?: number; // Claude Code, Gemini CLI
+  timeout?: number; // milliseconds; Claude Code, Gemini CLI, Grok Build, Kilo Code, Kimi Code, Kiro CLI
   oauthScopes?: string[]; // Cursor, Gemini CLI
   autoApproveTools?: string[]; // Codex, Claude Code; [] = all tools
 }

--- a/web/content/docs/05-agents.mdx
+++ b/web/content/docs/05-agents.mdx
@@ -5,27 +5,27 @@ description: Every coding agent add-mcp can install MCP servers to, with config 
 
 MCP servers can be installed to any of these agents. Project paths are relative to your working directory; agents without a project path are global-only.
 
-| Agent                  | `--agent`            | Project path              | Global path                                                                                                     |
-| ---------------------- | -------------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| Antigravity            | `antigravity`        | —                         | `~/.gemini/config/mcp_config.json` (shared by Antigravity, Antigravity IDE, and Antigravity CLI)                |
-| Cline VSCode Extension | `cline`              | —                         | `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` |
-| Cline CLI              | `cline-cli`          | —                         | `~/.cline/data/settings/cline_mcp_settings.json`                                                                |
-| Claude Code            | `claude-code`        | `.mcp.json`               | `~/.claude.json`                                                                                                |
-| Claude Desktop         | `claude-desktop`     | —                         | `~/Library/Application Support/Claude/claude_desktop_config.json`                                               |
-| Codex                  | `codex`              | `.codex/config.toml`      | `~/.codex/config.toml`                                                                                          |
-| Cursor                 | `cursor`             | `.cursor/mcp.json`        | `~/.cursor/mcp.json`                                                                                            |
-| Gemini CLI             | `gemini-cli`         | `.gemini/settings.json`   | `~/.gemini/settings.json`                                                                                       |
-| Goose                  | `goose`              | `.goose/config.yaml`      | `~/.config/goose/config.yaml`                                                                                   |
-| GitHub Copilot CLI     | `github-copilot-cli` | `.vscode/mcp.json`        | `~/.copilot/mcp-config.json`                                                                                    |
-| Grok Build             | `grok-build`         | `.grok/config.toml`       | `$GROK_HOME/config.toml` (defaults to `~/.grok/config.toml`)                                                    |
-| Kilo Code              | `kilo-code`          | `kilo.json`               | `~/.config/kilo/kilo.json` (existing `.kilo/kilo.json` or `kilo.jsonc` files are reused)                        |
-| Kimi Code              | `kimi-code`          | `.kimi-code/mcp.json`     | `$KIMI_CODE_HOME/mcp.json` (defaults to `~/.kimi-code/mcp.json`)                                                |
-| Kiro CLI               | `kiro-cli`           | `.kiro/settings/mcp.json` | `~/.kiro/settings/mcp.json` (shared with the Kiro IDE)                                                          |
-| MCPorter               | `mcporter`           | `config/mcporter.json`    | `~/.mcporter/mcporter.json` (or existing `~/.mcporter/mcporter.jsonc`)                                          |
-| OpenCode               | `opencode`           | `opencode.json`           | `~/.config/opencode/opencode.json`                                                                              |
-| VS Code                | `vscode`             | `.vscode/mcp.json`        | `~/Library/Application Support/Code/User/mcp.json`                                                              |
-| Windsurf               | `windsurf`           | —                         | `~/.codeium/windsurf/mcp_config.json`                                                                           |
-| Zed                    | `zed`                | `.zed/settings.json`      | `~/Library/Application Support/Zed/settings.json`                                                               |
+| Agent                  | `--agent`            | Project path                                                                  | Global path                                                                                                     |
+| ---------------------- | -------------------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Antigravity            | `antigravity`        | —                                                                             | `~/.gemini/config/mcp_config.json` (shared by Antigravity, Antigravity IDE, and Antigravity CLI)                |
+| Cline VSCode Extension | `cline`              | —                                                                             | `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` |
+| Cline CLI              | `cline-cli`          | —                                                                             | `~/.cline/data/settings/cline_mcp_settings.json`                                                                |
+| Claude Code            | `claude-code`        | `.mcp.json`                                                                   | `~/.claude.json`                                                                                                |
+| Claude Desktop         | `claude-desktop`     | —                                                                             | `~/Library/Application Support/Claude/claude_desktop_config.json`                                               |
+| Codex                  | `codex`              | `.codex/config.toml`                                                          | `~/.codex/config.toml`                                                                                          |
+| Cursor                 | `cursor`             | `.cursor/mcp.json`                                                            | `~/.cursor/mcp.json`                                                                                            |
+| Gemini CLI             | `gemini-cli`         | `.gemini/settings.json`                                                       | `~/.gemini/settings.json`                                                                                       |
+| Goose                  | `goose`              | `.goose/config.yaml`                                                          | `~/.config/goose/config.yaml`                                                                                   |
+| GitHub Copilot CLI     | `github-copilot-cli` | `.vscode/mcp.json`                                                            | `~/.copilot/mcp-config.json`                                                                                    |
+| Grok Build             | `grok-build`         | `.grok/config.toml`                                                           | `$GROK_HOME/config.toml` (defaults to `~/.grok/config.toml`)                                                    |
+| Kilo Code              | `kilo-code`          | `kilo.json` (or existing `.kilo/`, `.kilocode/`, or root `kilo.jsonc` config) | `~/.config/kilo/kilo.json` (or existing `~/.config/kilo/kilo.jsonc`)                                            |
+| Kimi Code              | `kimi-code`          | `.kimi-code/mcp.json`                                                         | `$KIMI_CODE_HOME/mcp.json` (defaults to `~/.kimi-code/mcp.json`)                                                |
+| Kiro CLI               | `kiro-cli`           | `.kiro/settings/mcp.json`                                                     | `~/.kiro/settings/mcp.json` (shared with the Kiro IDE)                                                          |
+| MCPorter               | `mcporter`           | `config/mcporter.json`                                                        | `~/.mcporter/mcporter.json` (or existing `~/.mcporter/mcporter.jsonc`)                                          |
+| OpenCode               | `opencode`           | `opencode.json`                                                               | `~/.config/opencode/opencode.json`                                                                              |
+| VS Code                | `vscode`             | `.vscode/mcp.json`                                                            | `~/Library/Application Support/Code/User/mcp.json`                                                              |
+| Windsurf               | `windsurf`           | —                                                                             | `~/.codeium/windsurf/mcp_config.json`                                                                           |
+| Zed                    | `zed`                | `.zed/settings.json`                                                          | `~/Library/Application Support/Zed/settings.json`                                                               |
 
 ## Aliases
 

--- a/web/content/docs/05-agents.mdx
+++ b/web/content/docs/05-agents.mdx
@@ -5,24 +5,27 @@ description: Every coding agent add-mcp can install MCP servers to, with config 
 
 MCP servers can be installed to any of these agents. Project paths are relative to your working directory; agents without a project path are global-only.
 
-| Agent                  | `--agent`            | Project path            | Global path                                                                                                     |
-| ---------------------- | -------------------- | ----------------------- | --------------------------------------------------------------------------------------------------------------- |
-| Antigravity            | `antigravity`        | —                       | `~/.gemini/config/mcp_config.json` (shared by Antigravity, Antigravity IDE, and Antigravity CLI)                |
-| Cline VSCode Extension | `cline`              | —                       | `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` |
-| Cline CLI              | `cline-cli`          | —                       | `~/.cline/data/settings/cline_mcp_settings.json`                                                                |
-| Claude Code            | `claude-code`        | `.mcp.json`             | `~/.claude.json`                                                                                                |
-| Claude Desktop         | `claude-desktop`     | —                       | `~/Library/Application Support/Claude/claude_desktop_config.json`                                               |
-| Codex                  | `codex`              | `.codex/config.toml`    | `~/.codex/config.toml`                                                                                          |
-| Cursor                 | `cursor`             | `.cursor/mcp.json`      | `~/.cursor/mcp.json`                                                                                            |
-| Gemini CLI             | `gemini-cli`         | `.gemini/settings.json` | `~/.gemini/settings.json`                                                                                       |
-| Goose                  | `goose`              | `.goose/config.yaml`    | `~/.config/goose/config.yaml`                                                                                   |
-| GitHub Copilot CLI     | `github-copilot-cli` | `.vscode/mcp.json`      | `~/.copilot/mcp-config.json`                                                                                    |
-| Grok Build             | `grok-build`         | `.grok/config.toml`     | `$GROK_HOME/config.toml` (defaults to `~/.grok/config.toml`)                                                    |
-| MCPorter               | `mcporter`           | `config/mcporter.json`  | `~/.mcporter/mcporter.json` (or existing `~/.mcporter/mcporter.jsonc`)                                          |
-| OpenCode               | `opencode`           | `opencode.json`         | `~/.config/opencode/opencode.json`                                                                              |
-| VS Code                | `vscode`             | `.vscode/mcp.json`      | `~/Library/Application Support/Code/User/mcp.json`                                                              |
-| Windsurf               | `windsurf`           | —                       | `~/.codeium/windsurf/mcp_config.json`                                                                           |
-| Zed                    | `zed`                | `.zed/settings.json`    | `~/Library/Application Support/Zed/settings.json`                                                               |
+| Agent                  | `--agent`            | Project path              | Global path                                                                                                     |
+| ---------------------- | -------------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Antigravity            | `antigravity`        | —                         | `~/.gemini/config/mcp_config.json` (shared by Antigravity, Antigravity IDE, and Antigravity CLI)                |
+| Cline VSCode Extension | `cline`              | —                         | `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` |
+| Cline CLI              | `cline-cli`          | —                         | `~/.cline/data/settings/cline_mcp_settings.json`                                                                |
+| Claude Code            | `claude-code`        | `.mcp.json`               | `~/.claude.json`                                                                                                |
+| Claude Desktop         | `claude-desktop`     | —                         | `~/Library/Application Support/Claude/claude_desktop_config.json`                                               |
+| Codex                  | `codex`              | `.codex/config.toml`      | `~/.codex/config.toml`                                                                                          |
+| Cursor                 | `cursor`             | `.cursor/mcp.json`        | `~/.cursor/mcp.json`                                                                                            |
+| Gemini CLI             | `gemini-cli`         | `.gemini/settings.json`   | `~/.gemini/settings.json`                                                                                       |
+| Goose                  | `goose`              | `.goose/config.yaml`      | `~/.config/goose/config.yaml`                                                                                   |
+| GitHub Copilot CLI     | `github-copilot-cli` | `.vscode/mcp.json`        | `~/.copilot/mcp-config.json`                                                                                    |
+| Grok Build             | `grok-build`         | `.grok/config.toml`       | `$GROK_HOME/config.toml` (defaults to `~/.grok/config.toml`)                                                    |
+| Kilo Code              | `kilo-code`          | `kilo.json`               | `~/.config/kilo/kilo.json` (existing `.kilo/kilo.json` or `kilo.jsonc` files are reused)                        |
+| Kimi Code              | `kimi-code`          | `.kimi-code/mcp.json`     | `$KIMI_CODE_HOME/mcp.json` (defaults to `~/.kimi-code/mcp.json`)                                                |
+| Kiro CLI               | `kiro-cli`           | `.kiro/settings/mcp.json` | `~/.kiro/settings/mcp.json` (shared with the Kiro IDE)                                                          |
+| MCPorter               | `mcporter`           | `config/mcporter.json`    | `~/.mcporter/mcporter.json` (or existing `~/.mcporter/mcporter.jsonc`)                                          |
+| OpenCode               | `opencode`           | `opencode.json`           | `~/.config/opencode/opencode.json`                                                                              |
+| VS Code                | `vscode`             | `.vscode/mcp.json`        | `~/Library/Application Support/Code/User/mcp.json`                                                              |
+| Windsurf               | `windsurf`           | —                         | `~/.codeium/windsurf/mcp_config.json`                                                                           |
+| Zed                    | `zed`                | `.zed/settings.json`      | `~/Library/Application Support/Zed/settings.json`                                                               |
 
 ## Aliases
 
@@ -33,7 +36,12 @@ MCP servers can be installed to any of these agents. Project paths are relative 
 | `gemini`             | `gemini-cli` |
 | `github-copilot`     | `vscode`     |
 | `grok`               | `grok-build` |
+| `kilo`, `kilocode`   | `kilo-code`  |
+| `kimi`               | `kimi-code`  |
+| `kiro`               | `kiro-cli`   |
 
 ## Troubleshooting
 
 Some agents and editors, like Claude Code, require a restart to load a new MCP server. Others, like Cursor, require you to navigate to the MCP settings page and toggle the new server as enabled.
+
+Kimi Code only loads a project-level `.kimi-code/mcp.json` after you trust the folder in the CLI, so a project install may not take effect until then. Its MCP config is also validated as a whole: if another entry in the file is invalid, Kimi Code disables every MCP server, including a newly added one.

--- a/web/content/docs/index.mdx
+++ b/web/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: Introduction
 description: add-mcp adds MCP servers to your favorite coding agents with a single command.
 ---
 
-`add-mcp` is an open-source CLI (and TypeScript SDK) that installs [Model Context Protocol](https://modelcontextprotocol.io) servers into the config files of your coding agents — Claude Code, Codex, Cursor, OpenCode, VS Code, Grok Build, and [10 more](/docs/agents) — with a single command.
+`add-mcp` is an open-source CLI (and TypeScript SDK) that installs [Model Context Protocol](https://modelcontextprotocol.io) servers into the config files of your coding agents — Claude Code, Codex, Cursor, OpenCode, VS Code, Grok Build, and [13 more](/docs/agents) — with a single command.
 
 ```bash
 npx add-mcp https://mcp.context7.com/mcp

--- a/web/pages/index.astro
+++ b/web/pages/index.astro
@@ -20,6 +20,9 @@ const agentNames = [
   "GitHub Copilot CLI",
   "Goose",
   "Grok Build",
+  "Kilo Code",
+  "Kimi Code",
+  "Kiro CLI",
   "MCPorter",
   "Windsurf",
   "Zed",
@@ -252,7 +255,7 @@ const structuredData = JSON.stringify({
         class="text-muted-foreground mx-auto mt-2 max-w-2xl text-sm text-pretty"
       >
         add-mcp installs any MCP server into Claude Code, Codex, Cursor,
-        OpenCode, VS Code, and 10 more coding agents from the same command.
+        OpenCode, VS Code, and 14 more coding agents from the same command.
       </p>
       <div class="mt-4 flex flex-wrap items-center justify-center gap-2">
         {


### PR DESCRIPTION
> _This PR description was written by an AI agent (Cursor) on behalf of @thisistonydang. The checked **Test plan** items were genuinely run, but by the agent locally (latest against commit `a4ae5ab`) rather than by a human. CI has not run on this branch yet, since fork PRs need a maintainer to approve workflows._

## Summary

Adds three agents to the registry, bringing the total to 19.

- **Kilo Code** (`kilo`, `kilocode`) — installs to `kilo.json` for projects and `~/.config/kilo/kilo.json` globally, using Kilo's `mcp` key with `local`/`remote` server types and per-server `timeout`. An existing `.kilo/kilo.json`, `.kilocode/kilo.json`, or `kilo.jsonc` is reused instead of creating a second config the tool would ignore.
- **Kimi Code** (`kimi`) — installs to `.kimi-code/mcp.json` for projects and `$KIMI_CODE_HOME/mcp.json` globally (default `~/.kimi-code/mcp.json`), using `mcpServers` with an explicit `transport` field and `toolTimeoutMs`.
- **Kiro CLI** (`kiro`) — installs to `.kiro/settings/mcp.json` and `~/.kiro/settings/mcp.json`, the same files the Kiro IDE reads, covering stdio and remote servers plus a native millisecond `timeout`. Co-authored with @donatoaz, superseding the stale #36.

Also fixes a pre-existing bug: `list`, `find`, `remove`, and `sync` returned empty entries for OpenCode-style servers that store a command and its arguments as one array, so those servers could not be matched or synced to other agents. This affected OpenCode before these agents existed.

## Notes on the tricky bits

**Kimi's config is fail-closed** — one rejected entry disables *every* MCP server, not just the offending one. So `toolTimeoutMs` is only emitted when it falls inside Kimi's accepted bounds; an out-of-range `--timeout` drops the field rather than risking the whole file.

**Kiro infers transport from `command` vs `url`** and ignores an explicit `type`, so the transform omits it. Verified against a `mcp.json` that Kiro itself wrote, which stores a remote server as `{ url, disabled }` with no `type`.

**Kiro silently drops `autoApprove`**, so it is deliberately left out of `supportedFields`. Users get an "unsupported" warning instead of a misleading silent no-op.

## Supersedes #36

This replaces @donatoaz's #36, open since May and stale since June. The Kiro CLI support here is derived from that PR, and commit `f72109c` carries a `Co-authored-by: donatoaz` trailer.

**#36 has to be closed manually when this merges.** GitHub's `Closes`/`Fixes` keywords only auto-close issues, not pull requests, so no keyword here can do it automatically.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run test` — 381 tests across 13 files, 0 failed
- [x] `bun run build` clean
- [x] `bun run registry:verify` — 1326 entries
- [x] Unit tests: registry counts, capabilities, `supportedFields`, transport support, and project detection for `.kilo`, `.kilocode`, `kilo.json`, `.kimi-code`, and `.kiro`
- [x] E2E tests: project + global installs for all three agents, remote and stdio, covering command arrays, env, headers, timeout mapping, Kimi's out-of-bounds timeout rejection, `kilo.jsonc` path preference, and the absence of `type` for Kiro
- [x] E2E CLI tests: `kimi`/`kilo`/`kiro` aliases, `KIMI_CODE_HOME` and `XDG_CONFIG_HOME` overrides
- [x] Manual: installed a packed tarball into a clean prefix and ran project + global installs for all three agents against a sandboxed `HOME`
- [x] Manual: confirmed a global Kilo install merges into a real pre-existing `kilo.jsonc`, preserving `$schema` and creating no competing `kilo.json`

Docs, README, landing page, SDK `AgentType` reference, and `CHANGELOG.md` are updated, with `package.json` bumped to 2.1.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Kilo Code, Kimi Code, and Kiro CLI, including aliases, configuration detection, local and remote setups, and timeout handling.
  * Expanded supported-agent coverage across the homepage, CLI, SDK, and agent documentation.
  * Added guidance for Kimi Code project trust requirements.

* **Bug Fixes**
  * Improved handling of OpenCode-style configurations with array-based commands and arguments.
  * Preserved transport settings when configuration type information is unavailable.

* **Documentation**
  * Published the 2.1.0 changelog and updated package metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


