### PR TITLE
feat: add fx support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.2.0] - 2026-08-23
+
+- add `fx` support with global installs to `~/.fx/mcp.json`, using fx's `mcp` config key, `local`/`http`/`sse` server types, a command array for stdio, and `environment`. fx does not load repository-local MCP files, so there is no project install path.
+
 ## [2.1.0] - 2026-08-12
 
 - add `kilo-code` support with project installs to `kilo.json` and global installs to `~/.config/kilo/kilo.json`, using Kilo Code's `mcp` config key, `local`/`remote` server types, and per-server `timeout`. Existing `.kilo/`, `.kilocode/`, and root `kilo.jsonc` configs are reused instead of creating a second config; aliases: `kilo`, `kilocode`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [2.2.0] - 2026-08-23
 
-- add `fx` support with global installs to `~/.fx/mcp.json`, using fx's `mcp` config key, `local`/`http`/`sse` server types, a command array for stdio, and `environment`. fx does not load repository-local MCP files, so there is no project install path.
+- add `fx` support with global installs to `~/.fx/mcp.json`, using fx's `mcp` config key, `local`/`http`/`sse` server types, a command array for stdio, and `environment`. fx does not load repository-local MCP files, so there is no project install path. A literal `Authorization` header is rejected rather than written, because fx refuses that header at runtime.
+- fix `sync` comparing command-array agents against `args` as stored, so a Cursor `command`/`args` pair and an fx command array for the same package no longer look like a conflict.
 
 ## [2.1.0] - 2026-08-12
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Add MCP servers to your favorite coding agents with a single command.
 
-Supports **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **VS Code**, **Grok Build** and [13 more](#supported-agents).
+Supports **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **VS Code**, **Grok Build** and [14 more](#supported-agents).
 
 Docs and registry: [add-mcp.com](https://add-mcp.com)
 
@@ -59,6 +59,7 @@ MCP servers can be installed to any of these agents:
 | Claude Desktop         | `claude-desktop`     | -                                                                             | `~/Library/Application Support/Claude/claude_desktop_config.json`                                               |
 | Codex                  | `codex`              | `.codex/config.toml`                                                          | `~/.codex/config.toml`                                                                                          |
 | Cursor                 | `cursor`             | `.cursor/mcp.json`                                                            | `~/.cursor/mcp.json`                                                                                            |
+| fx                     | `fx`                 | -                                                                             | `~/.fx/mcp.json`                                                                                                |
 | Gemini CLI             | `gemini-cli`         | `.gemini/settings.json`                                                       | `~/.gemini/settings.json`                                                                                       |
 | Goose                  | `goose`              | `.goose/config.yaml`                                                          | `~/.config/goose/config.yaml`                                                                                   |
 | GitHub Copilot CLI     | `github-copilot-cli` | `.vscode/mcp.json`                                                            | `~/.copilot/mcp-config.json`                                                                                    |
@@ -75,6 +76,8 @@ MCP servers can be installed to any of these agents:
 **Aliases:** `codeium`, `cascade` → `windsurf`, `cline-vscode` → `cline`, `gemini` → `gemini-cli`, `github-copilot` → `vscode`, `grok` → `grok-build`, `kilo`, `kilocode` → `kilo-code`, `kimi` → `kimi-code`, `kiro` → `kiro-cli`
 
 Kimi Code only loads a project-level `.kimi-code/mcp.json` after you trust the folder in the CLI, so a project install may not take effect until then.
+
+fx reads MCP servers only from `~/.fx/mcp.json`. A project file cannot add a server.
 
 ## Installation Scope
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ MCP servers can be installed to any of these agents:
 
 Kimi Code only loads a project-level `.kimi-code/mcp.json` after you trust the folder in the CLI, so a project install may not take effect until then.
 
-fx reads MCP servers only from `~/.fx/mcp.json`. A project file cannot add a server.
+fx reads MCP servers only from `~/.fx/mcp.json`. A project file cannot add a server. A running session applies the change with `/mcp reload`.
 
 ## Installation Scope
 
@@ -522,3 +522,5 @@ removeServer("claude-code", "example", {
 ### Server not loading
 
 Some agents & editors like Claude Code require a restart to load the new MCP server. Otherwise, like Cursor, require you to navigate to the MCP settings page and toggle the new server as enabled.
+
+fx reads MCP servers only from `~/.fx/mcp.json`. A project file cannot add a server. A running session applies the change with `/mcp reload`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-mcp",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Add MCP servers to your favorite coding agents with a single command.",
   "author": "Andre Landgraf <andre@neon.tech>",
   "license": "Apache-2.0",
@@ -46,6 +46,7 @@
     "claude-desktop",
     "codex",
     "cursor",
+    "fx",
     "github-copilot-cli",
     "gemini-cli",
     "goose",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -430,6 +430,17 @@ function transformFxConfig(
   config: McpServerConfig,
 ): unknown {
   if (config.url) {
+    if (
+      config.headers &&
+      Object.keys(config.headers).some(
+        (name) => name.toLowerCase() === "authorization",
+      )
+    ) {
+      throw new Error(
+        "fx rejects a literal Authorization header. Use a non-Authorization header, or set bearer_token_env / header_env in ~/.fx/mcp.json.",
+      );
+    }
+
     const entry: Record<string, unknown> = {
       type: config.type === "sse" ? "sse" : "http",
       url: config.url,

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -437,7 +437,7 @@ function transformFxConfig(
       )
     ) {
       throw new Error(
-        "fx rejects a literal Authorization header. Use a non-Authorization header, or set bearer_token_env / header_env in ~/.fx/mcp.json.",
+        "fx rejects a literal Authorization header. Use a non-Authorization header, or set bearer_token_env, header_env, or oauth in ~/.fx/mcp.json.",
       );
     }
 

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -421,6 +421,37 @@ function transformKiroCliConfig(
   return remoteConfig;
 }
 
+/**
+ * fx accepts command/args/env, but `/mcp add` writes a command array with
+ * `environment`: https://fx.sh/docs/capabilities/mcp
+ */
+function transformFxConfig(
+  _serverName: string,
+  config: McpServerConfig,
+): unknown {
+  if (config.url) {
+    const entry: Record<string, unknown> = {
+      type: config.type === "sse" ? "sse" : "http",
+      url: config.url,
+      enabled: true,
+    };
+    if (config.headers && Object.keys(config.headers).length > 0) {
+      entry.headers = config.headers;
+    }
+    return entry;
+  }
+
+  const entry: Record<string, unknown> = {
+    type: "local",
+    command: [config.command, ...(config.args || [])],
+    enabled: true,
+  };
+  if (config.env && Object.keys(config.env).length > 0) {
+    entry.environment = config.env;
+  }
+  return entry;
+}
+
 function transformCursorConfig(
   _serverName: string,
   config: McpServerConfig,
@@ -753,6 +784,23 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, ".cursor"));
     },
     transformConfig: transformCursorConfig,
+  },
+
+  fx: {
+    name: "fx",
+    displayName: "fx",
+    // fx reads MCP config only from its trusted global profile:
+    // https://fx.sh/docs/capabilities/mcp
+    configPath: join(home, ".fx", "mcp.json"),
+    projectDetectPaths: [],
+    configKey: "mcp",
+    format: "json",
+    supportedTransports: ["stdio", "http", "sse"],
+    supportedFields: [],
+    detectGlobalInstall: async () => {
+      return existsSync(join(home, ".fx"));
+    },
+    transformConfig: transformFxConfig,
   },
 
   "gemini-cli": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -884,7 +884,7 @@ function extractConflictFields(config: Record<string, unknown>): {
   return {
     headers: config.headers ?? config.http_headers ?? null,
     env: config.env ?? config.envs ?? config.environment ?? null,
-    args: config.args ?? null,
+    args: normalizeStoredCommand(config).args,
   };
 }
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -356,15 +356,12 @@ export function installServerForAgent(
   const configPath = getConfigPath(agent, options);
 
   try {
-    const dir = dirname(configPath);
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true });
-    }
-
     // Strip optional fields the agent can't represent, then transform the
     // gated config into the agent's native schema. Because every transform
     // builds a fresh object with only known keys, unsupported fields can never
     // leak into the written config.
+    // Agent detection treats an empty config directory as a global install,
+    // so validation must run before creating it.
     const { config: gatedConfig, dropped } = applyFieldSupport(
       serverConfig,
       agent.supportedFields,
@@ -373,6 +370,11 @@ export function installServerForAgent(
     const transformedConfig = agent.transformConfig(serverName, gatedConfig, {
       local: Boolean(options.local),
     });
+
+    const dir = dirname(configPath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
 
     const configKey = getConfigKey(agent, options);
     const config = buildConfigWithKey(configKey, serverName, transformedConfig);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "fs";
 import { homedir } from "os";
 import { join, dirname, isAbsolute, relative, sep } from "path";
 import type {
@@ -380,6 +386,12 @@ export function installServerForAgent(
     const config = buildConfigWithKey(configKey, serverName, transformedConfig);
 
     writeConfig(configPath, config, agent.format, configKey);
+
+    // Match fx's private profile permissions because --env may contain secrets.
+    if (agentType === "fx") {
+      chmodSync(dirname(configPath), 0o700);
+      chmodSync(configPath, 0o600);
+    }
 
     // Claude Code expresses auto-approval as permission rules in a separate
     // settings file rather than inside the MCP server entry, so apply it as a

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export type AgentType =
   | "claude-desktop"
   | "codex"
   | "cursor"
+  | "fx"
   | "gemini-cli"
   | "goose"
   | "github-copilot-cli"

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -60,9 +60,9 @@ function cleanup() {
 // Agent Configuration Tests
 // ============================================
 
-test("getAgentTypes returns all 19 agents", () => {
+test("getAgentTypes returns all 20 agents", () => {
   const types = getAgentTypes();
-  assert.strictEqual(types.length, 19);
+  assert.strictEqual(types.length, 20);
   assert.ok(types.includes("antigravity"));
   assert.ok(types.includes("cline"));
   assert.ok(types.includes("cline-cli"));
@@ -70,6 +70,7 @@ test("getAgentTypes returns all 19 agents", () => {
   assert.ok(types.includes("claude-desktop"));
   assert.ok(types.includes("codex"));
   assert.ok(types.includes("cursor"));
+  assert.ok(types.includes("fx"));
   assert.ok(types.includes("gemini-cli"));
   assert.ok(types.includes("goose"));
   assert.ok(types.includes("github-copilot-cli"));
@@ -144,6 +145,7 @@ test("supportedFields reflects per-client capabilities", () => {
   // Clients with no extra field support declare an empty list.
   assert.deepStrictEqual(agents.vscode.supportedFields, []);
   assert.deepStrictEqual(agents["claude-desktop"].supportedFields, []);
+  assert.deepStrictEqual(agents.fx.supportedFields, []);
 });
 
 // ============================================
@@ -173,6 +175,7 @@ test("supportsProjectConfig - returns false for global-only agents", () => {
   assert.strictEqual(supportsProjectConfig("claude-desktop"), false);
   assert.strictEqual(supportsProjectConfig("goose"), false);
   assert.strictEqual(supportsProjectConfig("windsurf"), false);
+  assert.strictEqual(supportsProjectConfig("fx"), false);
 });
 
 test("getProjectCapableAgents returns 13 agents", () => {
@@ -193,15 +196,16 @@ test("getProjectCapableAgents returns 13 agents", () => {
   assert.ok(projectAgents.includes("zed"));
 });
 
-test("getGlobalOnlyAgents returns 6 agents", () => {
+test("getGlobalOnlyAgents returns 7 agents", () => {
   const globalAgents = getGlobalOnlyAgents();
-  assert.strictEqual(globalAgents.length, 6);
+  assert.strictEqual(globalAgents.length, 7);
   assert.ok(globalAgents.includes("antigravity"));
   assert.ok(globalAgents.includes("cline"));
   assert.ok(globalAgents.includes("cline-cli"));
   assert.ok(globalAgents.includes("claude-desktop"));
   assert.ok(globalAgents.includes("goose"));
   assert.ok(globalAgents.includes("windsurf"));
+  assert.ok(globalAgents.includes("fx"));
 });
 
 test("Project + global-only agents equals all agents", () => {
@@ -452,6 +456,7 @@ test("detectProjectAgents - does not detect global-only agents", () => {
   assert.ok(!detected.includes("goose"));
   assert.ok(!detected.includes("windsurf"));
   assert.ok(!detected.includes("antigravity"));
+  assert.ok(!detected.includes("fx"));
 });
 
 // ============================================
@@ -476,6 +481,7 @@ test("isTransportSupported - most agents support http", () => {
     "claude-code",
     "codex",
     "cursor",
+    "fx",
     "gemini-cli",
     "github-copilot-cli",
     "goose",
@@ -507,6 +513,7 @@ test("isTransportSupported - most agents support sse", () => {
     "claude-code",
     "codex",
     "cursor",
+    "fx",
     "gemini-cli",
     "github-copilot-cli",
     "goose",

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -8,6 +8,7 @@ import {
   existsSync,
   mkdirSync,
   writeFileSync,
+  statSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
@@ -539,6 +540,8 @@ test("E2E CLI: fx remote install writes ~/.fx/mcp.json without -g", () => {
 
   const configPath = join(homeDir, ".fx", "mcp.json");
   assert.strictEqual(existsSync(configPath), true);
+  assert.strictEqual(statSync(join(homeDir, ".fx")).mode & 0o777, 0o700);
+  assert.strictEqual(statSync(configPath).mode & 0o777, 0o600);
   assert.strictEqual(existsSync(join(projectDir, ".fx.json")), false);
   assert.strictEqual(existsSync(join(projectDir, "mcp.json")), false);
 

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -576,7 +576,7 @@ test("E2E CLI: fx rejects a literal Authorization header", () => {
 
   const output = `${result.stdout}\n${result.stderr}`;
   assert.match(output, /literal Authorization header/);
-  assert.strictEqual(existsSync(join(homeDir, ".fx", "mcp.json")), false);
+  assert.strictEqual(existsSync(join(homeDir, ".fx")), false);
 });
 
 test("E2E CLI: fx stdio install uses command array and environment", () => {

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -525,7 +525,7 @@ test("E2E CLI: fx remote install writes ~/.fx/mcp.json without -g", () => {
       "--name",
       "example",
       "--header",
-      "Authorization: Bearer token",
+      "X-Workspace: demo",
     ],
     projectDir,
     homeDir,
@@ -551,8 +551,32 @@ test("E2E CLI: fx remote install writes ~/.fx/mcp.json without -g", () => {
   assert.strictEqual(server.url, "https://mcp.example.com/mcp");
   assert.strictEqual(server.enabled, true);
   assert.deepStrictEqual(server.headers, {
-    Authorization: "Bearer token",
+    "X-Workspace": "demo",
   });
+});
+
+test("E2E CLI: fx rejects a literal Authorization header", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "https://mcp.example.com/mcp",
+      "-a",
+      "fx",
+      "-y",
+      "--name",
+      "example",
+      "--header",
+      "Authorization: Bearer token",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.match(output, /literal Authorization header/);
+  assert.strictEqual(existsSync(join(homeDir, ".fx", "mcp.json")), false);
 });
 
 test("E2E CLI: fx stdio install uses command array and environment", () => {
@@ -1375,6 +1399,59 @@ test("remove: prints message when no matches found", () => {
 });
 
 // ── sync command tests ───────────────────────────────────────────────────
+
+test("sync: command-array fx args match Cursor args on global sync", () => {
+  const homeDir = createTempDir();
+  const projectDir = createTempDir();
+
+  mkdirSync(join(homeDir, ".cursor"), { recursive: true });
+  writeFileSync(
+    join(homeDir, ".cursor", "mcp.json"),
+    JSON.stringify({
+      mcpServers: {
+        postgres: {
+          command: "npx",
+          args: ["-y", "mcp-server-postgres"],
+        },
+      },
+    }),
+  );
+
+  mkdirSync(join(homeDir, ".fx"), { recursive: true });
+  writeFileSync(
+    join(homeDir, ".fx", "mcp.json"),
+    JSON.stringify({
+      mcp: {
+        pg: {
+          type: "local",
+          command: ["npx", "-y", "mcp-server-postgres"],
+          enabled: true,
+        },
+      },
+    }),
+  );
+
+  const result = runCli(["sync", "-g", "-y"], projectDir, homeDir);
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.doesNotMatch(output, /args differ/);
+
+  const cursorConfig = JSON.parse(
+    readFileSync(join(homeDir, ".cursor", "mcp.json"), "utf-8"),
+  );
+  const fxConfig = JSON.parse(
+    readFileSync(join(homeDir, ".fx", "mcp.json"), "utf-8"),
+  );
+  assert.ok(cursorConfig.mcpServers.pg, "Cursor should rename to pg");
+  assert.strictEqual(cursorConfig.mcpServers.postgres, undefined);
+  assert.ok(fxConfig.mcp.pg, "fx should keep pg");
+});
 
 test("sync: renames servers to canonical name across agents with -y", () => {
   const homeDir = createTempDir();

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -512,6 +512,114 @@ test("E2E CLI: Goose HTTP install with headers", () => {
   });
 });
 
+test("E2E CLI: fx remote install writes ~/.fx/mcp.json without -g", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "https://mcp.example.com/mcp",
+      "-a",
+      "fx",
+      "-y",
+      "--name",
+      "example",
+      "--header",
+      "Authorization: Bearer token",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const configPath = join(homeDir, ".fx", "mcp.json");
+  assert.strictEqual(existsSync(configPath), true);
+  assert.strictEqual(existsSync(join(projectDir, ".fx.json")), false);
+  assert.strictEqual(existsSync(join(projectDir, "mcp.json")), false);
+
+  const saved = JSON.parse(readFileSync(configPath, "utf-8")) as {
+    mcp: Record<string, Record<string, unknown>>;
+  };
+  const server = saved.mcp.example;
+  assert.ok(server);
+  assert.strictEqual(server.type, "http");
+  assert.strictEqual(server.url, "https://mcp.example.com/mcp");
+  assert.strictEqual(server.enabled, true);
+  assert.deepStrictEqual(server.headers, {
+    Authorization: "Bearer token",
+  });
+});
+
+test("E2E CLI: fx stdio install uses command array and environment", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "mcp-server-postgres",
+      "-a",
+      "fx",
+      "-y",
+      "--name",
+      "postgres",
+      "--env",
+      "DATABASE_URL=postgres://localhost/test",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const saved = JSON.parse(
+    readFileSync(join(homeDir, ".fx", "mcp.json"), "utf-8"),
+  ) as { mcp: Record<string, Record<string, unknown>> };
+  const server = saved.mcp.postgres;
+  assert.ok(server);
+  assert.strictEqual(server.type, "local");
+  assert.deepStrictEqual(server.command, ["npx", "-y", "mcp-server-postgres"]);
+  assert.deepStrictEqual(server.environment, {
+    DATABASE_URL: "postgres://localhost/test",
+  });
+  assert.strictEqual("args" in server, false);
+});
+
+test("E2E CLI: fx list reads the command-array identity", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const install = runCli(
+    ["mcp-server-github", "-a", "fx", "-y", "--name", "github"],
+    projectDir,
+    homeDir,
+  );
+  if (install.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${install.stdout}\nSTDERR:\n${install.stderr}`,
+    );
+  }
+
+  const listed = runCli(["list", "-g", "-a", "fx"], projectDir, homeDir);
+  if (listed.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${listed.stdout}\nSTDERR:\n${listed.stderr}`,
+    );
+  }
+
+  const output = `${listed.stdout}\n${listed.stderr}`;
+  assert.match(output, /github/);
+  assert.match(output, /mcp-server-github/);
+});
+
 test("E2E CLI: Goose HTTP install with -h header shorthand", () => {
   const projectDir = createTempDir();
   const homeDir = createTempDir();

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -579,6 +579,7 @@ test("E2E CLI: fx rejects a literal Authorization header", () => {
 
   const output = `${result.stdout}\n${result.stderr}`;
   assert.match(output, /literal Authorization header/);
+  assert.match(output, /bearer_token_env, header_env, or oauth/);
   assert.strictEqual(existsSync(join(homeDir, ".fx")), false);
 });
 

--- a/tests/e2e/install.test.ts
+++ b/tests/e2e/install.test.ts
@@ -1455,6 +1455,80 @@ test("E2E: Kimi Code drops a timeout its schema would reject", () => {
   assert.strictEqual(transformed.url, "https://mcp.example.com/mcp");
 });
 
+test("E2E: fx stdio transform uses a command array and environment", () => {
+  const parsed = parseSource("mcp-server-postgres");
+  const config = buildServerConfig(parsed, {
+    env: { DATABASE_URL: "postgres://localhost/test" },
+  });
+
+  const transformed = agents.fx.transformConfig("postgres", config) as Record<
+    string,
+    unknown
+  >;
+
+  assert.strictEqual(transformed.type, "local");
+  assert.deepStrictEqual(transformed.command, [
+    "npx",
+    "-y",
+    "mcp-server-postgres",
+  ]);
+  assert.deepStrictEqual(transformed.environment, {
+    DATABASE_URL: "postgres://localhost/test",
+  });
+  assert.strictEqual(transformed.enabled, true);
+  assert.strictEqual("args" in transformed, false);
+  assert.strictEqual("env" in transformed, false);
+});
+
+test("E2E: fx stdio transform omits empty environment", () => {
+  const config = buildServerConfig(parseSource("mcp-server-github"));
+  const transformed = agents.fx.transformConfig("github", config) as Record<
+    string,
+    unknown
+  >;
+
+  assert.strictEqual(transformed.type, "local");
+  assert.strictEqual("environment" in transformed, false);
+});
+
+test("E2E: fx remote transform writes http or sse plus headers", () => {
+  const httpConfig = buildServerConfig(
+    parseSource("https://mcp.example.com/mcp"),
+    {
+      headers: { Authorization: "Bearer token" },
+    },
+  );
+  const http = agents.fx.transformConfig("example", httpConfig) as Record<
+    string,
+    unknown
+  >;
+  assert.strictEqual(http.type, "http");
+  assert.strictEqual(http.url, "https://mcp.example.com/mcp");
+  assert.strictEqual(http.enabled, true);
+  assert.deepStrictEqual(http.headers, { Authorization: "Bearer token" });
+
+  const sseConfig = buildServerConfig(
+    parseSource("https://mcp.example.com/sse"),
+    {
+      transport: "sse",
+    },
+  );
+  const sse = agents.fx.transformConfig("example-sse", sseConfig) as Record<
+    string,
+    unknown
+  >;
+  assert.strictEqual(sse.type, "sse");
+  assert.strictEqual(sse.url, "https://mcp.example.com/sse");
+  assert.strictEqual("headers" in sse, false);
+});
+
+test("E2E: fx is global-only and writes ~/.fx/mcp.json", () => {
+  assert.ok(agents.fx.configPath.endsWith(join(".fx", "mcp.json")));
+  assert.strictEqual(agents.fx.localConfigPath, undefined);
+  assert.deepStrictEqual(agents.fx.projectDetectPaths, []);
+  assert.strictEqual(agents.fx.configKey, "mcp");
+});
+
 // ============================================
 // E2E Tests: Multiple agents at once
 // ============================================

--- a/tests/e2e/install.test.ts
+++ b/tests/e2e/install.test.ts
@@ -1495,7 +1495,7 @@ test("E2E: fx remote transform writes http or sse plus headers", () => {
   const httpConfig = buildServerConfig(
     parseSource("https://mcp.example.com/mcp"),
     {
-      headers: { Authorization: "Bearer token" },
+      headers: { "X-Workspace": "demo" },
     },
   );
   const http = agents.fx.transformConfig("example", httpConfig) as Record<
@@ -1505,7 +1505,7 @@ test("E2E: fx remote transform writes http or sse plus headers", () => {
   assert.strictEqual(http.type, "http");
   assert.strictEqual(http.url, "https://mcp.example.com/mcp");
   assert.strictEqual(http.enabled, true);
-  assert.deepStrictEqual(http.headers, { Authorization: "Bearer token" });
+  assert.deepStrictEqual(http.headers, { "X-Workspace": "demo" });
 
   const sseConfig = buildServerConfig(
     parseSource("https://mcp.example.com/sse"),
@@ -1520,6 +1520,17 @@ test("E2E: fx remote transform writes http or sse plus headers", () => {
   assert.strictEqual(sse.type, "sse");
   assert.strictEqual(sse.url, "https://mcp.example.com/sse");
   assert.strictEqual("headers" in sse, false);
+});
+
+test("E2E: fx remote transform rejects a literal Authorization header", () => {
+  const config = buildServerConfig(parseSource("https://mcp.example.com/mcp"), {
+    headers: { Authorization: "Bearer token" },
+  });
+
+  assert.throws(
+    () => agents.fx.transformConfig("example", config),
+    /literal Authorization header/,
+  );
 });
 
 test("E2E: fx is global-only and writes ~/.fx/mcp.json", () => {

--- a/tests/e2e/install.test.ts
+++ b/tests/e2e/install.test.ts
@@ -1529,7 +1529,7 @@ test("E2E: fx remote transform rejects a literal Authorization header", () => {
 
   assert.throws(
     () => agents.fx.transformConfig("example", config),
-    /literal Authorization header/,
+    /bearer_token_env, header_env, or oauth/,
   );
 });
 

--- a/tests/lib.test.ts
+++ b/tests/lib.test.ts
@@ -246,6 +246,13 @@ await test("upsertServer + removeServer reject local: true for global-only agent
   assert.strictEqual(remove.success, false);
   assert.strictEqual(remove.removed, false);
   assert.ok(remove.error?.includes("does not support project-level"));
+
+  const fxUpsert = upsertServer("fx", "x", remote("https://x.example.com"), {
+    local: true,
+    cwd: dir,
+  });
+  assert.strictEqual(fxUpsert.success, false);
+  assert.ok(fxUpsert.error?.includes("does not support project-level"));
 });
 
 await test("upsertServer + removeServer honor github-copilot-cli local `servers` key", () => {

--- a/web/content/docs/03-sdk/01-reference.mdx
+++ b/web/content/docs/03-sdk/01-reference.mdx
@@ -156,6 +156,7 @@ type AgentType =
   | "claude-desktop"
   | "codex"
   | "cursor"
+  | "fx"
   | "gemini-cli"
   | "goose"
   | "github-copilot-cli"

--- a/web/content/docs/05-agents.mdx
+++ b/web/content/docs/05-agents.mdx
@@ -47,4 +47,4 @@ Some agents and editors, like Claude Code, require a restart to load a new MCP s
 
 Kimi Code only loads a project-level `.kimi-code/mcp.json` after you trust the folder in the CLI, so a project install may not take effect until then. Its MCP config is also validated as a whole: if another entry in the file is invalid, Kimi Code disables every MCP server, including a newly added one.
 
-fx reads MCP servers only from `~/.fx/mcp.json`. A project file cannot add a server.
+fx reads MCP servers only from `~/.fx/mcp.json`. A project file cannot add a server. A running session applies the change with `/mcp reload`.

--- a/web/content/docs/05-agents.mdx
+++ b/web/content/docs/05-agents.mdx
@@ -14,6 +14,7 @@ MCP servers can be installed to any of these agents. Project paths are relative 
 | Claude Desktop         | `claude-desktop`     | —                                                                             | `~/Library/Application Support/Claude/claude_desktop_config.json`                                               |
 | Codex                  | `codex`              | `.codex/config.toml`                                                          | `~/.codex/config.toml`                                                                                          |
 | Cursor                 | `cursor`             | `.cursor/mcp.json`                                                            | `~/.cursor/mcp.json`                                                                                            |
+| fx                     | `fx`                 | —                                                                             | `~/.fx/mcp.json`                                                                                                |
 | Gemini CLI             | `gemini-cli`         | `.gemini/settings.json`                                                       | `~/.gemini/settings.json`                                                                                       |
 | Goose                  | `goose`              | `.goose/config.yaml`                                                          | `~/.config/goose/config.yaml`                                                                                   |
 | GitHub Copilot CLI     | `github-copilot-cli` | `.vscode/mcp.json`                                                            | `~/.copilot/mcp-config.json`                                                                                    |
@@ -45,3 +46,5 @@ MCP servers can be installed to any of these agents. Project paths are relative 
 Some agents and editors, like Claude Code, require a restart to load a new MCP server. Others, like Cursor, require you to navigate to the MCP settings page and toggle the new server as enabled.
 
 Kimi Code only loads a project-level `.kimi-code/mcp.json` after you trust the folder in the CLI, so a project install may not take effect until then. Its MCP config is also validated as a whole: if another entry in the file is invalid, Kimi Code disables every MCP server, including a newly added one.
+
+fx reads MCP servers only from `~/.fx/mcp.json`. A project file cannot add a server.

--- a/web/content/docs/index.mdx
+++ b/web/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: Introduction
 description: add-mcp adds MCP servers to your favorite coding agents with a single command.
 ---
 
-`add-mcp` is an open-source CLI (and TypeScript SDK) that installs [Model Context Protocol](https://modelcontextprotocol.io) servers into the config files of your coding agents — Claude Code, Codex, Cursor, OpenCode, VS Code, Grok Build, and [13 more](/docs/agents) — with a single command.
+`add-mcp` is an open-source CLI (and TypeScript SDK) that installs [Model Context Protocol](https://modelcontextprotocol.io) servers into the config files of your coding agents — Claude Code, Codex, Cursor, OpenCode, VS Code, Grok Build, and [14 more](/docs/agents) — with a single command.
 
 ```bash
 npx add-mcp https://mcp.context7.com/mcp

--- a/web/pages/index.astro
+++ b/web/pages/index.astro
@@ -16,6 +16,7 @@ const agentNames = [
   "Antigravity",
   "Claude Desktop",
   "Cline",
+  "fx",
   "Gemini CLI",
   "GitHub Copilot CLI",
   "Goose",
@@ -255,7 +256,7 @@ const structuredData = JSON.stringify({
         class="text-muted-foreground mx-auto mt-2 max-w-2xl text-sm text-pretty"
       >
         add-mcp installs any MCP server into Claude Code, Codex, Cursor,
-        OpenCode, VS Code, and 14 more coding agents from the same command.
+        OpenCode, VS Code, and 15 more coding agents from the same command.
       </p>
       <div class="mt-4 flex flex-wrap items-center justify-center gap-2">
         {


### PR DESCRIPTION
## Problem

add-mcp installs an MCP server into 19 coding agents. fx ([fx.sh](https://fx.sh)) is not one of them, so adding a server to fx means hand-writing `~/.fx/mcp.json` against a schema that differs from the Cursor-style `mcpServers` shape most agents share:

| fx | The shape most agents use |
| --- | --- |
| servers under `mcp` | `mcpServers` |
| explicit `type`: `local`, `http` or `sse` | inferred from `command` or `url` |
| `command: ["npx", "-y", "pkg"]` | `command: "npx"` plus `args: [...]` |
| `environment` | `env` |

fx validates the file as a whole, so a single malformed entry stops every other server in it from loading. With one entry carrying a literal `Authorization` header, sitting next to a valid one, fx 0.0.5 reports:

```
[fail] mcp_config: failed to load ~/.fx/mcp.json: McpConfigInvalidHeaders
```

Neither server loads.

## What fx gets

`fx` becomes an agent target that writes `~/.fx/mcp.json`. fx reads MCP servers from that one file, so every install is global and there is no project path. Docs and the README say a running session picks the change up with `/mcp reload`.

## Three constraints that shape the install path

**fx refuses a literal `Authorization` header, so add-mcp refuses it too.** The fx 0.0.5 binary carries the matching validation error, `Authorization must use bearer_token_env or OAuth`, and the runtime failure above confirms it. Writing the header anyway would produce a file that fx will not load, and because validation is whole-file, it would also disable servers that were already working. The transform throws before anything is written and the error names bearer_token_env, header_env, and oauth.

**Detection reads `~/.fx`, so validation has to run before the directory exists.** `detectGlobalInstall` for fx is `existsSync(~/.fx)`. `installServerForAgent` used to `mkdirSync` the config directory first and transform the config after, so a rejected install left an empty `~/.fx` behind and add-mcp would then report fx as installed on a machine that never ran it. Transform and field gating now run first; the directory is created only once there is something valid to write. After a rejected run, the home directory is still empty.

**Command arrays read as an args conflict in `sync`.** `sync` groups servers by identity and compares `headers`, `env` and `args` to decide whether two entries are the same server. It read `config.args`, which is absent for any agent that stores one `command` array. OpenCode and Kilo Code already store that shape, so this predates fx. On `origin/main`, with the same Postgres server in Cursor and OpenCode:

```
◇  Sync Plan ──────────────────────────────────────────────────────╮
│  Skipped (conflicts):                                            │
│    mcp-server-postgres: args differ between Cursor and OpenCode  │
├──────────────────────────────────────────────────────────────────╯
●  All servers are already in sync (some skipped due to conflicts)
```

`normalizeStoredCommand` in `reader.ts` already split a command array into command plus args for exactly this reason, and `extractConflictFields` now uses it. Same fixture on this branch:

```
◇  Sync Plan ────────────────────────────────────────╮
│  Renames:                                          │
│    Cursor: postgres → pg                           │
├────────────────────────────────────────────────────╯
◆  Synced 2 servers across 3 agents
```

## CLI

Remote server. fx is global-only, so add-mcp selects global scope without `-g`:

```bash
npx add-mcp https://mcp.example.com/mcp -a fx -y --name example --header "X-Workspace: demo"
```

```
●  Selected agents require global installation

◇  Installation Summary ─╮
│  Server: example       │
│  Type: remote          │
│  Scope: Global         │
│  Agents: fx            │
├────────────────────────╯

◇  Installed to 1 agent ─╮
│  ✓ fx: ~/.fx/mcp.json  │
├────────────────────────╯
```

```json
{
  "mcp": {
    "example": {
      "type": "http",
      "url": "https://mcp.example.com/mcp",
      "enabled": true,
      "headers": { "X-Workspace": "demo" }
    }
  }
}
```

`--transport sse` writes `"type": "sse"`. The directory is `0700` and the file is `0600`, matching how fx creates its own profile, because `--env` values are written into this file.

stdio server:

```bash
npx add-mcp mcp-server-postgres -a fx -y --name postgres --env DATABASE_URL=postgres://localhost/test
```

```json
{
  "mcp": {
    "postgres": {
      "type": "local",
      "command": ["npx", "-y", "mcp-server-postgres"],
      "enabled": true,
      "environment": { "DATABASE_URL": "postgres://localhost/test" }
    }
  }
}
```

`environment` is omitted when there are no env vars.

A literal `Authorization` header fails the install and writes nothing:

```bash
npx add-mcp https://mcp.example.com/mcp -a fx -y --name example --header "Authorization: Bearer token"
```

```
Failed to install to 1 agent

    ✗ fx: fx rejects a literal Authorization header. Use a non-Authorization header, or set bearer_token_env, header_env, or oauth in ~/.fx/mcp.json.
```

`~/.fx` does not exist afterwards.

`list` resolves the identity out of the command array:

```bash
npx add-mcp list -g -a fx
```

```
fx:
  - postgres (mcp-server-postgres)
```

fx declares no optional field support, so `--timeout`, `--scopes` and `--auto-approve` are dropped with a warning and the install still succeeds:

```
▲  request timeout is not supported by fx; dropped from that config.
```

## SDK

```ts
import { upsertServer } from "add-mcp";

upsertServer("fx", "example", {
  url: "https://mcp.example.com/mcp",
  headers: { "X-Workspace": "demo" },
});
```

A project install is refused, the same way the other global-only agents refuse it:

```ts
upsertServer(
  "fx",
  "example",
  { url: "https://mcp.example.com/mcp" },
  { local: true },
);
// {
//   success: false,
//   path: "",
//   error: "fx does not support project-level config"
// }
```

`AgentType` gains `"fx"`. Nothing changes for existing callers of `upsertServer`, `removeServer` or `listInstalledServers`. The one behavior change outside fx is the `sync` args comparison, which now also treats OpenCode and Kilo Code command arrays as equal to a Cursor `command` plus `args` pair for the same package.

## Also in here

- Version bump to 2.2.0 with a `CHANGELOG.md` entry covering fx and the `sync` fix.
- Agent counts and tables in `README.md`, `web/content/docs/05-agents.mdx`, `web/content/docs/index.mdx` and the agent list on `web/pages/index.astro`.
- `AgentType` in the SDK reference docs.
- The global-only note and `/mcp reload` line, in the README supported-agents section, the README troubleshooting section and the docs agents page.

## Verification

`bun run test` at `6e79561` on top of `origin/main` at `c817081`: 402 tests across 13 suites, 0 failures. `bun run typecheck` is clean.

Behaviors covered by the new tests:

- stdio transform produces a command array plus `environment`, with no `args` or `env` key
- `environment` is omitted when there are no env vars
- remote transform produces `http` or `sse` plus `headers`, and omits `headers` when there are none
- a literal `Authorization` header throws, and the CLI run leaves no `~/.fx` directory
- the written directory is `0700` and the file is `0600`
- no project file is written into the working directory
- `list -g -a fx` resolves the package name out of the command array
- `upsertServer("fx", ..., { local: true })` fails with the project-level error
- fx is counted in the agent, global-only and transport-support lists
- `sync -g` renames across a Cursor `args` pair and an fx command array without reporting an args conflict

Checked against fx 0.0.5 on this machine. `add-mcp` wrote `~/.fx/mcp.json`; `fx doctor` reported no `mcp_config` failure; the file was deleted after the run. A prior `fx ask` on the same shape called `mcp_search_tools` on the installed servers, and a decoy `$PROJ/.fx/mcp.json` was not loaded. `/mcp reload` is the command fx documents for a running session; it is interactive and was not driven in this pass.

## For your attention

- **fx validates `~/.fx/mcp.json` as a whole.** If any entry in the file is invalid, fx loads no MCP servers at all, including one add-mcp just wrote. The same class of caveat is already documented for Kimi Code. The fx docs note only covers the global path and `/mcp reload`.
- **Every write sets `enabled: true`.** fx treats `enabled` as optional and defaults it to `true`. add-mcp matches `/mcp add` and replaces the whole entry, so `sync -g` renaming an fx server, or a re-install of the same name, turns `"enabled": false` back on. The Sync Plan reports only the rename.
- **The `Authorization` refusal is a hard error.** add-mcp could translate the header into `bearer_token_env` instead, but that means inventing an environment variable name and depending on the user exporting it. The error names `bearer_token_env`, `header_env`, and `oauth` and stops there.
- **The `0700`/`0600` chmod is keyed on `agentType === "fx"` inside `installServerForAgent`.** One agent needing it is a special case; a second one should turn it into a field on the agent config.
- **fx detection is `existsSync(~/.fx)`.** A machine that ran fx once and removed it still reports fx as a global install target.
- **A failed fx install exits 0.** The CLI reports the failure per agent and finishes successfully, which is how it already treats every other per-agent failure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Writes a home-directory MCP profile (including env secrets) with fx-specific chmod and a hard Authorization-header refusal; also changes sync conflict detection for all command-array agents.
> 
> **Overview**
> Adds **fx** as a global-only agent that writes `~/.fx/mcp.json` under the `mcp` key (`local`/`http`/`sse`, command array, `environment`). There is no project path; a running session reloads with `/mcp reload`.
> 
> Remote installs reject a literal `Authorization` header before creating `~/.fx`, matching fx’s whole-file validation. Successful writes chmod the directory `0700` and file `0600`. Transform/validation now run before mkdir so a failed install does not leave an empty `~/.fx` that would look like a global install.
> 
> `sync` now compares args via `normalizeStoredCommand`, so a Cursor `command`/`args` pair and an fx (or OpenCode/Kilo) command array for the same package are no longer treated as a conflict. Version bump to **2.2.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 797ce04af7e953101b4b16420372f8462522b7d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
