### PR TITLE
Add Folklore Clinical Variant Interpretation MCP

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -9842,7 +9842,7 @@
       "name": "io.github.helena-bioinformatics/folklore",
       "title": "Folklore Clinical Variant Interpretation MCP",
       "description": "Helena Bioinformatics MCP for clinical variant interpretation, ACMG/AMP evidence and literature.",
-      "version": "1.3.1",
+      "version": "1.3.3",
       "websiteUrl": "https://folklore.helena.bio",
       "icons": [
         {

--- a/registry.json
+++ b/registry.json
@@ -9839,6 +9839,28 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "io.github.helena-bioinformatics/folklore",
+      "title": "Folklore Clinical Variant Interpretation MCP",
+      "description": "Helena Bioinformatics MCP for clinical variant interpretation, ACMG/AMP evidence and literature.",
+      "version": "1.2.2",
+      "websiteUrl": "https://folklore.helena.bio",
+      "icons": [
+        {
+          "src": "https://folklore.helena.bio/images/logos/folklore.png",
+          "mimeType": "image/png"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.helena.bio/folklore/v1/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.olutely/footchatball-mcp",
       "title": "FootChatBall",
       "description": "Olutely's widget service, operated by Spheric Admin Ltd, provides interactive widgets and basic app behavior inside ChatGPT. Its terms describe widget requests being handled by the company's own MCP servers without storing conversation content persistently.",

--- a/registry.json
+++ b/registry.json
@@ -9842,7 +9842,7 @@
       "name": "io.github.helena-bioinformatics/folklore",
       "title": "Folklore Clinical Variant Interpretation MCP",
       "description": "Helena Bioinformatics MCP for clinical variant interpretation, ACMG/AMP evidence and literature.",
-      "version": "1.2.2",
+      "version": "1.3.1",
       "websiteUrl": "https://folklore.helena.bio",
       "icons": [
         {

--- a/registry.json
+++ b/registry.json
@@ -9842,7 +9842,7 @@
       "name": "io.github.helena-bioinformatics/folklore",
       "title": "Folklore Clinical Variant Interpretation MCP",
       "description": "Helena Bioinformatics MCP for clinical variant interpretation, ACMG/AMP evidence and literature.",
-      "version": "1.3.3",
+      "version": "1.4.2",
       "websiteUrl": "https://folklore.helena.bio",
       "icons": [
         {

--- a/registry.json
+++ b/registry.json
@@ -9841,8 +9841,8 @@
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "io.github.helena-bioinformatics/folklore",
       "title": "Folklore Clinical Variant Interpretation MCP",
-      "description": "Helena Bioinformatics MCP for clinical variant interpretation, ACMG/AMP evidence and literature.",
-      "version": "1.4.2",
+      "description": "Bioinformatics MCP for genomic variant interpretation, gene-disease evidence and literature.",
+      "version": "1.5.0",
       "websiteUrl": "https://folklore.helena.bio",
       "icons": [
         {


### PR DESCRIPTION
## Summary

Registers the hosted Streamable HTTP endpoint; the existing branch now carries Registry version 1.5.0 and the canonical description.

**Current Folklore MCP release: 1.5.0.** Bioinformatics MCP for genomic variant interpretation, gene-disease evidence and literature.

## Public connection and capabilities

- Endpoint: https://api.helena.bio/folklore/v1/mcp (Streamable HTTP; no account or API key).
- Source: https://github.com/helena-bioinformatics/folklore-mcp
- Connection guide: https://folklore.helena.bio/integrations
- Registry identity: `io.github.helena-bioinformatics/folklore`
- Release: https://github.com/helena-bioinformatics/folklore-mcp/releases/tag/folklore-mcp-v1.5.0

The live endpoint exposes seven tools:

1. `search_variant_evidence`
2. `search_variant_literature`
3. `get_publication_details`
4. `search_literature_corpus`
5. `support_helena` (separate optional support discovery)
6. `get_gene_disease_associations`
7. `search_disease_genes`

The two new scientific tools return ClinGen Gene-Disease Validity assertions by exact gene symbol/HGNC ID or MONDO ID/disease-name search. They preserve distinct disease identities, inheritance, source classifications, reports and snapshot provenance. Existing variant and literature tools are retained; this release does not change the variant classifier.

## Scope and validation

Variant interpretation is limited to supported GRCh38 germline variants. Gene-disease validity is not individual variant pathogenicity or a patient diagnosis. No raw DNA/VCF ingestion, batch variant processing, patient symptoms or private case data. Results require qualified professional review.

The upstream release and live seven-tool catalogue were verified on 2026-09-11. This confirms the hosted service, not acceptance or complete compatibility testing by this project. Refer to this pull request's checks and current diff for project-specific validation.
