### PR TITLE
Add Ask Helena

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -2401,6 +2401,28 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "io.github.helena-bioinformatics/ask-helena",
+      "title": "Ask Helena",
+      "description": "Official answers about Helena Bioinformatics and its products, with citations to public sources.",
+      "version": "1.0.4",
+      "websiteUrl": "https://www.helena.bio/ask",
+      "icons": [
+        {
+          "src": "https://www.helena.bio/images/logos/helena-favicon-48.png",
+          "mimeType": "image/png"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.helena.bio/ask/v1/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.colossyan/mcp",
       "title": "Assessment Generator",
       "description": "Colossyan is an AI video creation platform for turning documents, slides, and prompts into avatar-led training and enablement videos. It also offers voices, translation, custom avatars, and interactive video features.",

--- a/registry.json
+++ b/registry.json
@@ -2404,7 +2404,7 @@
       "name": "io.github.helena-bioinformatics/ask-helena",
       "title": "Ask Helena",
       "description": "Official answers about Helena Bioinformatics and its products, with citations to public sources.",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "websiteUrl": "https://www.helena.bio/ask",
       "icons": [
         {


### PR DESCRIPTION
## Summary

Adds the canonical remote entry for **Ask Helena**, maintained by **Helena Bioinformatics**.

- Official Registry: `io.github.helena-bioinformatics/ask-helena` version `1.0.4`
- Remote: `https://api.helena.bio/ask/v1/mcp`
- Transport: Streamable HTTP
- Authentication: none
- Public source: https://github.com/helena-bioinformatics/ask-helena-mcp
- Website: https://www.helena.bio/ask

The entry is copied from the active latest Official MCP Registry record and adds no duplicate.

## Scope and safety

Ask Helena exposes two read-only tools for official, source-cited answers about Helena Bioinformatics and its published products. It excludes private Wiki content, backend details, credentials, patient data, clinical records and write operations. It does not perform live variant classification. The Apache-2.0 license applies only to the public integration bridge; the private backend and corpus are not published or relicensed.

## Verification

- JSON parses successfully.
- Registry contains exactly one Ask Helena entry.
- Entry remains sorted by title.
- Website, icon and source URLs return successfully.
- Diff is limited to one additive registry record.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Ask Helena MCP server to the registry.
  * Included its website, icon, version information, and streamable HTTP connection endpoint.
  * Updated the server version from 1.0.4 to 1.0.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->