### PR TITLE
Add Concord MCP to registry overlay

### DIFF
--- a/registry.overlay.json
+++ b/registry.overlay.json
@@ -271,5 +271,30 @@
         }
       ]
     }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "io.github.Get-Concord-AI/concord-mcp",
+      "title": "Concord MCP",
+      "description": "Cross-harness communication and shared work-state for AI coding agents.",
+      "repository": {
+        "url": "https://github.com/Get-Concord-AI/concord-mcp",
+        "source": "github",
+        "id": "1300719974"
+      },
+      "version": "0.10.1",
+      "websiteUrl": "https://getconcord.ai",
+      "packages": [
+        {
+          "registryType": "npm",
+          "identifier": "@concord-ai/concord-mcp",
+          "version": "0.10.1",
+          "transport": {
+            "type": "stdio"
+          }
+        }
+      ]
+    }
   }
 ]


### PR DESCRIPTION
## Summary

Adds Concord MCP to the package-only registry overlay so `add-mcp` users can discover and install it across supported coding-agent clients.

Concord is a cross-harness communication and shared work-state MCP server for Claude Code, Codex, Cursor, Gemini CLI, and Grok Build. It is published on npm and in the official MCP Registry.

## Verification

- `bun run registry:sort`
- `bun run registry:verify`
- `git diff --check`

Disclosure: I maintain Concord MCP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Concord to the MCP server registry.
  * Included its repository details, website, version information, and npm-based setup configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->