### PR TITLE
feat: add Pi agent support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # add-mcp
 
-A CLI to install MCP servers for different coding agents (Claude Code, Cursor, VS Code, OpenCode, Codex, Grok Build) with a single command.
+A CLI to install MCP servers for different coding agents (Claude Code, Cursor, VS Code, OpenCode, Codex, Grok Build, Pi) with a single command.
 
 ## Dev environment
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.2.0] - 2026-08-12
+
+- add `pi` support through the `pi-mcp-adapter` extension, with project installs to `.pi/mcp.json` and global installs to `$PI_CODING_AGENT_DIR/mcp.json` (default `~/.pi/agent/mcp.json`), including native `requestTimeoutMs` mapping; alias: `pi-agent`.
+
 ## [2.1.0] - 2026-08-12
 
 - add `kilo-code` support with project installs to `kilo.json` and global installs to `~/.config/kilo/kilo.json`, using Kilo Code's `mcp` config key, `local`/`remote` server types, and per-server `timeout`. Existing `.kilo/`, `.kilocode/`, and root `kilo.jsonc` configs are reused instead of creating a second config; aliases: `kilo`, `kilocode`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [2.2.0] - 2026-08-12
 
-- add `pi` support through the `pi-mcp-adapter` extension, with project installs to `.pi/mcp.json` and global installs to `$PI_CODING_AGENT_DIR/mcp.json` (default `~/.pi/agent/mcp.json`), including native `requestTimeoutMs` mapping; alias: `pi-agent`.
+- add `pi` support through the `pi-mcp-adapter` extension, with project installs to `.pi/mcp.json` and global installs to `$PI_CODING_AGENT_DIR/mcp.json` (default `~/.pi/agent/mcp.json`), including native `requestTimeoutMs` mapping.
 
 ## [2.1.0] - 2026-08-12
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Add MCP servers to your favorite coding agents with a single command.
 
-Supports **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **VS Code**, **Grok Build** and [13 more](#supported-agents).
+Supports **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **Pi**, **VS Code**, **Grok Build** and [13 more](#supported-agents).
 
 Docs and registry: [add-mcp.com](https://add-mcp.com)
 
@@ -68,11 +68,14 @@ MCP servers can be installed to any of these agents:
 | Kiro CLI               | `kiro-cli`           | `.kiro/settings/mcp.json`                                                     | `~/.kiro/settings/mcp.json` (shared with the Kiro IDE)                                                          |
 | MCPorter               | `mcporter`           | `config/mcporter.json`                                                        | `~/.mcporter/mcporter.json` (or existing `~/.mcporter/mcporter.jsonc`)                                          |
 | OpenCode               | `opencode`           | `opencode.jsonc` (or existing `opencode.json` / `.opencode/` config)          | `~/.config/opencode/opencode.jsonc` (or existing `opencode.json`)                                               |
+| Pi                     | `pi`                 | `.pi/mcp.json`                                                                | `$PI_CODING_AGENT_DIR/mcp.json` (defaults to `~/.pi/agent/mcp.json`)                                            |
 | VS Code                | `vscode`             | `.vscode/mcp.json`                                                            | `~/Library/Application Support/Code/User/mcp.json`                                                              |
 | Windsurf               | `windsurf`           | -                                                                             | `~/.codeium/windsurf/mcp_config.json`                                                                           |
 | Zed                    | `zed`                | `.zed/settings.json`                                                          | `~/Library/Application Support/Zed/settings.json`                                                               |
 
-**Aliases:** `codeium`, `cascade` → `windsurf`, `cline-vscode` → `cline`, `gemini` → `gemini-cli`, `github-copilot` → `vscode`, `grok` → `grok-build`, `kilo`, `kilocode` → `kilo-code`, `kimi` → `kimi-code`, `kiro` → `kiro-cli`
+**Aliases:** `codeium`, `cascade` → `windsurf`, `cline-vscode` → `cline`, `gemini` → `gemini-cli`, `github-copilot` → `vscode`, `grok` → `grok-build`, `kilo`, `kilocode` → `kilo-code`, `kimi` → `kimi-code`, `kiro` → `kiro-cli`, `pi-agent` → `pi`
+
+Pi support targets the [`pi-mcp-adapter`](https://github.com/nicobailon/pi-mcp-adapter) extension's Pi-owned config files. Install that extension with `pi install npm:pi-mcp-adapter` before using MCP servers in Pi.
 
 Kimi Code only loads a project-level `.kimi-code/mcp.json` after you trust the folder in the CLI, so a project install may not take effect until then.
 
@@ -202,11 +205,11 @@ Not every MCP client understands every field. `add-mcp` keeps one canonical
 server config and each agent declares which optional fields it supports, mapping
 them into that client's native shape:
 
-| Field              | Flag                                | Supported by                                                        | Mapped to                                                                                    |
-| ------------------ | ----------------------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| Timeout            | `--timeout`                         | Claude Code, Gemini CLI, Grok Build, Kilo Code, Kimi Code, Kiro CLI | `timeout` (milliseconds); Grok Build `tool_timeout_sec` (seconds), Kimi Code `toolTimeoutMs` |
-| OAuth scopes       | `--scopes`                          | Cursor, Gemini CLI                                                  | Cursor `auth.scopes`, Gemini `oauth.scopes`                                                  |
-| Tool auto-approval | `--auto-approve` / `--approve-tool` | Codex, Claude Code                                                  | Codex approval modes; Claude Code permission allow rules                                     |
+| Field              | Flag                                | Supported by                                                            | Mapped to                                                                                                           |
+| ------------------ | ----------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Timeout            | `--timeout`                         | Claude Code, Gemini CLI, Grok Build, Kilo Code, Kimi Code, Kiro CLI, Pi | `timeout` (milliseconds); Grok Build `tool_timeout_sec` (seconds), Kimi Code `toolTimeoutMs`, Pi `requestTimeoutMs` |
+| OAuth scopes       | `--scopes`                          | Cursor, Gemini CLI                                                      | Cursor `auth.scopes`, Gemini `oauth.scopes`                                                                         |
+| Tool auto-approval | `--auto-approve` / `--approve-tool` | Codex, Claude Code                                                      | Codex approval modes; Claude Code permission allow rules                                                            |
 
 When you target an agent that does not support a field, `add-mcp` drops it from
 that agent's config and prints a warning (e.g. _"request timeout is not

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ MCP servers can be installed to any of these agents:
 | Windsurf               | `windsurf`           | -                                                                             | `~/.codeium/windsurf/mcp_config.json`                                                                           |
 | Zed                    | `zed`                | `.zed/settings.json`                                                          | `~/Library/Application Support/Zed/settings.json`                                                               |
 
-**Aliases:** `codeium`, `cascade` → `windsurf`, `cline-vscode` → `cline`, `gemini` → `gemini-cli`, `github-copilot` → `vscode`, `grok` → `grok-build`, `kilo`, `kilocode` → `kilo-code`, `kimi` → `kimi-code`, `kiro` → `kiro-cli`, `pi-agent` → `pi`
+**Aliases:** `codeium`, `cascade` → `windsurf`, `cline-vscode` → `cline`, `gemini` → `gemini-cli`, `github-copilot` → `vscode`, `grok` → `grok-build`, `kilo`, `kilocode` → `kilo-code`, `kimi` → `kimi-code`, `kiro` → `kiro-cli`
 
 Pi support targets the [`pi-mcp-adapter`](https://github.com/nicobailon/pi-mcp-adapter) extension's Pi-owned config files. Install that extension with `pi install npm:pi-mcp-adapter` before using MCP servers in Pi.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-mcp",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Add MCP servers to your favorite coding agents with a single command.",
   "author": "Andre Landgraf <andre@neon.tech>",
   "license": "Apache-2.0",
@@ -57,6 +57,7 @@
     "kiro-cli",
     "mcporter",
     "opencode",
+    "pi",
     "vscode",
     "windsurf",
     "zed"

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -16,6 +16,7 @@ function getKimiCodeHome(): string {
   return process.env.KIMI_CODE_HOME || join(home, ".kimi-code");
 }
 
+/** Resolve Pi's global agent directory, honoring its documented override. */
 function getPiAgentDir(): string {
   return process.env.PI_CODING_AGENT_DIR || join(home, ".pi", "agent");
 }
@@ -942,6 +943,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     format: "json",
     supportedTransports: ["stdio", "http", "sse"],
     supportedFields: ["timeout"],
+    /** Detect Pi from its global agent directory. */
     detectGlobalInstall: async () => {
       return existsSync(getPiAgentDir());
     },

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -16,6 +16,10 @@ function getKimiCodeHome(): string {
   return process.env.KIMI_CODE_HOME || join(home, ".kimi-code");
 }
 
+function getPiAgentDir(): string {
+  return process.env.PI_CODING_AGENT_DIR || join(home, ".pi", "agent");
+}
+
 /**
  * Kilo Code resolves its global config through xdg-basedir on every platform,
  * so Windows uses `~/.config/kilo` rather than `%APPDATA%`.
@@ -419,6 +423,27 @@ function transformKiroCliConfig(
   }
 
   return remoteConfig;
+}
+
+/**
+ * Pi uses the pi-mcp-adapter extension, whose standard server shape omits a
+ * transport discriminator and names its per-request timeout requestTimeoutMs.
+ */
+function transformPiConfig(
+  _serverName: string,
+  config: McpServerConfig,
+): unknown {
+  const entry = config.url
+    ? buildStandardRemote(config)
+    : buildStandardLocal(config);
+
+  delete entry.type;
+  if (typeof config.timeout === "number") {
+    delete entry.timeout;
+    entry.requestTimeoutMs = config.timeout;
+  }
+
+  return entry;
 }
 
 function transformCursorConfig(
@@ -905,6 +930,22 @@ export const agents: Record<AgentType, AgentConfig> = {
     },
     resolveConfigPath: resolveOpenCodeConfigPath,
     transformConfig: transformOpenCodeConfig,
+  },
+
+  pi: {
+    name: "pi",
+    displayName: "Pi",
+    configPath: join(getPiAgentDir(), "mcp.json"),
+    localConfigPath: ".pi/mcp.json",
+    projectDetectPaths: [".pi"],
+    configKey: "mcpServers",
+    format: "json",
+    supportedTransports: ["stdio", "http", "sse"],
+    supportedFields: ["timeout"],
+    detectGlobalInstall: async () => {
+      return existsSync(getPiAgentDir());
+    },
+    transformConfig: transformPiConfig,
   },
 
   vscode: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export type AgentType =
   | "kiro-cli"
   | "mcporter"
   | "opencode"
+  | "pi"
   | "vscode"
   | "windsurf"
   | "zed";
@@ -32,6 +33,7 @@ export const agentAliases: Record<string, AgentType> = {
   kilocode: "kilo-code",
   kimi: "kimi-code",
   kiro: "kiro-cli",
+  "pi-agent": "pi",
 };
 
 export type ConfigFormat = "json" | "yaml" | "toml";

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,6 @@ export const agentAliases: Record<string, AgentType> = {
   kilocode: "kilo-code",
   kimi: "kimi-code",
   kiro: "kiro-cli",
-  "pi-agent": "pi",
 };
 
 export type ConfigFormat = "json" | "yaml" | "toml";

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -60,9 +60,9 @@ function cleanup() {
 // Agent Configuration Tests
 // ============================================
 
-test("getAgentTypes returns all 19 agents", () => {
+test("getAgentTypes returns all 20 agents", () => {
   const types = getAgentTypes();
-  assert.strictEqual(types.length, 19);
+  assert.strictEqual(types.length, 20);
   assert.ok(types.includes("antigravity"));
   assert.ok(types.includes("cline"));
   assert.ok(types.includes("cline-cli"));
@@ -79,6 +79,7 @@ test("getAgentTypes returns all 19 agents", () => {
   assert.ok(types.includes("kiro-cli"));
   assert.ok(types.includes("mcporter"));
   assert.ok(types.includes("opencode"));
+  assert.ok(types.includes("pi"));
   assert.ok(types.includes("vscode"));
   assert.ok(types.includes("windsurf"));
   assert.ok(types.includes("zed"));
@@ -141,6 +142,7 @@ test("supportedFields reflects per-client capabilities", () => {
   assert.deepStrictEqual(agents["kilo-code"].supportedFields, ["timeout"]);
   assert.deepStrictEqual(agents["kimi-code"].supportedFields, ["timeout"]);
   assert.deepStrictEqual(agents["kiro-cli"].supportedFields, ["timeout"]);
+  assert.deepStrictEqual(agents.pi.supportedFields, ["timeout"]);
   // Clients with no extra field support declare an empty list.
   assert.deepStrictEqual(agents.vscode.supportedFields, []);
   assert.deepStrictEqual(agents["claude-desktop"].supportedFields, []);
@@ -162,6 +164,7 @@ test("supportsProjectConfig - returns true for project-capable agents", () => {
   assert.strictEqual(supportsProjectConfig("kimi-code"), true);
   assert.strictEqual(supportsProjectConfig("kiro-cli"), true);
   assert.strictEqual(supportsProjectConfig("mcporter"), true);
+  assert.strictEqual(supportsProjectConfig("pi"), true);
   assert.strictEqual(supportsProjectConfig("codex"), true);
   assert.strictEqual(supportsProjectConfig("zed"), true);
 });
@@ -175,9 +178,9 @@ test("supportsProjectConfig - returns false for global-only agents", () => {
   assert.strictEqual(supportsProjectConfig("windsurf"), false);
 });
 
-test("getProjectCapableAgents returns 13 agents", () => {
+test("getProjectCapableAgents returns 14 agents", () => {
   const projectAgents = getProjectCapableAgents();
-  assert.strictEqual(projectAgents.length, 13);
+  assert.strictEqual(projectAgents.length, 14);
   assert.ok(projectAgents.includes("claude-code"));
   assert.ok(projectAgents.includes("cursor"));
   assert.ok(projectAgents.includes("vscode"));
@@ -189,6 +192,7 @@ test("getProjectCapableAgents returns 13 agents", () => {
   assert.ok(projectAgents.includes("kimi-code"));
   assert.ok(projectAgents.includes("kiro-cli"));
   assert.ok(projectAgents.includes("mcporter"));
+  assert.ok(projectAgents.includes("pi"));
   assert.ok(projectAgents.includes("codex"));
   assert.ok(projectAgents.includes("zed"));
 });
@@ -415,6 +419,14 @@ test("detectProjectAgents - detects .zed directory", () => {
   assert.ok(detected.includes("zed"));
 });
 
+test("detectProjectAgents - detects .pi directory", () => {
+  const tempDir = createTempDir();
+  mkdirSync(join(tempDir, ".pi"));
+
+  const detected = detectProjectAgents(tempDir);
+  assert.ok(detected.includes("pi"));
+});
+
 test("detectProjectAgents - detects config/mcporter.json", () => {
   const tempDir = createTempDir();
   mkdirSync(join(tempDir, "config"), { recursive: true });
@@ -485,6 +497,7 @@ test("isTransportSupported - most agents support http", () => {
     "kiro-cli",
     "mcporter",
     "opencode",
+    "pi",
     "vscode",
     "windsurf",
     "zed",
@@ -516,6 +529,7 @@ test("isTransportSupported - most agents support sse", () => {
     "kiro-cli",
     "mcporter",
     "opencode",
+    "pi",
     "vscode",
     "windsurf",
     "zed",

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -1715,6 +1715,33 @@ test("E2E CLI: Pi honors PI_CODING_AGENT_DIR for global installs", () => {
   assert.strictEqual("type" in server, false);
 });
 
+test("E2E CLI: Pi global install falls back to ~/.pi/agent", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    ["mcp-server-postgres", "-a", "pi", "-g", "-y", "--name", "pi-local"],
+    projectDir,
+    homeDir,
+    { PI_CODING_AGENT_DIR: "" },
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const configPath = join(homeDir, ".pi", "agent", "mcp.json");
+  assert.strictEqual(existsSync(configPath), true);
+
+  const saved = JSON.parse(readFileSync(configPath, "utf-8"));
+  const server = saved.mcpServers["pi-local"] as Record<string, unknown>;
+  assert.ok(server);
+  assert.strictEqual(server.command, "npx");
+  assert.deepStrictEqual(server.args, ["-y", "mcp-server-postgres"]);
+});
+
 test("E2E CLI: Kimi alias honors KIMI_CODE_HOME for global installs", () => {
   const projectDir = createTempDir();
   const homeDir = createTempDir();

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -1672,7 +1672,7 @@ test("E2E CLI: Kiro alias installs into .kiro/settings/mcp.json", () => {
   assert.strictEqual("type" in server, false);
 });
 
-test("E2E CLI: Pi alias honors PI_CODING_AGENT_DIR for global installs", () => {
+test("E2E CLI: Pi honors PI_CODING_AGENT_DIR for global installs", () => {
   const projectDir = createTempDir();
   const homeDir = createTempDir();
   const piAgentDir = createTempDir();
@@ -1681,7 +1681,7 @@ test("E2E CLI: Pi alias honors PI_CODING_AGENT_DIR for global installs", () => {
     [
       "https://mcp.example.com/mcp",
       "-a",
-      "pi-agent",
+      "pi",
       "-g",
       "-y",
       "--name",

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -1672,6 +1672,49 @@ test("E2E CLI: Kiro alias installs into .kiro/settings/mcp.json", () => {
   assert.strictEqual("type" in server, false);
 });
 
+test("E2E CLI: Pi alias honors PI_CODING_AGENT_DIR for global installs", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+  const piAgentDir = createTempDir();
+
+  const result = runCli(
+    [
+      "https://mcp.example.com/mcp",
+      "-a",
+      "pi-agent",
+      "-g",
+      "-y",
+      "--name",
+      "pi-remote",
+      "--timeout",
+      "5000",
+    ],
+    projectDir,
+    homeDir,
+    { PI_CODING_AGENT_DIR: piAgentDir },
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const configPath = join(piAgentDir, "mcp.json");
+  assert.strictEqual(existsSync(configPath), true);
+  assert.strictEqual(
+    existsSync(join(homeDir, ".pi", "agent", "mcp.json")),
+    false,
+  );
+
+  const saved = JSON.parse(readFileSync(configPath, "utf-8"));
+  const server = saved.mcpServers["pi-remote"] as Record<string, unknown>;
+  assert.ok(server);
+  assert.strictEqual(server.url, "https://mcp.example.com/mcp");
+  assert.strictEqual(server.requestTimeoutMs, 5000);
+  assert.strictEqual("type" in server, false);
+});
+
 test("E2E CLI: Kimi alias honors KIMI_CODE_HOME for global installs", () => {
   const projectDir = createTempDir();
   const homeDir = createTempDir();

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -501,6 +501,24 @@ test("installServerForAgent - Claude Code keeps timeout, drops scopes", () => {
   assert.ok(!("oauthScopes" in server));
 });
 
+test("installServerForAgent - Pi maps timeout to requestTimeoutMs", () => {
+  const tempDir = createTempDir();
+  const result = installRemoteWith("pi", tempDir, {
+    timeout: 12000,
+  });
+  assert.ok(result.success);
+  assert.strictEqual(result.droppedFields, undefined);
+
+  const saved = readJsonConfig(join(tempDir, ".pi", "mcp.json"));
+  const server = (saved.mcpServers as Record<string, Record<string, unknown>>)
+    .example;
+  assert.ok(server);
+  assert.strictEqual(server.url, "https://mcp.example.com/mcp");
+  assert.strictEqual(server.requestTimeoutMs, 12000);
+  assert.ok(!("type" in server));
+  assert.ok(!("timeout" in server));
+});
+
 test("installServerForAgent - VS Code drops both timeout and scopes", () => {
   const tempDir = createTempDir();
   const result = installRemoteWith("vscode", tempDir, {

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -519,6 +519,37 @@ test("installServerForAgent - Pi maps timeout to requestTimeoutMs", () => {
   assert.ok(!("timeout" in server));
 });
 
+test("installServerForAgent - Pi maps stdio config and timeout", () => {
+  const tempDir = createTempDir();
+  const result = installServerForAgent(
+    "postgres",
+    {
+      command: "npx",
+      args: ["-y", "mcp-server-postgres"],
+      env: { DATABASE_URL: "postgres://localhost/test" },
+      timeout: 12000,
+    },
+    "pi",
+    { local: true, cwd: tempDir },
+  );
+  assert.ok(result.success);
+  assert.strictEqual(result.droppedFields, undefined);
+
+  const saved = readJsonConfig(join(tempDir, ".pi", "mcp.json"));
+  const server = (saved.mcpServers as Record<string, Record<string, unknown>>)
+    .postgres;
+  assert.ok(server);
+  assert.strictEqual(server.command, "npx");
+  assert.deepStrictEqual(server.args, ["-y", "mcp-server-postgres"]);
+  assert.deepStrictEqual(server.env, {
+    DATABASE_URL: "postgres://localhost/test",
+  });
+  assert.strictEqual(server.requestTimeoutMs, 12000);
+  assert.ok(!("type" in server));
+  assert.ok(!("transport" in server));
+  assert.ok(!("timeout" in server));
+});
+
 test("installServerForAgent - VS Code drops both timeout and scopes", () => {
   const tempDir = createTempDir();
   const result = installRemoteWith("vscode", tempDir, {

--- a/web/content/docs/02-cli/01-add.mdx
+++ b/web/content/docs/02-cli/01-add.mdx
@@ -77,11 +77,11 @@ Local servers (npm packages, commands) always use **stdio** transport. Most agen
 
 Not every MCP client understands every field. add-mcp keeps one canonical server config; each agent declares which optional fields it supports and maps them into its native shape:
 
-| Field              | Flag                                | Supported by                                                        | Mapped to                                                                                    |
-| ------------------ | ----------------------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| Timeout            | `--timeout`                         | Claude Code, Gemini CLI, Grok Build, Kilo Code, Kimi Code, Kiro CLI | `timeout` (milliseconds); Grok Build `tool_timeout_sec` (seconds), Kimi Code `toolTimeoutMs` |
-| OAuth scopes       | `--scopes`                          | Cursor, Gemini CLI                                                  | Cursor `auth.scopes`, Gemini `oauth.scopes`                                                  |
-| Tool auto-approval | `--auto-approve` / `--approve-tool` | Codex, Claude Code                                                  | Codex approval modes; Claude Code permission allow rules                                     |
+| Field              | Flag                                | Supported by                                                            | Mapped to                                                                                                           |
+| ------------------ | ----------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Timeout            | `--timeout`                         | Claude Code, Gemini CLI, Grok Build, Kilo Code, Kimi Code, Kiro CLI, Pi | `timeout` (milliseconds); Grok Build `tool_timeout_sec` (seconds), Kimi Code `toolTimeoutMs`, Pi `requestTimeoutMs` |
+| OAuth scopes       | `--scopes`                          | Cursor, Gemini CLI                                                      | Cursor `auth.scopes`, Gemini `oauth.scopes`                                                                         |
+| Tool auto-approval | `--auto-approve` / `--approve-tool` | Codex, Claude Code                                                      | Codex approval modes; Claude Code permission allow rules                                                            |
 
 When a targeted agent doesn't support a field, add-mcp drops it from that agent's config and prints a warning — other agents still receive it.
 

--- a/web/content/docs/03-sdk/01-reference.mdx
+++ b/web/content/docs/03-sdk/01-reference.mdx
@@ -114,7 +114,7 @@ interface McpServerConfig {
   env?: Record<string, string>;
 
   // Capability-gated optional fields
-  timeout?: number; // milliseconds; Claude Code, Gemini CLI, Grok Build, Kilo Code, Kimi Code, Kiro CLI
+  timeout?: number; // milliseconds; Claude Code, Gemini CLI, Grok Build, Kilo Code, Kimi Code, Kiro CLI, Pi
   oauthScopes?: string[]; // Cursor, Gemini CLI
   autoApproveTools?: string[]; // Codex, Claude Code; [] = all tools
 }

--- a/web/content/docs/03-sdk/01-reference.mdx
+++ b/web/content/docs/03-sdk/01-reference.mdx
@@ -165,6 +165,7 @@ type AgentType =
   | "kiro-cli"
   | "mcporter"
   | "opencode"
+	| "pi"
   | "vscode"
   | "windsurf"
   | "zed";

--- a/web/content/docs/05-agents.mdx
+++ b/web/content/docs/05-agents.mdx
@@ -40,7 +40,6 @@ MCP servers can be installed to any of these agents. Project paths are relative 
 | `kilo`, `kilocode`   | `kilo-code`  |
 | `kimi`               | `kimi-code`  |
 | `kiro`               | `kiro-cli`   |
-| `pi-agent`           | `pi`         |
 
 ## Pi
 

--- a/web/content/docs/05-agents.mdx
+++ b/web/content/docs/05-agents.mdx
@@ -23,6 +23,7 @@ MCP servers can be installed to any of these agents. Project paths are relative 
 | Kiro CLI               | `kiro-cli`           | `.kiro/settings/mcp.json`                                                     | `~/.kiro/settings/mcp.json` (shared with the Kiro IDE)                                                          |
 | MCPorter               | `mcporter`           | `config/mcporter.json`                                                        | `~/.mcporter/mcporter.json` (or existing `~/.mcporter/mcporter.jsonc`)                                          |
 | OpenCode               | `opencode`           | `opencode.jsonc` (or existing `opencode.json` / `.opencode/` config)          | `~/.config/opencode/opencode.jsonc` (or existing `opencode.json`)                                               |
+| Pi                     | `pi`                 | `.pi/mcp.json`                                                                | `$PI_CODING_AGENT_DIR/mcp.json` (defaults to `~/.pi/agent/mcp.json`)                                            |
 | VS Code                | `vscode`             | `.vscode/mcp.json`                                                            | `~/Library/Application Support/Code/User/mcp.json`                                                              |
 | Windsurf               | `windsurf`           | —                                                                             | `~/.codeium/windsurf/mcp_config.json`                                                                           |
 | Zed                    | `zed`                | `.zed/settings.json`                                                          | `~/Library/Application Support/Zed/settings.json`                                                               |
@@ -39,6 +40,11 @@ MCP servers can be installed to any of these agents. Project paths are relative 
 | `kilo`, `kilocode`   | `kilo-code`  |
 | `kimi`               | `kimi-code`  |
 | `kiro`               | `kiro-cli`   |
+| `pi-agent`           | `pi`         |
+
+## Pi
+
+Pi support targets the [`pi-mcp-adapter`](https://github.com/nicobailon/pi-mcp-adapter) extension's Pi-owned config files. Install it with `pi install npm:pi-mcp-adapter` before using MCP servers in Pi.
 
 ## Troubleshooting
 

--- a/web/content/docs/index.mdx
+++ b/web/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: Introduction
 description: add-mcp adds MCP servers to your favorite coding agents with a single command.
 ---
 
-`add-mcp` is an open-source CLI (and TypeScript SDK) that installs [Model Context Protocol](https://modelcontextprotocol.io) servers into the config files of your coding agents — Claude Code, Codex, Cursor, OpenCode, VS Code, Grok Build, and [13 more](/docs/agents) — with a single command.
+`add-mcp` is an open-source CLI (and TypeScript SDK) that installs [Model Context Protocol](https://modelcontextprotocol.io) servers into the config files of your coding agents — Claude Code, Codex, Cursor, OpenCode, Pi, VS Code, Grok Build, and [13 more](/docs/agents) — with a single command.
 
 ```bash
 npx add-mcp https://mcp.context7.com/mcp


### PR DESCRIPTION

Add Pi agent support. 
Necessary for a clean implementation of https://github.com/neondatabase/neon-pkgs/issues/458

Tested on my mac, I do not have a windows machine to test it on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added support for installing and configuring Pi as a coding agent.
* Supports project and global configurations, custom agent directories, HTTP/SSE connections, and timeout mapping.
* Added bearer-token environment configuration support for fx.

## Documentation
* Updated setup guides, agent lists, CLI and SDK references, and changelog details.

## Tests
* Added coverage for Pi installation, configuration paths, transports, URLs, and timeout handling.
* Added validation for fx bearer-token environment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->