### PR TITLE
feat: add --bearer-token-env for fx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [2.3.0] - 2026-08-23
 
-- add `--bearer-token-env <name>` for remote servers. fx writes it as `bearer_token_env`. Other agents drop it with a warning. When the same run also passes `--header Authorization`, fx omits that header and keeps `bearer_token_env`; other agents keep the header. Authorization without `--bearer-token-env` still fails on fx. Empty or whitespace names fail in the CLI and the SDK.
+- add `--bearer-token-env <name>` for remote servers. fx writes it as `bearer_token_env`. Other agents drop it with a warning. When the same run also passes `--header Authorization`, fx omits that header, warns, and keeps `bearer_token_env`; other agents keep the header. Authorization without `--bearer-token-env` still fails on fx. Empty or whitespace names fail in the CLI and the SDK.
 
 ## [2.2.0] - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.3.0] - 2026-08-23
+
+- add `--bearer-token-env <name>` for remote servers. fx writes it as `bearer_token_env`. Other agents drop it with a warning. When the same run also passes `--header Authorization`, fx omits that header and keeps `bearer_token_env`; other agents keep the header. Authorization without `--bearer-token-env` still fails on fx.
+
 ## [2.2.0] - 2026-08-23
 
 - add `fx` support with global installs to `~/.fx/mcp.json`, using fx's `mcp` config key, `local`/`http`/`sse` server types, a command array for stdio, and `environment`. fx does not load repository-local MCP files, so there is no project install path. A literal `Authorization` header is rejected rather than written, because fx refuses that header at runtime.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [2.3.0] - 2026-08-23
 
-- add `--bearer-token-env <name>` for remote servers. fx writes it as `bearer_token_env`. Other agents drop it with a warning. When the same run also passes `--header Authorization`, fx omits that header, warns, and keeps `bearer_token_env`; other agents keep the header. Authorization without `--bearer-token-env` still fails on fx. Empty or whitespace names fail in the CLI and the SDK.
+- add `--bearer-token-env <name>` for remote servers. fx writes it as `bearer_token_env`. Other agents drop it with a warning. When the same run also passes `--header Authorization`, fx omits that header, warns, and keeps `bearer_token_env`; other agents keep the header. Authorization without `--bearer-token-env` still fails on fx. Empty, whitespace, and non-identifier names fail in the CLI and the SDK.
 
 ## [2.2.0] - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [2.3.0] - 2026-08-23
 
-- add `--bearer-token-env <name>` for remote servers. fx writes it as `bearer_token_env`. Other agents drop it with a warning. When the same run also passes `--header Authorization`, fx omits that header and keeps `bearer_token_env`; other agents keep the header. Authorization without `--bearer-token-env` still fails on fx.
+- add `--bearer-token-env <name>` for remote servers. fx writes it as `bearer_token_env`. Other agents drop it with a warning. When the same run also passes `--header Authorization`, fx omits that header and keeps `bearer_token_env`; other agents keep the header. Authorization without `--bearer-token-env` still fails on fx. Empty or whitespace names fail in the CLI and the SDK.
 
 ## [2.2.0] - 2026-08-23
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ npx add-mcp https://mcp.example.com/sse --transport sse
 # Remote MCP server with auth header
 npx add-mcp https://mcp.example.com/mcp --header "Authorization: Bearer $TOKEN"
 
+# Remote server whose bearer token lives in an environment variable (fx)
+npx add-mcp https://mcp.example.com/mcp --bearer-token-env NEON_API_KEY
+
 # Remote server with a request timeout and OAuth scopes
 # (each agent only keeps the fields it supports; others are dropped with a warning)
 npx add-mcp https://mcp.example.com/mcp --timeout 30000 --scopes "read,write"
@@ -181,25 +184,26 @@ npx add-mcp https://mcp.example.com/mcp -a cursor -y --gitignore
 
 ### Options
 
-| Option                    | Description                                                              |
-| ------------------------- | ------------------------------------------------------------------------ |
-| `-g, --global`            | Install to user directory instead of project                             |
-| `-a, --agent <agent>`     | Target specific agents (e.g., `cursor`, `claude-code`). Can be repeated. |
-| `-t, --transport <type>`  | Transport type for remote servers: `http` (default), `sse`               |
-| `--type <type>`           | Alias for `--transport`                                                  |
-| `-h, --header <header>`   | HTTP header for remote servers (repeatable, `Key: Value`)                |
-| `--env <env>`             | Env var for local stdio servers (repeatable, `KEY=VALUE`)                |
-| `--timeout <ms>`          | Request timeout (ms) for remote servers (capability-gated, see below)    |
-| `--scopes <scopes>`       | OAuth scopes for remote servers, comma-separated (capability-gated)      |
-| `--oauth-scopes <scopes>` | Alias for `--scopes`                                                     |
-| `--auto-approve`          | Auto-approve MCP tool calls for supported agents (Codex, Claude Code)    |
-| `--approve-tool <tool>`   | Tool to auto-approve with `--auto-approve` (repeatable; defaults to all) |
-| `-n, --name <name>`       | Server name (auto-inferred if not provided)                              |
-| `-y, --yes`               | Skip all confirmation prompts                                            |
-| `--all`                   | Install to all agents                                                    |
-| `--gitignore`             | Add generated config files to `.gitignore`                               |
+| Option                      | Description                                                              |
+| --------------------------- | ------------------------------------------------------------------------ |
+| `-g, --global`              | Install to user directory instead of project                             |
+| `-a, --agent <agent>`       | Target specific agents (e.g., `cursor`, `claude-code`). Can be repeated. |
+| `-t, --transport <type>`    | Transport type for remote servers: `http` (default), `sse`               |
+| `--type <type>`             | Alias for `--transport`                                                  |
+| `-h, --header <header>`     | HTTP header for remote servers (repeatable, `Key: Value`)                |
+| `--bearer-token-env <name>` | Env var name fx sends as a bearer token (capability-gated, see below)    |
+| `--env <env>`               | Env var for local stdio servers (repeatable, `KEY=VALUE`)                |
+| `--timeout <ms>`            | Request timeout (ms) for remote servers (capability-gated, see below)    |
+| `--scopes <scopes>`         | OAuth scopes for remote servers, comma-separated (capability-gated)      |
+| `--oauth-scopes <scopes>`   | Alias for `--scopes`                                                     |
+| `--auto-approve`            | Auto-approve MCP tool calls for supported agents (Codex, Claude Code)    |
+| `--approve-tool <tool>`     | Tool to auto-approve with `--auto-approve` (repeatable; defaults to all) |
+| `-n, --name <name>`         | Server name (auto-inferred if not provided)                              |
+| `-y, --yes`                 | Skip all confirmation prompts                                            |
+| `--all`                     | Install to all agents                                                    |
+| `--gitignore`               | Add generated config files to `.gitignore`                               |
 
-#### Capability-gated fields (`--timeout`, `--scopes`)
+#### Capability-gated fields (`--timeout`, `--scopes`, `--bearer-token-env`)
 
 Not every MCP client understands every field. `add-mcp` keeps one canonical
 server config and each agent declares which optional fields it supports, mapping
@@ -209,13 +213,18 @@ them into that client's native shape:
 | ------------------ | ----------------------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
 | Timeout            | `--timeout`                         | Claude Code, Gemini CLI, Grok Build, Kilo Code, Kimi Code, Kiro CLI | `timeout` (milliseconds); Grok Build `tool_timeout_sec` (seconds), Kimi Code `toolTimeoutMs` |
 | OAuth scopes       | `--scopes`                          | Cursor, Gemini CLI                                                  | Cursor `auth.scopes`, Gemini `oauth.scopes`                                                  |
+| Bearer token env   | `--bearer-token-env`                | fx                                                                  | `bearer_token_env`                                                                           |
 | Tool auto-approval | `--auto-approve` / `--approve-tool` | Codex, Claude Code                                                  | Codex approval modes; Claude Code permission allow rules                                     |
 
 When you target an agent that does not support a field, `add-mcp` drops it from
 that agent's config and prints a warning (e.g. _"request timeout is not
 supported by VS Code; dropped from that config."_). Other agents still receive
-it. `--timeout` and `--scopes` apply to remote servers only; `--auto-approve`
-applies to both remote and local servers.
+it. `--timeout`, `--scopes`, and `--bearer-token-env` apply to remote servers
+only; `--auto-approve` applies to both remote and local servers.
+
+When `--bearer-token-env` and `--header Authorization` are both set, fx omits
+the Authorization header and writes `bearer_token_env`. Other agents keep the
+header.
 
 #### Auto-approving tool calls (`--auto-approve`)
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,6 @@ npx add-mcp https://mcp.example.com/sse --transport sse
 # Remote MCP server with auth header
 npx add-mcp https://mcp.example.com/mcp --header "Authorization: Bearer $TOKEN"
 
-# Remote server whose bearer token lives in an environment variable (fx)
 npx add-mcp https://mcp.example.com/mcp --bearer-token-env NEON_API_KEY
 
 # Remote server with a request timeout and OAuth scopes

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ npx add-mcp https://mcp.example.com/sse --transport sse
 # Remote MCP server with auth header
 npx add-mcp https://mcp.example.com/mcp --header "Authorization: Bearer $TOKEN"
 
+# Remote server; fx reads the bearer token from this env var
 npx add-mcp https://mcp.example.com/mcp --bearer-token-env NEON_API_KEY
 
 # Remote server with a request timeout and OAuth scopes
@@ -183,24 +184,24 @@ npx add-mcp https://mcp.example.com/mcp -a cursor -y --gitignore
 
 ### Options
 
-| Option                      | Description                                                              |
-| --------------------------- | ------------------------------------------------------------------------ |
-| `-g, --global`              | Install to user directory instead of project                             |
-| `-a, --agent <agent>`       | Target specific agents (e.g., `cursor`, `claude-code`). Can be repeated. |
-| `-t, --transport <type>`    | Transport type for remote servers: `http` (default), `sse`               |
-| `--type <type>`             | Alias for `--transport`                                                  |
-| `-h, --header <header>`     | HTTP header for remote servers (repeatable, `Key: Value`)                |
-| `--bearer-token-env <name>` | Env var name fx sends as a bearer token (capability-gated, see below)    |
-| `--env <env>`               | Env var for local stdio servers (repeatable, `KEY=VALUE`)                |
-| `--timeout <ms>`            | Request timeout (ms) for remote servers (capability-gated, see below)    |
-| `--scopes <scopes>`         | OAuth scopes for remote servers, comma-separated (capability-gated)      |
-| `--oauth-scopes <scopes>`   | Alias for `--scopes`                                                     |
-| `--auto-approve`            | Auto-approve MCP tool calls for supported agents (Codex, Claude Code)    |
-| `--approve-tool <tool>`     | Tool to auto-approve with `--auto-approve` (repeatable; defaults to all) |
-| `-n, --name <name>`         | Server name (auto-inferred if not provided)                              |
-| `-y, --yes`                 | Skip all confirmation prompts                                            |
-| `--all`                     | Install to all agents                                                    |
-| `--gitignore`               | Add generated config files to `.gitignore`                               |
+| Option                      | Description                                                                  |
+| --------------------------- | ---------------------------------------------------------------------------- |
+| `-g, --global`              | Install to user directory instead of project                                 |
+| `-a, --agent <agent>`       | Target specific agents (e.g., `cursor`, `claude-code`). Can be repeated.     |
+| `-t, --transport <type>`    | Transport type for remote servers: `http` (default), `sse`                   |
+| `--type <type>`             | Alias for `--transport`                                                      |
+| `-h, --header <header>`     | HTTP header for remote servers (repeatable, `Key: Value`)                    |
+| `--bearer-token-env <name>` | Env var whose value fx sends as a bearer token (capability-gated, see below) |
+| `--env <env>`               | Env var for local stdio servers (repeatable, `KEY=VALUE`)                    |
+| `--timeout <ms>`            | Request timeout (ms) for remote servers (capability-gated, see below)        |
+| `--scopes <scopes>`         | OAuth scopes for remote servers, comma-separated (capability-gated)          |
+| `--oauth-scopes <scopes>`   | Alias for `--scopes`                                                         |
+| `--auto-approve`            | Auto-approve MCP tool calls for supported agents (Codex, Claude Code)        |
+| `--approve-tool <tool>`     | Tool to auto-approve with `--auto-approve` (repeatable; defaults to all)     |
+| `-n, --name <name>`         | Server name (auto-inferred if not provided)                                  |
+| `-y, --yes`                 | Skip all confirmation prompts                                                |
+| `--all`                     | Install to all agents                                                        |
+| `--gitignore`               | Add generated config files to `.gitignore`                                   |
 
 #### Capability-gated fields (`--timeout`, `--scopes`, `--bearer-token-env`)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "add-mcp",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Add MCP servers to your favorite coding agents with a single command.",
   "author": "Andre Landgraf <andre@neon.tech>",
   "license": "Apache-2.0",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "path";
 import { existsSync } from "fs";
 import type { AgentConfig, AgentType, McpServerConfig } from "./types.js";
 import { getLastSelectedAgents, saveSelectedAgents } from "./config.js";
+import { resolvedBearerTokenEnv } from "./schema.js";
 
 const home = homedir();
 const defaultGrokHome = join(home, ".grok");
@@ -448,8 +449,9 @@ function transformFxConfig(
   config: McpServerConfig,
 ): unknown {
   if (config.url) {
+    const bearerTokenEnv = resolvedBearerTokenEnv(config);
     const headers = config.headers
-      ? config.bearerTokenEnv
+      ? bearerTokenEnv
         ? headersWithoutAuthorization(config.headers)
         : config.headers
       : undefined;
@@ -468,8 +470,8 @@ function transformFxConfig(
     if (headers && Object.keys(headers).length > 0) {
       entry.headers = headers;
     }
-    if (config.bearerTokenEnv) {
-      entry.bearer_token_env = config.bearerTokenEnv;
+    if (bearerTokenEnv) {
+      entry.bearer_token_env = bearerTokenEnv;
     }
     return entry;
   }

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -421,6 +421,24 @@ function transformKiroCliConfig(
   return remoteConfig;
 }
 
+function headersWithoutAuthorization(
+  headers: Record<string, string>,
+): Record<string, string> {
+  const next: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    if (name.toLowerCase() !== "authorization") {
+      next[name] = value;
+    }
+  }
+  return next;
+}
+
+function hasAuthorizationHeader(headers: Record<string, string>): boolean {
+  return Object.keys(headers).some(
+    (name) => name.toLowerCase() === "authorization",
+  );
+}
+
 /**
  * fx accepts command/args/env, but `/mcp add` writes a command array with
  * `environment`: https://fx.sh/docs/capabilities/mcp
@@ -430,14 +448,15 @@ function transformFxConfig(
   config: McpServerConfig,
 ): unknown {
   if (config.url) {
-    if (
-      config.headers &&
-      Object.keys(config.headers).some(
-        (name) => name.toLowerCase() === "authorization",
-      )
-    ) {
+    const headers = config.headers
+      ? config.bearerTokenEnv
+        ? headersWithoutAuthorization(config.headers)
+        : config.headers
+      : undefined;
+
+    if (headers && hasAuthorizationHeader(headers)) {
       throw new Error(
-        "fx rejects a literal Authorization header. Use a non-Authorization header, or set bearer_token_env, header_env, or oauth in ~/.fx/mcp.json.",
+        "fx rejects a literal Authorization header. Pass --bearer-token-env <NAME>, use a non-Authorization header, or set header_env or oauth in ~/.fx/mcp.json.",
       );
     }
 
@@ -446,8 +465,11 @@ function transformFxConfig(
       url: config.url,
       enabled: true,
     };
-    if (config.headers && Object.keys(config.headers).length > 0) {
-      entry.headers = config.headers;
+    if (headers && Object.keys(headers).length > 0) {
+      entry.headers = headers;
+    }
+    if (config.bearerTokenEnv) {
+      entry.bearer_token_env = config.bearerTokenEnv;
     }
     return entry;
   }
@@ -807,7 +829,7 @@ export const agents: Record<AgentType, AgentConfig> = {
     configKey: "mcp",
     format: "json",
     supportedTransports: ["stdio", "http", "sse"],
-    supportedFields: [],
+    supportedFields: ["bearerTokenEnv"],
     detectGlobalInstall: async () => {
       return existsSync(join(home, ".fx"));
     },

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -458,7 +458,7 @@ function transformFxConfig(
 
     if (headers && hasAuthorizationHeader(headers)) {
       throw new Error(
-        "fx rejects a literal Authorization header. Pass --bearer-token-env <NAME>, use a non-Authorization header, or set header_env or oauth in ~/.fx/mcp.json.",
+        "fx rejects a literal Authorization header. Pass --bearer-token-env <name>, use a non-Authorization header, or set header_env or oauth in ~/.fx/mcp.json.",
       );
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1523,14 +1523,12 @@ async function main(target: string | undefined, options: Options) {
   if (options.bearerTokenEnv !== undefined) {
     const name = options.bearerTokenEnv.trim();
     if (name.length === 0) {
-      p.log.error(
-        "Invalid --bearer-token-env value. The name cannot be empty.",
-      );
+      p.log.error("Invalid --bearer-token-env. The name cannot be empty.");
       process.exit(1);
     }
     if (!isBearerTokenEnvName(name)) {
       p.log.error(
-        `--bearer-token-env takes an environment variable name, not a value. "${name}" is not a valid name.`,
+        `--bearer-token-env takes an environment variable name ([A-Za-z_][A-Za-z0-9_]*). "${name}" is not a valid name.`,
       );
       process.exit(1);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -471,7 +471,7 @@ program
   .option("--oauth-scopes <scopes>", "Alias for --scopes")
   .option(
     "--bearer-token-env <name>",
-    "Environment variable name whose value fx sends as a bearer token. Written as bearer_token_env for fx; dropped with a warning elsewhere.",
+    "Environment variable name whose value fx sends as a bearer token for remote servers. Written as bearer_token_env for fx; dropped with a warning elsewhere.",
   )
   .option(
     "--auto-approve",
@@ -1520,7 +1520,7 @@ async function main(target: string | undefined, options: Options) {
     const name = options.bearerTokenEnv.trim();
     if (name.length === 0) {
       p.log.error(
-        "Invalid --bearer-token-env value. Provide the environment variable name, not its value.",
+        "Invalid --bearer-token-env value. The name cannot be empty.",
       );
       process.exit(1);
     }
@@ -1899,6 +1899,19 @@ async function main(target: string | undefined, options: Options) {
       `${describeOptionalField(field)} is not supported by ${agentNames.join(", ")}; dropped from ${
         agentNames.length === 1 ? "that config" : "those configs"
       }.`,
+    );
+  }
+
+  if (
+    results.get("fx")?.success &&
+    resolvedBearerTokenEnv &&
+    serverConfig.headers &&
+    Object.keys(serverConfig.headers).some(
+      (name) => name.toLowerCase() === "authorization",
+    )
+  ) {
+    p.log.warn(
+      `Authorization header dropped from the fx config; fx reads the token from ${resolvedBearerTokenEnv}.`,
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,6 +164,7 @@ interface Options {
   oauthScopes?: string;
   autoApprove?: boolean;
   approveTool?: string[];
+  bearerTokenEnv?: string;
   yes?: boolean;
   all?: boolean;
   gitignore?: boolean;
@@ -468,6 +469,10 @@ program
     "OAuth scopes to request for remote servers (comma-separated). Only applied to agents that support it (e.g. Cursor, Gemini CLI); dropped with a warning elsewhere.",
   )
   .option("--oauth-scopes <scopes>", "Alias for --scopes")
+  .option(
+    "--bearer-token-env <name>",
+    "Environment variable name whose value fx sends as a bearer token. Written as bearer_token_env for fx; dropped with a warning elsewhere.",
+  )
   .option(
     "--auto-approve",
     "Auto-approve MCP tool calls for agents that support it (Codex, Claude Code). Dropped with a warning for other agents.",
@@ -1510,6 +1515,22 @@ async function main(target: string | undefined, options: Options) {
   const autoApproveTools =
     options.autoApprove || approveTools.length > 0 ? approveTools : undefined;
 
+  let resolvedBearerTokenEnv: string | undefined;
+  if (options.bearerTokenEnv !== undefined) {
+    const name = options.bearerTokenEnv.trim();
+    if (name.length === 0) {
+      p.log.error(
+        "Invalid --bearer-token-env value. Provide the environment variable name, not its value.",
+      );
+      process.exit(1);
+    }
+    if (isRemote) {
+      resolvedBearerTokenEnv = name;
+    } else {
+      p.log.warn("--bearer-token-env is only used for remote URLs, ignoring");
+    }
+  }
+
   // Build server config
   const serverConfig = buildServerConfig(parsed, {
     transport: resolvedTransport,
@@ -1525,6 +1546,7 @@ async function main(target: string | undefined, options: Options) {
     timeout: resolvedTimeout,
     oauthScopes: resolvedScopes,
     autoApproveTools,
+    bearerTokenEnv: resolvedBearerTokenEnv,
   });
 
   // Determine target agents

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,11 @@ import {
   resolveArrayTemplates,
   resolveRecordTemplates,
 } from "./template.js";
-import { describeOptionalField, type OptionalField } from "./schema.js";
+import {
+  describeOptionalField,
+  isBearerTokenEnvName,
+  type OptionalField,
+} from "./schema.js";
 
 import packageJson from "../package.json" with { type: "json" };
 
@@ -1521,6 +1525,12 @@ async function main(target: string | undefined, options: Options) {
     if (name.length === 0) {
       p.log.error(
         "Invalid --bearer-token-env value. The name cannot be empty.",
+      );
+      process.exit(1);
+    }
+    if (!isBearerTokenEnvName(name)) {
+      p.log.error(
+        `--bearer-token-env takes an environment variable name, not a value. "${name}" is not a valid name.`,
       );
       process.exit(1);
     }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -17,7 +17,11 @@ import type {
 import { agents } from "./agents.js";
 import { writeConfig, buildConfigWithKey } from "./formats/index.js";
 import { looksLikePath } from "./source-parser.js";
-import { applyFieldSupport, type OptionalField } from "./schema.js";
+import {
+  applyFieldSupport,
+  INVALID_BEARER_TOKEN_ENV,
+  type OptionalField,
+} from "./schema.js";
 
 const home = homedir();
 
@@ -70,7 +74,6 @@ export interface BuildServerConfigOptions {
    * "all tools". Applies to remote and local servers alike.
    */
   autoApproveTools?: string[];
-  /** Remote-only; fx maps this environment variable to `bearer_token_env`. */
   bearerTokenEnv?: string;
 }
 
@@ -371,6 +374,17 @@ export function installServerForAgent(
   const configPath = getConfigPath(agent, options);
 
   try {
+    if (
+      typeof serverConfig.bearerTokenEnv === "string" &&
+      serverConfig.bearerTokenEnv.trim().length === 0
+    ) {
+      return {
+        success: false,
+        path: configPath,
+        error: INVALID_BEARER_TOKEN_ENV,
+      };
+    }
+
     // Strip optional fields the agent can't represent, then transform the
     // gated config into the agent's native schema. Because every transform
     // builds a fresh object with only known keys, unsupported fields can never

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -19,7 +19,8 @@ import { writeConfig, buildConfigWithKey } from "./formats/index.js";
 import { looksLikePath } from "./source-parser.js";
 import {
   applyFieldSupport,
-  INVALID_BEARER_TOKEN_ENV,
+  invalidBearerTokenEnvMessage,
+  isBearerTokenEnvName,
   type OptionalField,
 } from "./schema.js";
 
@@ -374,15 +375,15 @@ export function installServerForAgent(
   const configPath = getConfigPath(agent, options);
 
   try {
-    if (
-      typeof serverConfig.bearerTokenEnv === "string" &&
-      serverConfig.bearerTokenEnv.trim().length === 0
-    ) {
-      return {
-        success: false,
-        path: configPath,
-        error: INVALID_BEARER_TOKEN_ENV,
-      };
+    if (typeof serverConfig.bearerTokenEnv === "string") {
+      const name = serverConfig.bearerTokenEnv.trim();
+      if (!isBearerTokenEnvName(name)) {
+        return {
+          success: false,
+          path: configPath,
+          error: invalidBearerTokenEnvMessage(serverConfig.bearerTokenEnv),
+        };
+      }
     }
 
     // Strip optional fields the agent can't represent, then transform the

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -70,6 +70,8 @@ export interface BuildServerConfigOptions {
    * "all tools". Applies to remote and local servers alike.
    */
   autoApproveTools?: string[];
+  /** Remote-only; fx maps this environment variable to `bearer_token_env`. */
+  bearerTokenEnv?: string;
 }
 
 export interface UpdateGitignoreOptions {
@@ -106,6 +108,13 @@ export function buildServerConfig(
 
     if (options.autoApproveTools) {
       config.autoApproveTools = options.autoApproveTools;
+    }
+
+    if (typeof options.bearerTokenEnv === "string") {
+      const name = options.bearerTokenEnv.trim();
+      if (name.length > 0) {
+        config.bearerTokenEnv = name;
+      }
     }
 
     return config;

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -51,13 +51,19 @@ const OPTIONAL_FIELD_SPECS: Record<OptionalField, OptionalFieldSpec> = {
     },
   },
   bearerTokenEnv: {
-    label: "bearer token env",
+    label: "bearer token env var",
     isSet: (config) => resolvedBearerTokenEnv(config) !== undefined,
     clear: (config) => {
       delete config.bearerTokenEnv;
     },
   },
 };
+
+const BEARER_TOKEN_ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export function isBearerTokenEnvName(name: string): boolean {
+  return BEARER_TOKEN_ENV_NAME.test(name);
+}
 
 export function resolvedBearerTokenEnv(
   config: McpServerConfig,
@@ -66,11 +72,16 @@ export function resolvedBearerTokenEnv(
     return undefined;
   }
   const name = config.bearerTokenEnv.trim();
-  return name.length > 0 ? name : undefined;
+  return isBearerTokenEnvName(name) ? name : undefined;
 }
 
-export const INVALID_BEARER_TOKEN_ENV =
-  "Invalid bearerTokenEnv. The name cannot be empty.";
+export function invalidBearerTokenEnvMessage(value: string): string {
+  const name = value.trim();
+  if (name.length === 0) {
+    return "Invalid bearerTokenEnv. The name cannot be empty.";
+  }
+  return `Invalid bearerTokenEnv. "${name}" is not an environment variable name.`;
+}
 
 const ALL_OPTIONAL_FIELDS = Object.keys(
   OPTIONAL_FIELD_SPECS,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -70,7 +70,7 @@ export function resolvedBearerTokenEnv(
 }
 
 export const INVALID_BEARER_TOKEN_ENV =
-  "Invalid bearerTokenEnv. Provide the environment variable name, not its value.";
+  "Invalid bearerTokenEnv. The name cannot be empty.";
 
 const ALL_OPTIONAL_FIELDS = Object.keys(
   OPTIONAL_FIELD_SPECS,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -10,7 +10,11 @@ import type { McpServerConfig } from "./types.js";
  * before its transform runs, guaranteeing that only known fields are ever
  * written to a client config.
  */
-export type OptionalField = "timeout" | "scopes" | "autoApprove";
+export type OptionalField =
+  | "timeout"
+  | "scopes"
+  | "autoApprove"
+  | "bearerTokenEnv";
 
 interface OptionalFieldSpec {
   /** Human-friendly label used in user-facing "dropped" warnings. */
@@ -44,6 +48,15 @@ const OPTIONAL_FIELD_SPECS: Record<OptionalField, OptionalFieldSpec> = {
     isSet: (config) => Array.isArray(config.autoApproveTools),
     clear: (config) => {
       delete config.autoApproveTools;
+    },
+  },
+  bearerTokenEnv: {
+    label: "bearer token env",
+    isSet: (config) =>
+      typeof config.bearerTokenEnv === "string" &&
+      config.bearerTokenEnv.trim().length > 0,
+    clear: (config) => {
+      delete config.bearerTokenEnv;
     },
   },
 };

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -80,7 +80,7 @@ export function invalidBearerTokenEnvMessage(value: string): string {
   if (name.length === 0) {
     return "Invalid bearerTokenEnv. The name cannot be empty.";
   }
-  return `Invalid bearerTokenEnv. "${name}" is not an environment variable name.`;
+  return `Invalid bearerTokenEnv. "${name}" is not an environment variable name ([A-Za-z_][A-Za-z0-9_]*).`;
 }
 
 const ALL_OPTIONAL_FIELDS = Object.keys(

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -52,14 +52,25 @@ const OPTIONAL_FIELD_SPECS: Record<OptionalField, OptionalFieldSpec> = {
   },
   bearerTokenEnv: {
     label: "bearer token env",
-    isSet: (config) =>
-      typeof config.bearerTokenEnv === "string" &&
-      config.bearerTokenEnv.trim().length > 0,
+    isSet: (config) => resolvedBearerTokenEnv(config) !== undefined,
     clear: (config) => {
       delete config.bearerTokenEnv;
     },
   },
 };
+
+export function resolvedBearerTokenEnv(
+  config: McpServerConfig,
+): string | undefined {
+  if (typeof config.bearerTokenEnv !== "string") {
+    return undefined;
+  }
+  const name = config.bearerTokenEnv.trim();
+  return name.length > 0 ? name : undefined;
+}
+
+export const INVALID_BEARER_TOKEN_ENV =
+  "Invalid bearerTokenEnv. Provide the environment variable name, not its value.";
 
 const ALL_OPTIONAL_FIELDS = Object.keys(
   OPTIONAL_FIELD_SPECS,
@@ -95,6 +106,15 @@ export function applyFieldSupport(
   // caller's nested objects/arrays.
   if (copy.oauthScopes) copy.oauthScopes = [...copy.oauthScopes];
   if (copy.autoApproveTools) copy.autoApproveTools = [...copy.autoApproveTools];
+
+  if (typeof copy.bearerTokenEnv === "string") {
+    const name = resolvedBearerTokenEnv(copy);
+    if (name) {
+      copy.bearerTokenEnv = name;
+    } else {
+      delete copy.bearerTokenEnv;
+    }
+  }
 
   const dropped: OptionalField[] = [];
   for (const field of ALL_OPTIONAL_FIELDS) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,7 +127,6 @@ export interface McpServerConfig {
    * separate settings file). It is never written into a server entry verbatim.
    */
   autoApproveTools?: string[];
-  /** Remote-only; fx maps this environment variable to `bearer_token_env`. */
   bearerTokenEnv?: string;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,6 +127,8 @@ export interface McpServerConfig {
    * separate settings file). It is never written into a server entry verbatim.
    */
   autoApproveTools?: string[];
+  /** Remote-only; fx maps this environment variable to `bearer_token_env`. */
+  bearerTokenEnv?: string;
 }
 
 export interface ConfigFile {

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -145,7 +145,7 @@ test("supportedFields reflects per-client capabilities", () => {
   // Clients with no extra field support declare an empty list.
   assert.deepStrictEqual(agents.vscode.supportedFields, []);
   assert.deepStrictEqual(agents["claude-desktop"].supportedFields, []);
-  assert.deepStrictEqual(agents.fx.supportedFields, []);
+  assert.deepStrictEqual(agents.fx.supportedFields, ["bearerTokenEnv"]);
 });
 
 // ============================================

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -622,7 +622,7 @@ test("E2E CLI: mixed fx then cursor keeps Authorization on Cursor and bearer_tok
   }
 
   const output = `${result.stdout}\n${result.stderr}`;
-  assert.match(output, /bearer token env is not supported by Cursor/);
+  assert.match(output, /bearer token env var is not supported by Cursor/);
   assert.match(
     output,
     /Authorization header dropped from the fx config; fx reads the token from NEON_API_KEY/,
@@ -644,6 +644,31 @@ test("E2E CLI: mixed fx then cursor keeps Authorization on Cursor and bearer_tok
   assert.deepStrictEqual(cursorServer.headers, {
     Authorization: "Bearer token",
   });
+});
+
+test("E2E CLI: --bearer-token-env rejects a value in place of a name", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "https://mcp.example.com/mcp",
+      "-a",
+      "fx",
+      "-y",
+      "--header",
+      "Authorization: Bearer token",
+      "--bearer-token-env",
+      "Bearer sk-live",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.notStrictEqual(result.status, 0);
+  assert.match(output, /not a valid name/);
+  assert.strictEqual(existsSync(join(homeDir, ".fx")), false);
 });
 
 test("E2E CLI: whitespace-only --bearer-token-env fails", () => {

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -558,6 +558,150 @@ test("E2E CLI: fx remote install writes ~/.fx/mcp.json without -g", () => {
   });
 });
 
+test("E2E CLI: fx writes bearer_token_env", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "https://mcp.example.com/mcp",
+      "-a",
+      "fx",
+      "-y",
+      "--name",
+      "example",
+      "--bearer-token-env",
+      "NEON_API_KEY",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const saved = JSON.parse(
+    readFileSync(join(homeDir, ".fx", "mcp.json"), "utf-8"),
+  ) as { mcp: Record<string, Record<string, unknown>> };
+  const server = saved.mcp.example;
+  assert.ok(server);
+  assert.strictEqual(server.bearer_token_env, "NEON_API_KEY");
+  assert.strictEqual("headers" in server, false);
+});
+
+test("E2E CLI: mixed fx then cursor keeps Authorization on Cursor and bearer_token_env on fx", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "https://mcp.example.com/mcp",
+      "-a",
+      "fx",
+      "-a",
+      "cursor",
+      "-y",
+      "--name",
+      "example",
+      "--header",
+      "Authorization: Bearer token",
+      "--bearer-token-env",
+      "NEON_API_KEY",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.match(output, /bearer token env is not supported by Cursor/);
+
+  const fxSaved = JSON.parse(
+    readFileSync(join(homeDir, ".fx", "mcp.json"), "utf-8"),
+  ) as { mcp: Record<string, Record<string, unknown>> };
+  const fxServer = fxSaved.mcp.example;
+  assert.ok(fxServer);
+  assert.strictEqual(fxServer.bearer_token_env, "NEON_API_KEY");
+  assert.strictEqual("headers" in fxServer, false);
+
+  const cursorSaved = JSON.parse(
+    readFileSync(join(homeDir, ".cursor", "mcp.json"), "utf-8"),
+  ) as { mcpServers: Record<string, Record<string, unknown>> };
+  const cursorServer = cursorSaved.mcpServers.example;
+  assert.ok(cursorServer);
+  assert.deepStrictEqual(cursorServer.headers, {
+    Authorization: "Bearer token",
+  });
+});
+
+test("E2E CLI: whitespace-only --bearer-token-env fails", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "https://mcp.example.com/mcp",
+      "-a",
+      "fx",
+      "-y",
+      "--bearer-token-env",
+      "   ",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.notStrictEqual(result.status, 0);
+  assert.match(output, /Invalid --bearer-token-env/);
+  assert.strictEqual(existsSync(join(homeDir, ".fx")), false);
+});
+
+test("E2E CLI: --bearer-token-env is ignored for stdio installs", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "mcp-server-postgres",
+      "-a",
+      "fx",
+      "-y",
+      "--name",
+      "postgres",
+      "--bearer-token-env",
+      "NEON_API_KEY",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const output = `${result.stdout}\n${result.stderr}`;
+  assert.match(output, /--bearer-token-env is only used for remote URLs/);
+
+  const saved = JSON.parse(
+    readFileSync(join(homeDir, ".fx", "mcp.json"), "utf-8"),
+  ) as { mcp: Record<string, Record<string, unknown>> };
+  const server = saved.mcp.postgres;
+  assert.ok(server);
+  assert.strictEqual(server.type, "local");
+  assert.strictEqual("bearer_token_env" in server, false);
+});
+
 test("E2E CLI: fx rejects a literal Authorization header", () => {
   const projectDir = createTempDir();
   const homeDir = createTempDir();
@@ -579,7 +723,7 @@ test("E2E CLI: fx rejects a literal Authorization header", () => {
 
   const output = `${result.stdout}\n${result.stderr}`;
   assert.match(output, /literal Authorization header/);
-  assert.match(output, /bearer_token_env, header_env, or oauth/);
+  assert.match(output, /--bearer-token-env/);
   assert.strictEqual(existsSync(join(homeDir, ".fx")), false);
 });
 

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -623,6 +623,10 @@ test("E2E CLI: mixed fx then cursor keeps Authorization on Cursor and bearer_tok
 
   const output = `${result.stdout}\n${result.stderr}`;
   assert.match(output, /bearer token env is not supported by Cursor/);
+  assert.match(
+    output,
+    /Authorization header dropped from the fx config; fx reads the token from NEON_API_KEY/,
+  );
 
   const fxSaved = JSON.parse(
     readFileSync(join(homeDir, ".fx", "mcp.json"), "utf-8"),

--- a/tests/e2e/install.test.ts
+++ b/tests/e2e/install.test.ts
@@ -28,6 +28,7 @@ import {
   installServerForAgent,
 } from "../../src/installer.js";
 import { agents } from "../../src/agents.js";
+import { applyFieldSupport } from "../../src/schema.js";
 import { writeConfig, buildConfigWithKey } from "../../src/formats/index.js";
 import type { AgentType } from "../../src/types.js";
 
@@ -1529,8 +1530,50 @@ test("E2E: fx remote transform rejects a literal Authorization header", () => {
 
   assert.throws(
     () => agents.fx.transformConfig("example", config),
-    /bearer_token_env, header_env, or oauth/,
+    /--bearer-token-env/,
   );
+});
+
+test("E2E: fx remote transform writes bearer_token_env and drops mixed-case Authorization", () => {
+  const headers = {
+    authorization: "Bearer token",
+    "X-Workspace": "demo",
+  };
+  const config = buildServerConfig(parseSource("https://mcp.example.com/mcp"), {
+    headers,
+    bearerTokenEnv: "  NEON_API_KEY  ",
+  });
+  const transformed = agents.fx.transformConfig("example", config) as Record<
+    string,
+    unknown
+  >;
+
+  assert.strictEqual(transformed.bearer_token_env, "NEON_API_KEY");
+  assert.deepStrictEqual(transformed.headers, { "X-Workspace": "demo" });
+  assert.strictEqual(headers.authorization, "Bearer token");
+});
+
+test("E2E: Cursor keeps Authorization after an fx transform on the same config", () => {
+  const headers = { authorization: "Bearer token" };
+  const config = buildServerConfig(parseSource("https://mcp.example.com/mcp"), {
+    headers,
+    bearerTokenEnv: "NEON_API_KEY",
+  });
+
+  const fxGated = applyFieldSupport(config, agents.fx.supportedFields);
+  agents.fx.transformConfig("example", fxGated.config);
+
+  const cursorGated = applyFieldSupport(config, agents.cursor.supportedFields);
+  const cursorEntry = agents.cursor.transformConfig(
+    "example",
+    cursorGated.config,
+  ) as Record<string, unknown>;
+
+  assert.deepStrictEqual(cursorEntry.headers, {
+    authorization: "Bearer token",
+  });
+  assert.deepStrictEqual(cursorGated.dropped, ["bearerTokenEnv"]);
+  assert.strictEqual(headers.authorization, "Bearer token");
 });
 
 test("E2E: fx is global-only and writes ~/.fx/mcp.json", () => {

--- a/tests/e2e/install.test.ts
+++ b/tests/e2e/install.test.ts
@@ -28,7 +28,6 @@ import {
   installServerForAgent,
 } from "../../src/installer.js";
 import { agents } from "../../src/agents.js";
-import { applyFieldSupport } from "../../src/schema.js";
 import { writeConfig, buildConfigWithKey } from "../../src/formats/index.js";
 import type { AgentType } from "../../src/types.js";
 
@@ -1532,48 +1531,6 @@ test("E2E: fx remote transform rejects a literal Authorization header", () => {
     () => agents.fx.transformConfig("example", config),
     /--bearer-token-env/,
   );
-});
-
-test("E2E: fx remote transform writes bearer_token_env and drops mixed-case Authorization", () => {
-  const headers = {
-    authorization: "Bearer token",
-    "X-Workspace": "demo",
-  };
-  const config = buildServerConfig(parseSource("https://mcp.example.com/mcp"), {
-    headers,
-    bearerTokenEnv: "  NEON_API_KEY  ",
-  });
-  const transformed = agents.fx.transformConfig("example", config) as Record<
-    string,
-    unknown
-  >;
-
-  assert.strictEqual(transformed.bearer_token_env, "NEON_API_KEY");
-  assert.deepStrictEqual(transformed.headers, { "X-Workspace": "demo" });
-  assert.strictEqual(headers.authorization, "Bearer token");
-});
-
-test("E2E: Cursor keeps Authorization after an fx transform on the same config", () => {
-  const headers = { authorization: "Bearer token" };
-  const config = buildServerConfig(parseSource("https://mcp.example.com/mcp"), {
-    headers,
-    bearerTokenEnv: "NEON_API_KEY",
-  });
-
-  const fxGated = applyFieldSupport(config, agents.fx.supportedFields);
-  agents.fx.transformConfig("example", fxGated.config);
-
-  const cursorGated = applyFieldSupport(config, agents.cursor.supportedFields);
-  const cursorEntry = agents.cursor.transformConfig(
-    "example",
-    cursorGated.config,
-  ) as Record<string, unknown>;
-
-  assert.deepStrictEqual(cursorEntry.headers, {
-    authorization: "Bearer token",
-  });
-  assert.deepStrictEqual(cursorGated.dropped, ["bearerTokenEnv"]);
-  assert.strictEqual(headers.authorization, "Bearer token");
 });
 
 test("E2E: fx is global-only and writes ~/.fx/mcp.json", () => {

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -565,6 +565,28 @@ test("applyFieldSupport - keeps bearerTokenEnv when supported", () => {
   assert.deepStrictEqual(dropped, []);
 });
 
+test("applyFieldSupport - trims padded bearerTokenEnv and clears whitespace-only", () => {
+  const padded = {
+    type: "http" as const,
+    url: "https://mcp.example.com/mcp",
+    bearerTokenEnv: "  NEON_API_KEY  ",
+  };
+  const kept = applyFieldSupport(padded, ["bearerTokenEnv"]);
+  assert.strictEqual(kept.config.bearerTokenEnv, "NEON_API_KEY");
+  assert.deepStrictEqual(kept.dropped, []);
+  assert.strictEqual(padded.bearerTokenEnv, "  NEON_API_KEY  ");
+
+  const whitespace = {
+    type: "http" as const,
+    url: "https://mcp.example.com/mcp",
+    bearerTokenEnv: "   ",
+  };
+  const cleared = applyFieldSupport(whitespace, []);
+  assert.strictEqual(cleared.config.bearerTokenEnv, undefined);
+  assert.deepStrictEqual(cleared.dropped, []);
+  assert.strictEqual(whitespace.bearerTokenEnv, "   ");
+});
+
 test("fx drops Authorization when bearerTokenEnv is set; Cursor keeps the shared header object intact", () => {
   const headers = {
     authorization: "Bearer token",
@@ -593,6 +615,24 @@ test("fx drops Authorization when bearerTokenEnv is set; Cursor keeps the shared
   assert.deepStrictEqual(cursorEntry.headers, headers);
   assert.deepStrictEqual(cursorGated.dropped, ["bearerTokenEnv"]);
   assert.strictEqual(headers.authorization, "Bearer token");
+});
+
+test("fx does not drop Authorization for whitespace-only bearerTokenEnv", () => {
+  const headers = { Authorization: "Bearer token" };
+  const config = {
+    type: "http" as const,
+    url: "https://mcp.example.com/mcp",
+    headers,
+    bearerTokenEnv: "   ",
+  };
+
+  const gated = applyFieldSupport(config, agents.fx.supportedFields);
+  assert.strictEqual(gated.config.bearerTokenEnv, undefined);
+  assert.throws(
+    () => agents.fx.transformConfig("example", gated.config),
+    /literal Authorization header/,
+  );
+  assert.strictEqual(headers.Authorization, "Bearer token");
 });
 
 test("installServerForAgent - Codex auto-approve selected tools writes per-tool approval", () => {

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -617,6 +617,24 @@ test("fx drops Authorization when bearerTokenEnv is set; Cursor keeps the shared
   assert.strictEqual(headers.authorization, "Bearer token");
 });
 
+test("fx does not drop Authorization for a bearerTokenEnv that is not an env var name", () => {
+  const headers = { Authorization: "Bearer token" };
+  const config = {
+    type: "http" as const,
+    url: "https://mcp.example.com/mcp",
+    headers,
+    bearerTokenEnv: "Bearer sk-live",
+  };
+
+  const gated = applyFieldSupport(config, agents.fx.supportedFields);
+  assert.strictEqual(gated.config.bearerTokenEnv, undefined);
+  assert.throws(
+    () => agents.fx.transformConfig("example", gated.config),
+    /literal Authorization header/,
+  );
+  assert.strictEqual(headers.Authorization, "Bearer token");
+});
+
 test("fx does not drop Authorization for whitespace-only bearerTokenEnv", () => {
   const headers = { Authorization: "Bearer token" };
   const config = {

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -540,6 +540,61 @@ test("applyFieldSupport - autoApprove dropped (and reported) when unsupported, i
   assert.deepStrictEqual(original.autoApproveTools, ["run"]);
 });
 
+test("applyFieldSupport - drops bearerTokenEnv when unsupported", () => {
+  const original = {
+    type: "http" as const,
+    url: "https://mcp.example.com/mcp",
+    bearerTokenEnv: "NEON_API_KEY",
+  };
+  const { config, dropped } = applyFieldSupport(original, []);
+  assert.strictEqual(config.bearerTokenEnv, undefined);
+  assert.deepStrictEqual(dropped, ["bearerTokenEnv"]);
+  assert.strictEqual(original.bearerTokenEnv, "NEON_API_KEY");
+});
+
+test("applyFieldSupport - keeps bearerTokenEnv when supported", () => {
+  const { config, dropped } = applyFieldSupport(
+    {
+      type: "http",
+      url: "https://mcp.example.com/mcp",
+      bearerTokenEnv: "NEON_API_KEY",
+    },
+    ["bearerTokenEnv"],
+  );
+  assert.strictEqual(config.bearerTokenEnv, "NEON_API_KEY");
+  assert.deepStrictEqual(dropped, []);
+});
+
+test("fx drops Authorization when bearerTokenEnv is set; Cursor keeps the shared header object intact", () => {
+  const headers = {
+    authorization: "Bearer token",
+    "X-Workspace": "demo",
+  };
+  const config = {
+    type: "http" as const,
+    url: "https://mcp.example.com/mcp",
+    headers,
+    bearerTokenEnv: "NEON_API_KEY",
+  };
+
+  const fxGated = applyFieldSupport(config, agents.fx.supportedFields);
+  const fxEntry = agents.fx.transformConfig(
+    "example",
+    fxGated.config,
+  ) as Record<string, unknown>;
+  const cursorGated = applyFieldSupport(config, agents.cursor.supportedFields);
+  const cursorEntry = agents.cursor.transformConfig(
+    "example",
+    cursorGated.config,
+  ) as Record<string, unknown>;
+
+  assert.strictEqual(fxEntry.bearer_token_env, "NEON_API_KEY");
+  assert.deepStrictEqual(fxEntry.headers, { "X-Workspace": "demo" });
+  assert.deepStrictEqual(cursorEntry.headers, headers);
+  assert.deepStrictEqual(cursorGated.dropped, ["bearerTokenEnv"]);
+  assert.strictEqual(headers.authorization, "Bearer token");
+});
+
 test("installServerForAgent - Codex auto-approve selected tools writes per-tool approval", () => {
   const tempDir = createTempDir();
   const config = buildServerConfig(parseSource("executor mcp"), {

--- a/tests/lib.test.ts
+++ b/tests/lib.test.ts
@@ -26,7 +26,7 @@ import {
   getAgentTypes,
   type McpServerConfig,
 } from "../src/lib.js";
-import { INVALID_BEARER_TOKEN_ENV } from "../src/schema.js";
+import { invalidBearerTokenEnvMessage } from "../src/schema.js";
 
 const remote = (url: string): McpServerConfig => ({ type: "http", url });
 const pkg = (name: string): McpServerConfig => ({
@@ -297,7 +297,29 @@ await test("upsertServer rejects whitespace-only bearerTokenEnv and writes nothi
   );
 
   assert.strictEqual(result.success, false);
-  assert.strictEqual(result.error, INVALID_BEARER_TOKEN_ENV);
+  assert.strictEqual(result.error, invalidBearerTokenEnvMessage("   "));
+  assert.strictEqual(existsSync(join(dir, ".vscode", "mcp.json")), false);
+});
+
+await test("upsertServer rejects a bearerTokenEnv that is not an env var name", () => {
+  const dir = createTempDir();
+  const result = upsertServer(
+    "github-copilot-cli",
+    "example",
+    {
+      type: "http",
+      url: "https://mcp.example.com/mcp",
+      headers: { Authorization: "Bearer token" },
+      bearerTokenEnv: "Bearer sk-live",
+    },
+    { local: true, cwd: dir },
+  );
+
+  assert.strictEqual(result.success, false);
+  assert.strictEqual(
+    result.error,
+    invalidBearerTokenEnvMessage("Bearer sk-live"),
+  );
   assert.strictEqual(existsSync(join(dir, ".vscode", "mcp.json")), false);
 });
 

--- a/tests/lib.test.ts
+++ b/tests/lib.test.ts
@@ -26,6 +26,7 @@ import {
   getAgentTypes,
   type McpServerConfig,
 } from "../src/lib.js";
+import { INVALID_BEARER_TOKEN_ENV } from "../src/schema.js";
 
 const remote = (url: string): McpServerConfig => ({ type: "http", url });
 const pkg = (name: string): McpServerConfig => ({
@@ -253,6 +254,51 @@ await test("upsertServer + removeServer reject local: true for global-only agent
   });
   assert.strictEqual(fxUpsert.success, false);
   assert.ok(fxUpsert.error?.includes("does not support project-level"));
+});
+
+await test("upsertServer trims padded bearerTokenEnv and does not leak it to an unsupported local agent", () => {
+  const dir = createTempDir();
+  const result = upsertServer(
+    "github-copilot-cli",
+    "example",
+    {
+      type: "http",
+      url: "https://mcp.example.com/mcp",
+      headers: { Authorization: "Bearer token" },
+      bearerTokenEnv: "  NEON_API_KEY  ",
+    },
+    { local: true, cwd: dir },
+  );
+
+  assert.ok(result.success, result.error);
+  assert.deepStrictEqual(result.droppedFields, ["bearerTokenEnv"]);
+
+  const written = readJson(join(dir, ".vscode", "mcp.json"));
+  const server = (written.servers as Record<string, Record<string, unknown>>)
+    .example;
+  assert.ok(server);
+  assert.strictEqual("bearerTokenEnv" in server, false);
+  assert.strictEqual("bearer_token_env" in server, false);
+  assert.deepStrictEqual(server.headers, { Authorization: "Bearer token" });
+});
+
+await test("upsertServer rejects whitespace-only bearerTokenEnv and writes nothing", () => {
+  const dir = createTempDir();
+  const result = upsertServer(
+    "github-copilot-cli",
+    "example",
+    {
+      type: "http",
+      url: "https://mcp.example.com/mcp",
+      headers: { Authorization: "Bearer token" },
+      bearerTokenEnv: "   ",
+    },
+    { local: true, cwd: dir },
+  );
+
+  assert.strictEqual(result.success, false);
+  assert.strictEqual(result.error, INVALID_BEARER_TOKEN_ENV);
+  assert.strictEqual(existsSync(join(dir, ".vscode", "mcp.json")), false);
 });
 
 await test("upsertServer + removeServer honor github-copilot-cli local `servers` key", () => {

--- a/web/content/docs/02-cli/01-add.mdx
+++ b/web/content/docs/02-cli/01-add.mdx
@@ -21,7 +21,6 @@ npx add-mcp https://mcp.example.com/sse --transport sse
 # Remote server with an auth header
 npx add-mcp https://mcp.example.com/mcp --header 'Authorization: Bearer ${TOKEN}'
 
-# Remote server whose bearer token lives in an environment variable (fx)
 npx add-mcp https://mcp.example.com/mcp --bearer-token-env NEON_API_KEY
 
 # Remote server with a request timeout and OAuth scopes (capability-gated)

--- a/web/content/docs/02-cli/01-add.mdx
+++ b/web/content/docs/02-cli/01-add.mdx
@@ -21,6 +21,9 @@ npx add-mcp https://mcp.example.com/sse --transport sse
 # Remote server with an auth header
 npx add-mcp https://mcp.example.com/mcp --header 'Authorization: Bearer ${TOKEN}'
 
+# Remote server whose bearer token lives in an environment variable (fx)
+npx add-mcp https://mcp.example.com/mcp --bearer-token-env NEON_API_KEY
+
 # Remote server with a request timeout and OAuth scopes (capability-gated)
 npx add-mcp https://mcp.example.com/mcp --timeout 30000 --scopes "read,write"
 
@@ -45,24 +48,25 @@ npx add-mcp https://mcp.example.com/mcp -g -a claude-code -y
 
 ## Options
 
-| Option                    | Description                                                              |
-| ------------------------- | ------------------------------------------------------------------------ |
-| `-g, --global`            | Install to user directory instead of project                             |
-| `-a, --agent <agent>`     | Target specific agents (e.g. `cursor`, `claude-code`). Repeatable.       |
-| `-t, --transport <type>`  | Transport type for remote servers: `http` (default), `sse`               |
-| `--type <type>`           | Alias for `--transport`                                                  |
-| `-h, --header <header>`   | HTTP header for remote servers (repeatable, `Key: Value`)                |
-| `--env <env>`             | Env var for local stdio servers (repeatable, `KEY=VALUE`)                |
-| `--args <args>`           | Arguments for local stdio servers                                        |
-| `--timeout <ms>`          | Request timeout (ms) for remote servers (capability-gated)               |
-| `--scopes <scopes>`       | OAuth scopes for remote servers, comma-separated (capability-gated)      |
-| `--oauth-scopes <scopes>` | Alias for `--scopes`                                                     |
-| `--auto-approve`          | Auto-approve MCP tool calls for supported agents (Codex, Claude Code)    |
-| `--approve-tool <tool>`   | Tool to auto-approve with `--auto-approve` (repeatable; defaults to all) |
-| `-n, --name <name>`       | Server name (auto-inferred if not provided)                              |
-| `-y, --yes`               | Skip all confirmation prompts                                            |
-| `--all`                   | Install to all agents                                                    |
-| `--gitignore`             | Add generated config files to `.gitignore`                               |
+| Option                      | Description                                                              |
+| --------------------------- | ------------------------------------------------------------------------ |
+| `-g, --global`              | Install to user directory instead of project                             |
+| `-a, --agent <agent>`       | Target specific agents (e.g. `cursor`, `claude-code`). Repeatable.       |
+| `-t, --transport <type>`    | Transport type for remote servers: `http` (default), `sse`               |
+| `--type <type>`             | Alias for `--transport`                                                  |
+| `-h, --header <header>`     | HTTP header for remote servers (repeatable, `Key: Value`)                |
+| `--bearer-token-env <name>` | Env var name fx sends as a bearer token (capability-gated)               |
+| `--env <env>`               | Env var for local stdio servers (repeatable, `KEY=VALUE`)                |
+| `--args <args>`             | Arguments for local stdio servers                                        |
+| `--timeout <ms>`            | Request timeout (ms) for remote servers (capability-gated)               |
+| `--scopes <scopes>`         | OAuth scopes for remote servers, comma-separated (capability-gated)      |
+| `--oauth-scopes <scopes>`   | Alias for `--scopes`                                                     |
+| `--auto-approve`            | Auto-approve MCP tool calls for supported agents (Codex, Claude Code)    |
+| `--approve-tool <tool>`     | Tool to auto-approve with `--auto-approve` (repeatable; defaults to all) |
+| `-n, --name <name>`         | Server name (auto-inferred if not provided)                              |
+| `-y, --yes`                 | Skip all confirmation prompts                                            |
+| `--all`                     | Install to all agents                                                    |
+| `--gitignore`               | Add generated config files to `.gitignore`                               |
 
 ## Transports
 
@@ -81,9 +85,10 @@ Not every MCP client understands every field. add-mcp keeps one canonical server
 | ------------------ | ----------------------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
 | Timeout            | `--timeout`                         | Claude Code, Gemini CLI, Grok Build, Kilo Code, Kimi Code, Kiro CLI | `timeout` (milliseconds); Grok Build `tool_timeout_sec` (seconds), Kimi Code `toolTimeoutMs` |
 | OAuth scopes       | `--scopes`                          | Cursor, Gemini CLI                                                  | Cursor `auth.scopes`, Gemini `oauth.scopes`                                                  |
+| Bearer token env   | `--bearer-token-env`                | fx                                                                  | `bearer_token_env`                                                                           |
 | Tool auto-approval | `--auto-approve` / `--approve-tool` | Codex, Claude Code                                                  | Codex approval modes; Claude Code permission allow rules                                     |
 
-When a targeted agent doesn't support a field, add-mcp drops it from that agent's config and prints a warning — other agents still receive it.
+When a targeted agent doesn't support a field, add-mcp drops it from that agent's config and prints a warning — other agents still receive it. `--timeout`, `--scopes`, and `--bearer-token-env` apply to remote servers only. When `--bearer-token-env` and `--header Authorization` are both set, fx omits the Authorization header and writes `bearer_token_env`; other agents keep the header.
 
 ## Auto-approving tool calls
 

--- a/web/content/docs/02-cli/01-add.mdx
+++ b/web/content/docs/02-cli/01-add.mdx
@@ -21,6 +21,7 @@ npx add-mcp https://mcp.example.com/sse --transport sse
 # Remote server with an auth header
 npx add-mcp https://mcp.example.com/mcp --header 'Authorization: Bearer ${TOKEN}'
 
+# Remote server; fx reads the bearer token from this env var
 npx add-mcp https://mcp.example.com/mcp --bearer-token-env NEON_API_KEY
 
 # Remote server with a request timeout and OAuth scopes (capability-gated)
@@ -54,7 +55,7 @@ npx add-mcp https://mcp.example.com/mcp -g -a claude-code -y
 | `-t, --transport <type>`    | Transport type for remote servers: `http` (default), `sse`               |
 | `--type <type>`             | Alias for `--transport`                                                  |
 | `-h, --header <header>`     | HTTP header for remote servers (repeatable, `Key: Value`)                |
-| `--bearer-token-env <name>` | Env var name fx sends as a bearer token (capability-gated)               |
+| `--bearer-token-env <name>` | Env var whose value fx sends as a bearer token (capability-gated)        |
 | `--env <env>`               | Env var for local stdio servers (repeatable, `KEY=VALUE`)                |
 | `--args <args>`             | Arguments for local stdio servers                                        |
 | `--timeout <ms>`            | Request timeout (ms) for remote servers (capability-gated)               |

--- a/web/content/docs/03-sdk/01-reference.mdx
+++ b/web/content/docs/03-sdk/01-reference.mdx
@@ -117,6 +117,7 @@ interface McpServerConfig {
   timeout?: number; // milliseconds; Claude Code, Gemini CLI, Grok Build, Kilo Code, Kimi Code, Kiro CLI
   oauthScopes?: string[]; // Cursor, Gemini CLI
   autoApproveTools?: string[]; // Codex, Claude Code; [] = all tools
+  bearerTokenEnv?: string; // fx writes bearer_token_env
 }
 ```
 


### PR DESCRIPTION
## Problem

add-mcp 2.2.0 added fx support. fx refuses a literal `Authorization` header, so add-mcp refuses to write one and the install fails:

```
✗ fx: fx rejects a literal Authorization header. Use a non-Authorization
  header, or set bearer_token_env, header_env, or oauth in ~/.fx/mcp.json.
```

That message names three fields and then leaves you to hand-edit `~/.fx/mcp.json`. There was no `add-mcp` invocation that put an authenticated remote MCP server into fx.

## What fx accepts

fx's [MCP docs](https://fx.sh/docs/capabilities/mcp) list `bearer_token_env` for a bearer token. The config holds the name of an environment variable and fx reads the value from the environment at runtime.

add-mcp already handles fields that one client understands and the rest don't. `OptionalField` plus each agent's `supportedFields` is how `--timeout`, `--scopes` and `--auto-approve` are gated today. `bearerTokenEnv` is a fourth entry in that list, declared by fx and nobody else. Every other agent drops it through the existing path and prints the existing warning.

## The CLI

```bash
npx add-mcp https://mcp.example.com/mcp -a fx -y --name example \
  --bearer-token-env NEON_API_KEY
```

```jsonc
// ~/.fx/mcp.json
{
  "mcp": {
    "example": {
      "type": "http",
      "url": "https://mcp.example.com/mcp",
      "enabled": true,
      "bearer_token_env": "NEON_API_KEY"
    }
  }
}
```

### Mixed with `--header Authorization`

fx cannot take both. It keeps `bearer_token_env` and omits the header. Agents that don't support the field keep the header and lose the field. One run, two different configs, two warnings:

```bash
npx add-mcp https://mcp.example.com/mcp -a fx -a cursor -y --name example \
  --header 'Authorization: Bearer $TOKEN' \
  --bearer-token-env NEON_API_KEY
```

```
✓ fx: ~/.fx/mcp.json
✓ Cursor: ~/.cursor/mcp.json

▲ bearer token env var is not supported by Cursor; dropped from that config.
▲ Authorization header dropped from the fx config; fx reads the token from NEON_API_KEY.
```

```jsonc
// ~/.fx/mcp.json
"example": {
  "type": "http",
  "url": "https://mcp.example.com/mcp",
  "enabled": true,
  "bearer_token_env": "NEON_API_KEY"
}

// ~/.cursor/mcp.json
"example": {
  "url": "https://mcp.example.com/mcp",
  "headers": { "Authorization": "Bearer $TOKEN" }
}
```

The header match is case-insensitive and only `Authorization` is removed. Other headers survive on fx alongside `bearer_token_env`.

### Validation

The flag takes a POSIX environment variable name (`[A-Za-z_][A-Za-z0-9_]*`). Values that cannot be names fail before anything is written:

```
$ npx add-mcp https://mcp.example.com/mcp -a fx -y --bearer-token-env "Bearer sk-live"
■ --bearer-token-env takes an environment variable name ([A-Za-z_][A-Za-z0-9_]*). "Bearer sk-live" is not a valid name.

$ npx add-mcp https://mcp.example.com/mcp -a fx -y --bearer-token-env "   "
■ Invalid --bearer-token-env. The name cannot be empty.
```

Both exit non-zero and `~/.fx` is not created. Names are trimmed before the check, so `"  NEON_API_KEY  "` is accepted and written as `NEON_API_KEY`.

### Other cases

| Case | Result |
| --- | --- |
| `--bearer-token-env` on a stdio install | `▲ --bearer-token-env is only used for remote URLs, ignoring`, install proceeds |
| `--bearer-token-env` with no fx in the target list | dropped per agent with the standard warning |
| `--header Authorization` on fx with no `--bearer-token-env` | still fails; the message now names the flag instead of three config fields |

The last one is the only user-visible change to existing behavior:

```
✗ fx: fx rejects a literal Authorization header. Pass --bearer-token-env <name>,
  use a non-Authorization header, or set header_env or oauth in ~/.fx/mcp.json.
```

## The SDK

```ts
interface McpServerConfig {
  // ...
  bearerTokenEnv?: string; // fx writes bearer_token_env
}
```

```ts
import { upsertServer } from "add-mcp";

upsertServer("fx", "example", {
  type: "http",
  url: "https://mcp.example.com/mcp",
  bearerTokenEnv: "NEON_API_KEY",
});
// { success: true, path: "<home>/.fx/mcp.json" }

upsertServer("github-copilot-cli", "example", {
  type: "http",
  url: "https://mcp.example.com/mcp",
  bearerTokenEnv: "NEON_API_KEY",
}, { local: true });
// { success: true, path: "<cwd>/.vscode/mcp.json", droppedFields: ["bearerTokenEnv"] }
```

A bad name is an error rather than a dropped field. Nothing is written:

```ts
// bearerTokenEnv: "   "
// { success: false, error: 'Invalid bearerTokenEnv. The name cannot be empty.' }

// bearerTokenEnv: "Bearer sk-live"
// { success: false, error: 'Invalid bearerTokenEnv. "Bearer sk-live" is not an environment variable name ([A-Za-z_][A-Za-z0-9_]*).' }
```

`invalidBearerTokenEnvMessage`, `isBearerTokenEnvName` and `resolvedBearerTokenEnv` live in `src/schema.ts` and are not exported from `src/lib.ts`. The public addition is the one optional field on `McpServerConfig` and `"bearerTokenEnv"` joining the `OptionalField` union.

Nothing changes for callers that don't set the field. `applyFieldSupport` still copies before it mutates, so the caller's config object and its `headers` object come back untouched.

## Also in here

- `CHANGELOG.md` entry and `package.json` bumped to `2.3.0`.
- `README.md` and `web/content/docs/02-cli/01-add.mdx`: the flag in the options table, the capability-gated table row (`Bearer token env` / fx / `bearer_token_env`), an example and the mixed-with-Authorization rule. The options tables were reflowed because the new flag is the widest entry in the first column.
- `web/content/docs/03-sdk/01-reference.mdx`: the field on the `McpServerConfig` listing.
- Two existing tests changed their expected string because the fx Authorization error copy changed.

## Verification

`bun run typecheck`, `bun run build` and `bun run test` on `23412a6`. 416 tests across 13 files, 0 failures.

New tests:

- fx writes `bearer_token_env` and no `headers` key
- fx and Cursor in one run: fx gets the field and loses the header, Cursor gets the header and loses the field, both warnings print
- a token passed in place of a name exits non-zero and creates no `~/.fx`
- a whitespace-only name exits non-zero and creates no `~/.fx`
- a stdio install warns and writes a `local` entry with no `bearer_token_env`
- `applyFieldSupport` drops the field for an agent without it, keeps it for fx, trims a padded name and clears a whitespace-only one
- an invalid or whitespace-only name leaves the `Authorization` header in place, so `transformConfig` still throws rather than writing an unauthenticated entry
- `upsertServer` returns the two error messages and writes no file
- `upsertServer` on an agent without the field reports `droppedFields: ["bearerTokenEnv"]` and writes neither `bearerTokenEnv` nor `bearer_token_env`

Ran by hand against a temporary `HOME`: every CLI case shown above and the four `upsertServer` calls, reading the written JSON each time.

Not verified: no fx runtime was started against a written config. `bearer_token_env` and the rejection of a literal `Authorization` header both come from fx's MCP docs. No fx session read a config this branch wrote.

## For your attention

- **An invalid name fails the install for every targeted agent, including the ones that would have dropped the field.** `installServerForAgent` validates before capability gating, so `upsertServer("github-copilot-cli", ..., { bearerTokenEnv: "Bearer sk-live" })` returns `success: false` even though VS Code never writes the field. Refusing a malformed value at the boundary beats writing a set of configs that are correct only for the agents that ignore it.
- **add-mcp picks the name rule.** fx's docs give a naming rule for server names and say nothing about the env var, so this branch uses `[A-Za-z_][A-Za-z0-9_]*`. It accepts lowercase. An identifier-shaped secret such as `sk_live_…` still passes, because no syntactic check can tell that from a name.
- **On an fx-only install with both flags, the resulting config has no `Authorization` header at all.** The terminal says so; the file gives no sign. That is the same shape as every other capability-gated drop.
- **`header_env` and `oauth` are not exposed.** fx supports both. Neither maps onto a field any other agent has and neither is needed to install an authenticated server. `--bearer-token-env` covers the bearer-token case only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth-related MCP config for fx (env-var names vs literal tokens) and mixed-agent header handling. Validation is strict, but a bad name fails the whole install, including agents that would drop the field.
> 
> **Overview**
> Lets users install authenticated remote MCP servers into **fx** by naming an env var instead of writing a literal `Authorization` header, which fx still rejects.
> 
> `--bearer-token-env` / `bearerTokenEnv` is a new optional field, supported only by fx (`bearer_token_env`). Other agents drop it with the usual warning. If both that flag and `--header Authorization` are set, fx strips the header (case-insensitive) and keeps the env name; other agents keep the header. Empty, whitespace, and non-identifier names fail in the CLI and SDK before any file is written. Stdio installs ignore the flag.
> 
> Bumps to **2.3.0**. Docs, changelog, and tests cover mixed fx+Cursor installs, invalid names, and SDK `upsertServer` errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23412a667f2c860b673e237ee23c495dac7b15dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

