### PR TITLE
Sync registry from integrations.sh and pin dropped remotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ The first time you run `find` or `search`, the CLI automatically saves the add-m
 
 ### Missing A Server in integrations.sh?
 
-The default add-mcp registry is generated from [integrations.sh](https://integrations.sh). To be listed in add-mcp, add your MCP server to integrations.sh. Package-only entries that integrations.sh cannot represent yet can still be contributed to add-mcp's `registry.overlay.json`.
+The default add-mcp registry is generated from [integrations.sh](https://integrations.sh). To be listed in add-mcp, add your MCP server to integrations.sh. Package-only servers, and remotes integrations.sh dropped that still speak MCP, go in `registry.overlay.json`.
 
 Maintainers can refresh the checked-in registry snapshot with:
 

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ The first time you run `find` or `search`, the CLI automatically saves the add-m
 
 ### Missing A Server in integrations.sh?
 
-The default add-mcp registry is generated from [integrations.sh](https://integrations.sh). To be listed in add-mcp, add your MCP server to integrations.sh. Package-only servers, and remotes integrations.sh dropped that still speak MCP, go in `registry.overlay.json`.
+The default add-mcp registry is generated from [integrations.sh](https://integrations.sh). To be listed in add-mcp, add your MCP server to integrations.sh. Package-only servers, and remotes integrations.sh dropped that we still want in `find`, go in `registry.overlay.json`.
 
 Maintainers can refresh the checked-in registry snapshot with:
 

--- a/registry.json
+++ b/registry.json
@@ -6879,22 +6879,14 @@
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.cosmicjs/cosmic-hosted-mcp-agent-scope",
-      "title": "Cosmic",
-      "description": "Cosmic hosted MCP server for agent-scoped access to CMS buckets and content.",
+      "title": "Cosmic Agent",
+      "description": "Cosmic MCP for agent signup at /v1/agent (cosmic_agent_signup, verify, status).",
       "version": "1.0.0",
       "websiteUrl": "https://www.cosmicjs.com/docs/agent-skills",
       "remotes": [
         {
           "type": "streamable-http",
-          "url": "https://mcp.cosmicjs.com/v1/agent",
-          "headers": [
-            {
-              "name": "Authorization",
-              "description": "Agent key. Use Bearer <token>.",
-              "isRequired": true,
-              "isSecret": true
-            }
-          ]
+          "url": "https://mcp.cosmicjs.com/v1/agent"
         }
       ]
     }
@@ -24217,21 +24209,13 @@
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "io.signoz/mcp",
       "title": "SigNoz",
-      "description": "SigNoz Cloud MCP server for metrics, traces, and logs.",
+      "description": "SigNoz Cloud US MCP server for metrics, traces, and logs. Sign in with OAuth in the agent after install.",
       "version": "1.0.0",
       "websiteUrl": "https://signoz.io/docs/ai/signoz-mcp-server/",
       "remotes": [
         {
           "type": "streamable-http",
-          "url": "https://mcp.us.signoz.cloud/mcp",
-          "headers": [
-            {
-              "name": "Authorization",
-              "description": "SigNoz API key. Use Bearer <token> or SIGNOZ-API-KEY.",
-              "isRequired": true,
-              "isSecret": true
-            }
-          ]
+          "url": "https://mcp.us.signoz.cloud/mcp"
         }
       ]
     }
@@ -29930,21 +29914,12 @@
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.zillow/mcp",
       "title": "Zillow",
-      "description": "Zillow MCP server for real-estate listing search.",
+      "description": "Zillow MCP server for real-estate listing search. Sign in with OAuth in the agent after install.",
       "version": "1.0.0",
-      "websiteUrl": "https://mcp.zillow.com/mcp",
       "remotes": [
         {
           "type": "streamable-http",
-          "url": "https://mcp.zillow.com/mcp",
-          "headers": [
-            {
-              "name": "Authorization",
-              "description": "Bearer token.",
-              "isRequired": true,
-              "isSecret": true
-            }
-          ]
+          "url": "https://mcp.zillow.com/mcp"
         }
       ]
     }

--- a/registry.json
+++ b/registry.json
@@ -149,6 +149,27 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "directory.404/mcp",
+      "title": "404.directory",
+      "description": "404.directory provides agent discovery and trust infrastructure for AI agents, including official-docs search, tool discovery, website verification, webpage understanding, and controlled read-only invocation of curated remote MCP tools. It publishes both MCP and REST interfaces plus machine-readable discovery metadata on its website.",
+      "version": "1.0.0",
+      "websiteUrl": "https://404.directory/docs.md",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/404.directory"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://404.directory/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.olutely/789-sudoku-mcp",
       "title": "789 Sudoku",
       "description": "Olutely's widget service, operated by Spheric Admin Ltd, provides interactive widgets and basic app behavior inside ChatGPT. Its terms describe widget requests being handled by the company's own MCP servers without storing conversation content persistently.",
@@ -527,35 +548,6 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.activepieces/mcp",
-      "title": "Activepieces",
-      "description": "Activepieces is an automation platform for building workflows, integrations, and AI-driven actions across many third-party apps. It offers hosted and embedded automation experiences, including per-project MCP access for AI clients.",
-      "version": "1.0.0",
-      "websiteUrl": "https://www.activepieces.com/docs/embedding/embeddable-mcp",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/activepieces.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://www.activepieces.com/.well-known/mcp/server-card.json",
-          "headers": [
-            {
-              "name": "Authorization",
-              "description": "Generated MCP bearer token for an embedded project. Use Bearer <token>.",
-              "isRequired": true,
-              "isSecret": true
-            }
-          ]
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "de.bpcs-ad-broker/mcp",
       "title": "ADAC Mietwagen",
       "description": "bpcs-ad-broker.de appears to host a broker-related service; the only public machine-facing interface found is an MCP endpoint branded ADAC Mietwagen. No public HTTP API, GraphQL API, or CLI documentation was found for this domain.",
@@ -633,6 +625,27 @@
         {
           "type": "streamable-http",
           "url": "https://adisinsight-mcp.springer.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "markets.adjacent/mcp",
+      "title": "Adjacent",
+      "description": "Adjacent News provides indexing, benchmarking, and market data for prediction markets and event contracts, including indices, reference rates, markets, events, news, and methodology documents. It also publishes the same data through public JSON, MCP, and oracle-proxy access points.",
+      "version": "1.0.0",
+      "websiteUrl": "https://docs.adjacent.markets/explore/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/adjacent.markets"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.adjacent.markets/mcp"
         }
       ]
     }
@@ -934,6 +947,48 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.agentdomainsearch/mcp",
+      "title": "Agent Domain Search",
+      "description": "Agent Domain Search is a domain registration and DNS management service designed for programmatic use. It lets users check availability, register and renew domains, and manage DNS using Ethereum wallet signatures and USDC payments on Base.",
+      "version": "1.0.0",
+      "websiteUrl": "https://integrations.sh/agentdomainsearch.com/agent-domain-search-mcp-server/",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/agentdomainsearch.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://agentdomainsearch.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.onrender.agent-guild-5d5r/mcp",
+      "title": "Agent Guild",
+      "description": "Agent Guild is a service for evaluating, discovering, and transacting with autonomous agents. It provides trust and payment-safety checks, portable agent reputation credentials, escrow/payment workflows, and a set of deterministic utility capabilities.",
+      "version": "1.0.0",
+      "websiteUrl": "https://agent-guild-5d5r.onrender.com/llms.txt",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/agent-guild-5d5r.onrender.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://agent-guild-5d5r.onrender.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "ai.agenta/mcp",
       "title": "Agenta",
       "description": "Agenta is an LLMOps platform for building, evaluating, deploying, and observing LLM applications and workflows. It provides prompt management, evaluation tooling, and observability for AI systems in both cloud-hosted and self-hosted setups.",
@@ -948,6 +1003,119 @@
         {
           "type": "sse",
           "url": "https://mcp.eu.algolia.com/1/M_CIMvH38zVydbZOtDAzTjI3szBOMUq0tDA0NTJOMjO3TEtLtUwxNDUxNrfOrdRNyU8u1s1NLMpOyS_PszY0NzMyNDA1sDQFAA/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "so.agentcloud/mcp",
+      "title": "AgentCloud",
+      "description": "AgentCloud provides hosted iOS Simulator sessions for cloud coding agents so they can build, launch, inspect, and operate iOS apps remotely. It focuses on a constrained MCP tool surface rather than a general-purpose remote Mac or shell.",
+      "version": "1.0.0",
+      "websiteUrl": "https://agentcloud.so/index.md",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/agentcloud.so"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.agentcloud.so/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.agentgrade/mcp",
+      "title": "AgentGrade",
+      "description": "AgentGrade scans websites for AI-agent readiness, checking discovery files, payment protocols, MCP/OpenAPI support, identity signals, and related infrastructure. It returns scored reports, badges, history, and remediation guidance for improving a site's agent accessibility.",
+      "version": "1.0.0",
+      "websiteUrl": "https://agentgrade.com/llms.txt",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/agentgrade.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://agentgrade.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "to.agentmail/agentmail-mcp-server",
+      "title": "AgentMail",
+      "description": "AgentMail provides programmatic email inboxes for AI agents so they can send, receive, reply to, and manage threaded email conversations. It also supports related capabilities like webhooks, real-time event streaming, custom domains, and multi-tenant isolation.",
+      "version": "1.0.0",
+      "websiteUrl": "https://docs.agentmail.to/integrations/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/agentmail.to"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.agentmail.to/mcp",
+          "headers": [
+            {
+              "name": "x-api-key",
+              "description": "AgentMail API key. Use <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "to.agentmail/agentmail-docs-mcp",
+      "title": "AgentMail docs",
+      "description": "AgentMail provides programmatic email inboxes for AI agents so they can send, receive, reply to, and manage threaded email conversations. It also supports related capabilities like webhooks, real-time event streaming, custom domains, and multi-tenant isolation.",
+      "version": "1.0.0",
+      "websiteUrl": "https://docs.agentmail.to",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/agentmail.to"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://docs.agentmail.to/_mcp/server"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "news.agent/mcp",
+      "title": "AgentNews",
+      "description": "AgentNews is a news feed for autonomous AI agents where agents bid to publish posts and can read, search, vote, and comment on content. It publishes developer-facing discovery documents including llms.txt, an OpenAPI spec, and a machine-readable service manifest.",
+      "version": "1.0.0",
+      "websiteUrl": "https://agent.news/llms.txt",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/agent.news"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://agent.news/mcp"
         }
       ]
     }
@@ -1095,27 +1263,6 @@
         {
           "type": "streamable-http",
           "url": "https://api.ahrefs.com/mcp/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "app.phaseo.ai-stats/mcp",
-      "title": "AI Stats Docs",
-      "description": "AI Stats by Phaseo is an AI gateway and model intelligence database for comparing models, providers, pricing, benchmarks, latency, and availability. It also provides a hosted API gateway for routing requests across supported AI providers.",
-      "version": "1.0.0",
-      "websiteUrl": "https://docs.ai-stats.phaseo.app/v1/guides/integrations/docs-mcp",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/ai-stats.phaseo.app"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://ai-stats.phaseo.app/mcp"
         }
       ]
     }
@@ -1398,49 +1545,13 @@
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.algolia/algolia-productivity-mcp",
       "title": "Algolia Productivity",
-      "description": "Algolia is a hosted search and discovery platform for indexing content, serving search and recommendation results, and analyzing search behavior. It also offers AI-oriented MCP server features for exposing Algolia data and workflows to LLM clients.",
+      "description": "Algolia Productivity MCP for searching and analyzing Algolia applications and indices.",
       "version": "1.0.0",
       "websiteUrl": "https://www.algolia.com/doc/guides/model-context-protocol/productivity-mcp",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/algolia.com"
-        }
-      ],
       "remotes": [
         {
           "type": "streamable-http",
           "url": "https://mcp.algolia.com/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.algolia/algolia-public-mcp",
-      "title": "Algolia Public",
-      "description": "Algolia is a hosted search and discovery platform for indexing content, serving search and recommendation results, and analyzing search behavior. It also offers AI-oriented MCP server features for exposing Algolia data and workflows to LLM clients.",
-      "version": "1.0.0",
-      "websiteUrl": "https://www.algolia.com/doc/guides/model-context-protocol/public-mcp",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/algolia.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://{APP_ID}.algolia.net/mcp/1/{UNIQ_ID}/mcp",
-          "variables": {
-            "APP_ID": {
-              "description": "Algolia application ID in the MCP server URL.",
-              "isRequired": true
-            },
-            "UNIQ_ID": {
-              "description": "Unique MCP server instance ID copied from the Algolia dashboard.",
-              "isRequired": true
-            }
-          }
         }
       ]
     }
@@ -2214,9 +2325,9 @@
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.apple/mcp",
       "title": "Apple Music",
-      "description": "Apple develops consumer and developer platforms including the App Store, Apple Music, and Siri integrations. Its public developer documentation includes APIs for managing App Store Connect resources and integrating media services with Siri and Apple Music.",
+      "description": "Apple develops consumer and developer platforms including the App Store, Siri integrations, and Apple Music services. Its developer documentation covers APIs for managing App Store Connect resources and integrating cloud-backed media services with Siri.",
       "version": "1.0.0",
-      "websiteUrl": "https://developer.apple.com/documentation/applemusicapi/",
+      "websiteUrl": "https://mcp.music.apple.com/v1/longandcomplexstring294/mcp",
       "icons": [
         {
           "src": "https://integrations.sh/logo/apple.com"
@@ -2485,6 +2596,27 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.atlassian/mcp",
+      "title": "Atlassian Rovo",
+      "description": "Atlassian builds cloud and self-managed software for project tracking, documentation, source control, service management, and AI-assisted teamwork. Its products include Jira, Confluence, Bitbucket, Jira Service Management, Rovo, and the Teamwork Graph platform.",
+      "version": "1.0.0",
+      "websiteUrl": "https://www.atlassian.com/platform/remote-mcp-server",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/atlassian.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.atlassian.com/v1/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.jira/mcp",
       "title": "Atlassian Rovo",
       "description": "Jira is Atlassian’s issue tracking and work management product. It is offered as part of Atlassian Cloud and connects with other Atlassian products such as Confluence, Jira Service Management, Bitbucket, and Rovo.",
@@ -2674,58 +2806,6 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.oracle/mcp",
-      "title": "Autonomous AI Database",
-      "description": "Oracle provides cloud infrastructure, database, and enterprise software platforms. Its public documentation covers OCI service APIs and developer tooling, plus database access surfaces such as Oracle REST Data Services GraphQL and MCP servers for Oracle databases.",
-      "version": "1.0.0",
-      "websiteUrl": "https://docs.oracle.com/en-us/iaas/autonomous-database-serverless/doc/mcp-server.html",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/oracle.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://dataaccess.adb.{region-identifier}.oraclecloudapps.com/adb/mcp/v1/databases/{database-ocid}",
-          "variables": {
-            "region-identifier": {
-              "description": "Region identifier for the Autonomous AI Database.",
-              "isRequired": true
-            },
-            "database-ocid": {
-              "description": "OCID of the Autonomous AI Database with MCP enabled.",
-              "isRequired": true
-            }
-          }
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.autoscout24/mcp",
-      "title": "AutoScout24",
-      "description": "AutoScout24 is an online vehicle marketplace focused on buying and selling cars and other vehicles in Europe. It also provides dealer-facing tooling for creating and managing vehicle listings on its platform.",
-      "version": "1.0.0",
-      "websiteUrl": "https://www.autoscout24.com/chatgpt/eu/mcp",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/autoscout24.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "sse",
-          "url": "https://www.autoscout24.com/chatgpt/eu/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.autotrader/mcp",
       "title": "Autotrader",
       "description": "Autotrader is an online automotive marketplace for buying and selling vehicles, with B2B products for dealers and OEMs. Its business site also describes integrations with other Cox Automotive products, but no public developer API documentation was found on autotrader.com.",
@@ -2770,9 +2850,9 @@
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "ro.autovit/mcp",
       "title": "Autovit.ro",
-      "description": "Autovit.ro is a Romanian online marketplace for buying and selling vehicles. It lists cars and other vehicles from private sellers and professional dealers.",
+      "description": "Autovit.ro MCP server discovered by integrations.sh.",
       "version": "1.0.0",
-      "websiteUrl": "https://integrations.sh/autovit.ro/autovit-ro-mcp-server/",
+      "websiteUrl": "https://www.autovit.ro/",
       "icons": [
         {
           "src": "https://integrations.sh/logo/autovit.ro"
@@ -2782,6 +2862,27 @@
         {
           "type": "streamable-http",
           "url": "https://www.autovit.ro/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.useautumn/mcp",
+      "title": "Autumn",
+      "description": "Autumn is billing infrastructure for AI and SaaS products that sits on top of Stripe. It manages subscription state, usage metering, credits, entitlements, and related billing logic for customer applications.",
+      "version": "1.0.0",
+      "websiteUrl": "https://docs.useautumn.com/documentation/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/useautumn.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.useautumn.com/mcp"
         }
       ]
     }
@@ -3227,20 +3328,20 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "app.replit.all-ten-chat-gpt-app/mcp",
-      "title": "Beast Academy - All Ten",
-      "description": "This Replit-hosted app appears to provide an MCP server for a Beast Academy “All Ten” experience. Its homepage lists a single MCP endpoint and links to a few HTML pages.",
+      "name": "com.getbeachfinder/mcp",
+      "title": "BeachFinder",
+      "description": "BeachFinder is a beach, lake, and swimming-spot discovery service that helps people compare places using mapped spot data, current planning conditions, guides, and community context. It also surfaces related activity providers and beach-planning tools through its website and app.",
       "version": "1.0.0",
-      "websiteUrl": "https://all-ten-chat-gpt-app.replit.app/",
+      "websiteUrl": "https://getbeachfinder.com/tools",
       "icons": [
         {
-          "src": "https://integrations.sh/logo/all-ten-chat-gpt-app.replit.app"
+          "src": "https://integrations.sh/logo/getbeachfinder.com"
         }
       ],
       "remotes": [
         {
           "type": "streamable-http",
-          "url": "https://all-ten-chat-gpt-app.replit.app/mcp"
+          "url": "https://getbeachfinder.com/mcp"
         }
       ]
     }
@@ -3332,6 +3433,27 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.benevity/mcp",
+      "title": "Benevity Nonprofit",
+      "description": "Benevity provides an enterprise impact platform for corporate giving, volunteering, grants, and related social-impact programs. It also maintains a large database of vetted nonprofits and charitable causes used across its platform.",
+      "version": "1.0.0",
+      "websiteUrl": "https://causeshelp.benevity.org/hc/en-us/articles/43364091494164-Benevity-nonprofit-MCP-server",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/benevity.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.benevity.org/general/v1/nonprofit"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.bestlawyers/mcp",
       "title": "Best Lawyers",
       "description": "Best Lawyers is a legal directory and publishing platform that lists lawyers and law firms, publishes legal guides and articles, and provides member access for legal professionals.",
@@ -3395,9 +3517,51 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "gr.bestprice.mcp/mcp",
+      "title": "BestPrice",
+      "description": "BestPrice is a Greek price-comparison shopping service. Its MCP server exposes read-only product search, offer comparison, and price-history information from the Greek market.",
+      "version": "1.0.0",
+      "websiteUrl": "https://www.bestprice.gr/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/mcp.bestprice.gr"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.bestprice.gr/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.better-design/mcp",
+      "title": "Better Design",
+      "description": "Better Design is a design intelligence service for AI coding agents. It provides shadcn-compatible design systems, UI/UX principles, icon discovery, and review rules through an MCP server and related registry content.",
+      "version": "1.0.0",
+      "websiteUrl": "https://better-design.com/mcp/install",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/better-design.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://better-design.com/api/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.betterstack/mcp",
       "title": "Better Stack",
-      "description": "Better Stack is an observability and incident-management platform covering uptime monitoring, on-call/incident response, log and telemetry management, and error tracking. It also offers an MCP server so AI assistants can access Better Stack data.",
+      "description": "Better Stack exposes Uptime, Telemetry, Errors, Telemetry ingestion, and Telemetry SQL HTTP APIs plus an MCP server; authenticate with Bearer global API tokens, Telemetry team tokens, source tokens for ingestion, SQL username/password for the SQL API, or OAuth/DCR for MCP.",
       "version": "1.0.0",
       "websiteUrl": "https://betterstack.com/docs/getting-started/integrations/mcp/",
       "icons": [
@@ -3408,7 +3572,28 @@
       "remotes": [
         {
           "type": "streamable-http",
-          "url": "https://betterstack.com/mcp"
+          "url": "https://mcp.betterstack.com"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "dev.bigcommerce/mcp",
+      "title": "BigCommerce documentation",
+      "description": "BigCommerce is an ecommerce platform for building and operating online stores. It provides APIs and agent tooling for managing store data, powering storefront experiences, and enabling AI-assisted shopping flows.",
+      "version": "1.0.0",
+      "websiteUrl": "https://docs.bigcommerce.com/llms.txt",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/bigcommerce.dev"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://docs.bigcommerce.com/_mcp/server"
         }
       ]
     }
@@ -3438,27 +3623,6 @@
               "isSecret": true
             }
           ]
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.bigdatacloud/mcp",
-      "title": "Bigdatacloud",
-      "description": "BigDataCloud provides location-intelligence APIs including IP geolocation, reverse geocoding, phone and email verification, and network engineering data. It also offers a free client-side API package for browser and mobile use cases such as reverse geocoding, roaming detection, and client IP information.",
-      "version": "1.0.0",
-      "websiteUrl": "https://integrations.sh/bigdatacloud.com/mcp-server/",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/bigdatacloud.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://www.bigdatacloud.com/.well-known/mcp/server-card.json"
         }
       ]
     }
@@ -3543,27 +3707,6 @@
         {
           "type": "streamable-http",
           "url": "https://mcp.services.biorender.com/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.messagebird/mcp",
-      "title": "Bird   (hosted)",
-      "description": "MessageBird/Bird provides communications infrastructure for sending and managing email, SMS, voice, WhatsApp, and related messaging workflows. Its newer Bird platform also includes agent-oriented access via a CLI and MCP server.",
-      "version": "1.0.0",
-      "websiteUrl": "https://bird.com/en-us/docs/ai/mcp-server",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/messagebird.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://mcp.platform.bird.com"
         }
       ]
     }
@@ -3726,27 +3869,6 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "xyz.flowerdiary/mcp",
-      "title": "Blossom",
-      "description": "Flower Diary, branded on its website as Blossom Diary, is an AI-assisted diary writing service with related language-learning and proofreading features. Its public site describes consumer apps and products centered on writing diaries in multiple languages.",
-      "version": "1.0.0",
-      "websiteUrl": "https://blossomdiary.com",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/flowerdiary.xyz"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://openai.flowerdiary.xyz/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.jebbit/mcp",
       "title": "BlueConic Solutions Finder",
       "description": "Jebbit is a customer engagement and quiz/experience platform used to collect zero-party data and power personalized experiences. Its public docs describe APIs for managing businesses, campaigns, feeds, launch links, integrations, and related webhooks.",
@@ -3831,27 +3953,6 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "bg.boleron/mcp",
-      "title": "Boleron AI",
-      "description": "Boleron is a Bulgarian digital insurance broker and online insurance platform for comparing, buying, and renewing insurance products. Its site also offers related online services such as vignette purchase and vehicle/insurance checks.",
-      "version": "1.0.0",
-      "websiteUrl": "https://boleron.bg",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/boleron.bg"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://ai.boleron.bg/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "co.book-direct/mcp",
       "title": "Book Direct",
       "description": "Book Direct is a lodging discovery platform that connects property owners directly with travelers and AI assistants, surfacing accommodations with direct booking links and contact details. It focuses on helping hotels and vacation-rental owners receive direct bookings outside traditional OTA marketplaces.",
@@ -3874,10 +3975,10 @@
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.booking/mcp",
-      "title": "Booking.com Demand API",
-      "description": "Booking.com is an online travel platform for accommodations and other travel services. Its developer offerings let partners access travel inventory, metasearch connectivity, and user-authorized data portability exports.",
+      "title": "Booking.com",
+      "description": "Booking.com is an online travel platform for accommodations and other travel products. It also operates partner and provider platforms that let affiliates, connectivity partners, metasearch partners, and approved businesses access Booking.com inventory, property-management features, and user data portability exports.",
       "version": "1.0.0",
-      "websiteUrl": "https://integrations.sh/booking.com/booking-com-demand-api-mcp-server/",
+      "websiteUrl": "https://developers.booking.com/demand/docs",
       "icons": [
         {
           "src": "https://integrations.sh/logo/booking.com"
@@ -3915,6 +4016,27 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "sh.botlify/mcp",
+      "title": "Botlify",
+      "description": "Botlify lets people claim a slug and turn a documentation site or website into a public Grok Bot knowledge source. It crawls same-host sitemap and `llms.txt` content, then publishes an install page and public MCP for each claimed bot.",
+      "version": "1.0.0",
+      "websiteUrl": "https://botlify.sh/docs",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/botlify.sh"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://botlify.sh/api/mcp/convex"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "sh.botpress/mcp",
       "title": "Botpress",
       "description": "Botpress is a platform for building and operating AI agents and chatbots. It provides cloud-hosted tooling for agent development, deployment, conversations, integrations, and related runtime/admin capabilities.",
@@ -3929,6 +4051,48 @@
         {
           "type": "streamable-http",
           "url": "https://botgpt.botpress.sh/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "dev.workers.mimirslab.bountyverdict-agent-production/bountyverdict-agent-decision-mcp",
+      "title": "BountyVerdict Agent Decision",
+      "description": "BountyVerdict provides read-only decision checks for public GitHub engineering workflows, including bounty triage, repository instruction audits, CI failure diagnosis, flake classification, and MCP tool-catalog drift checks. It returns bounded, evidence-linked verdicts and uses x402 payment challenges for successful paid results.",
+      "version": "1.0.0",
+      "websiteUrl": "https://cristianmoroaica.github.io/bountyverdict/llms-install.md",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/bountyverdict-agent-production.mimirslab.workers.dev"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://bountyverdict-agent-production.mimirslab.workers.dev/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "dev.workers.mimirslab.bountyverdict-agent-production/mcp-server",
+      "title": "Bountyverdict-agent-production",
+      "description": "BountyVerdict provides read-only decision checks for public GitHub engineering workflows, including bounty triage, repository instruction audits, CI failure diagnosis, flake classification, and MCP tool-catalog drift checks. It returns bounded, evidence-linked verdicts and uses x402 payment challenges for successful paid results.",
+      "version": "1.0.0",
+      "websiteUrl": "https://integrations.sh/bountyverdict-agent-production.mimirslab.workers.dev/mcp-server/",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/bountyverdict-agent-production.mimirslab.workers.dev"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://bountyverdict-agent-production.mimirslab.workers.dev/api/mcp-drift"
         }
       ]
     }
@@ -4181,6 +4345,41 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "io.bronto/mcp",
+      "title": "Bronto Hosted",
+      "description": "Bronto is an observability platform for logs, traces, and metrics with long-retention search and AI-assisted investigation features. It stores telemetry data, supports ingestion from common collectors and cloud sources, and offers MCP access so AI agents can query that telemetry directly.",
+      "version": "1.0.0",
+      "websiteUrl": "https://docs.bronto.io/ai-features/hosted-mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/bronto.io"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.{region}.bronto.io/mcp",
+          "variables": {
+            "region": {
+              "description": "Bronto region, documented as `eu` or `us`.",
+              "isRequired": true
+            }
+          },
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "Bronto API key. Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.browser-use/mcp",
       "title": "Browser Use Cloud",
       "description": "Browser Use provides cloud and open-source tooling for AI-driven browser automation, letting agents interact with websites through natural-language tasks and direct browser control. Its product includes managed browser infrastructure and a local/open-source stack for self-hosted automation.",
@@ -4231,6 +4430,35 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "works.buddy/mcp",
+      "title": "Buddy",
+      "description": "Buddy provides infrastructure for software development workflows, including sandboxes, hosting, repositories, domains, package artifacts, and CI/CD-style automation. It offers these capabilities through a web platform plus programmatic interfaces for developers and AI agents.",
+      "version": "1.0.0",
+      "websiteUrl": "https://buddy.works/docs",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/buddy.works"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.buddy.works/mcp",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "Buddy personal access token. Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "build.buf/mcp",
       "title": "Buf",
       "description": "Buf provides tooling and hosted services for working with Protocol Buffers, gRPC, and ConnectRPC, including the Buf CLI and the Buf Schema Registry. It is used to manage schemas, generate code, and interact with Protobuf-based APIs and registry resources.",
@@ -4266,6 +4494,27 @@
         {
           "type": "streamable-http",
           "url": "https://mcp.builder.io"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "so.buildy.app/mcp",
+      "title": "Buildy",
+      "description": "Buildy hosts interactive web apps that agents can create, update, and render inline, publishing each app at a Buildy URL. The service supports building and operating those apps through either MCP tools or its HTTP API.",
+      "version": "1.0.0",
+      "websiteUrl": "https://buildy.so/build-mcp.md",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/app.buildy.so"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://app.buildy.so/mcp"
         }
       ]
     }
@@ -4462,27 +4711,6 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "shop.cmcp/mcp",
-      "title": "C.FLIP",
-      "description": "cmcp.shop appears to host an MCP endpoint branded C.FLIP. No additional public product or developer documentation was discoverable from the domain during this review.",
-      "version": "1.0.0",
-      "websiteUrl": "https://integrations.sh/cmcp.shop/c-flip-mcp-server/",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/cmcp.shop"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://cmcp.shop/mcp/e4b5ec4f-6e83-4292-b7c5-32272974d287"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.cafe24/mcp",
       "title": "Cafe24",
       "description": "Cafe24 MCP server discovered by integrations.sh.",
@@ -4588,27 +4816,6 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.calorieappguide/mcp",
-      "title": "Calorie Tracker Guide",
-      "description": "Calorie Tracker Guide is a website that organizes calorie and macro tracking apps into directories, comparisons, rankings, and feature-based guides. Its public pages present editorial comparison content rather than end-user fitness tracking software.",
-      "version": "1.0.0",
-      "websiteUrl": "https://calorieappguide.com/",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/calorieappguide.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://calorieappguide.com/.well-known/mcp/server-card.json"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "app.railway.up.oaimcp-production/mcp",
       "title": "CalorieCam",
       "description": "CalorieCam appears to expose a Model Context Protocol server hosted on Railway. No public documentation or additional API, GraphQL, or CLI surfaces were discoverable on the given domain.",
@@ -4693,20 +4900,20 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.candidhealth/mcp",
-      "title": "Candidhealth",
-      "description": "Candid Health provides healthcare revenue-cycle APIs for claims submission, eligibility, patient collections, and related operational workflows. Its documentation describes production and sandbox/staging environments and SDKs for Python, JavaScript/TypeScript, Ruby, and .NET.",
+      "name": "money.candor.api/mcp",
+      "title": "Candor",
+      "description": "Candor is a personal finance service that lets a user's existing AI agent access read-only financial records, organize budgets and goals, and retain notes and prior decisions across conversations. It does not move money or make changes at the user's bank or broker.",
       "version": "1.0.0",
-      "websiteUrl": "https://integrations.sh/candidhealth.com/mcp-server/",
+      "websiteUrl": "https://candor.money/START.md",
       "icons": [
         {
-          "src": "https://integrations.sh/logo/candidhealth.com"
+          "src": "https://integrations.sh/logo/api.candor.money"
         }
       ],
       "remotes": [
         {
           "type": "streamable-http",
-          "url": "https://candidhealth.com/.well-known/mcp/server-card.json"
+          "url": "https://api.candor.money/mcp"
         }
       ]
     }
@@ -4737,7 +4944,7 @@
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.canva/mcp",
       "title": "Canva",
-      "description": "Canva is an online visual design platform for creating and managing designs, assets, templates, and team content workflows. It also provides enterprise administration, provisioning, and audit-log capabilities for organizations.",
+      "description": "Canva is a visual design platform for creating, editing, and managing designs, assets, teams, and brand content. Its developer platform supports app building, workflow integrations, organization administration, identity provisioning, and AI assistant connectivity.",
       "version": "1.0.0",
       "websiteUrl": "https://www.canva.dev/docs/mcp/",
       "icons": [
@@ -5071,6 +5278,41 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.carsxe/mcp",
+      "title": "CarsXE",
+      "description": "CarsXE is a B2B vehicle data platform from PiWaves, LLC that provides VIN decoding, vehicle specifications, recalls, market values, history, plate decoding, OCR, OBD decoding, and related automotive data. It is used by dealerships, insurers, lenders, fleets, and other auto-tech businesses.",
+      "version": "1.0.0",
+      "websiteUrl": "https://carsxe.com/docs/integrations/mcp-quickstart",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/carsxe.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.carsxe.com/mcp",
+          "headers": [
+            {
+              "name": "X-API-Key",
+              "description": "CarsXE API key. Use <token>.",
+              "isRequired": true,
+              "isSecret": true
+            },
+            {
+              "name": "Authorization",
+              "description": "CarsXE API key. Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.carta/mcp",
       "title": "Carta CRM",
       "description": "Carta provides equity management, cap table, investor, and related financial workflow software. It also offers a CRM product for managing investment relationships, deals, fundraising, contacts, and notes.",
@@ -5190,6 +5432,35 @@
         {
           "type": "sse",
           "url": "https://mcp.cashbackhive.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.cavuno/mcp",
+      "title": "Cavuno",
+      "description": "Cavuno provides AI-native job board software for launching and managing branded job boards. It handles job listings, companies, blog content, monetization, and related board management features.",
+      "version": "1.0.0",
+      "websiteUrl": "https://cavuno.com/docs/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/cavuno.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.cavuno.com/mcp",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "Cavuno API key. Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
         }
       ]
     }
@@ -5337,142 +5608,6 @@
         {
           "type": "streamable-http",
           "url": "https://mcp.channel99.com/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.chargebee/chargebee-custom-mcp-server",
-      "title": "Chargebee Custom",
-      "description": "Chargebee exposes tenant-scoped REST APIs at `/api/v1` and `/api/v2` authenticated with a site API key via HTTP Basic Auth, plus MCP servers for Knowledge Base (public), Data Lookup, Onboarding, and Custom tools authenticated either by per-server Bearer API keys or Chargebee-issued OAuth clients.",
-      "version": "1.0.0",
-      "websiteUrl": "https://www.chargebee.com/docs/billing/2.0/ai-in-chargebee/custom-mcp-server",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/chargebee.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://YOUR-CHARGEBEE-SUBDOMAIN.mcp.chargebee.com/YOUR-CUSTOM-SERVER-SLUG",
-          "variables": {
-            "YOUR-CHARGEBEE-SUBDOMAIN": {
-              "description": "Site subdomain; EU and AU data centers use `mcp.eu.chargebee.com` or `mcp.au.chargebee.com` instead.",
-              "isRequired": true
-            },
-            "YOUR-CUSTOM-SERVER-SLUG": {
-              "description": "Slug derived from the custom server name, e.g. `invoice_lookup_mcp_server`.",
-              "isRequired": true
-            }
-          },
-          "headers": [
-            {
-              "name": "Authorization",
-              "description": "Chargebee MCP server API key. Use Bearer <token>.",
-              "isRequired": true,
-              "isSecret": true
-            }
-          ]
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.chargebee/chargebee-data-lookup-mcp-server",
-      "title": "Chargebee Data Lookup",
-      "description": "Chargebee exposes tenant-scoped REST APIs at `/api/v1` and `/api/v2` authenticated with a site API key via HTTP Basic Auth, plus MCP servers for Knowledge Base (public), Data Lookup, Onboarding, and Custom tools authenticated either by per-server Bearer API keys or Chargebee-issued OAuth clients.",
-      "version": "1.0.0",
-      "websiteUrl": "https://www.chargebee.com/docs/billing/2.0/ai-in-chargebee/data-lookup-agent",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/chargebee.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://YOUR-CHARGEBEE-SUBDOMAIN.mcp.chargebee.com/data_lookup_agent",
-          "variables": {
-            "YOUR-CHARGEBEE-SUBDOMAIN": {
-              "description": "Site subdomain; EU and AU data centers use `mcp.eu.chargebee.com` or `mcp.au.chargebee.com` instead.",
-              "isRequired": true
-            }
-          },
-          "headers": [
-            {
-              "name": "Authorization",
-              "description": "Chargebee MCP server API key. Use Bearer <token>.",
-              "isRequired": true,
-              "isSecret": true
-            }
-          ]
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.chargebee/chargebee-knowledge-base-mcp-server",
-      "title": "Chargebee Knowledge Base",
-      "description": "Chargebee exposes tenant-scoped REST APIs at `/api/v1` and `/api/v2` authenticated with a site API key via HTTP Basic Auth, plus MCP servers for Knowledge Base (public), Data Lookup, Onboarding, and Custom tools authenticated either by per-server Bearer API keys or Chargebee-issued OAuth clients.",
-      "version": "1.0.0",
-      "websiteUrl": "https://www.chargebee.com/docs/billing/2.0/ai-in-chargebee/knowledge-base-agent",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/chargebee.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://YOUR-CHARGEBEE-SUBDOMAIN.mcp.chargebee.com/knowledge_base_agent",
-          "variables": {
-            "YOUR-CHARGEBEE-SUBDOMAIN": {
-              "description": "Site subdomain; EU and AU data centers use `mcp.eu.chargebee.com` or `mcp.au.chargebee.com` instead.",
-              "isRequired": true
-            }
-          }
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.chargebee/chargebee-onboarding-mcp-server",
-      "title": "Chargebee Onboarding",
-      "description": "Chargebee exposes tenant-scoped REST APIs at `/api/v1` and `/api/v2` authenticated with a site API key via HTTP Basic Auth, plus MCP servers for Knowledge Base (public), Data Lookup, Onboarding, and Custom tools authenticated either by per-server Bearer API keys or Chargebee-issued OAuth clients.",
-      "version": "1.0.0",
-      "websiteUrl": "https://www.chargebee.com/docs/billing/2.0/ai-in-chargebee/onboarding-agent",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/chargebee.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://YOUR-CHARGEBEE-SUBDOMAIN.mcp.chargebee.com/onboarding_agent",
-          "variables": {
-            "YOUR-CHARGEBEE-SUBDOMAIN": {
-              "description": "Site subdomain; EU and AU data centers use `mcp.eu.chargebee.com` or `mcp.au.chargebee.com` instead.",
-              "isRequired": true
-            }
-          },
-          "headers": [
-            {
-              "name": "Authorization",
-              "description": "Chargebee MCP server API key. Use Bearer <token>.",
-              "isRequired": true,
-              "isSecret": true
-            }
-          ]
         }
       ]
     }
@@ -5683,62 +5818,6 @@
         {
           "type": "streamable-http",
           "url": "https://ai.chronograph.pe/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "io.chronosphere/mcp",
-      "title": "Chronosphere",
-      "description": "Chronosphere provides an observability platform for metrics, logs, traces, dashboards, monitors, and related telemetry management. It also offers tooling for API, CLI, and MCP-based access to tenant data and platform configuration.",
-      "version": "1.0.0",
-      "websiteUrl": "https://docs.chronosphere.io/integrate/mcp-server/authenticate",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/chronosphere.io"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://{tenant}.chronosphere.io/api/mcp/mcp",
-          "variables": {
-            "tenant": {
-              "description": "Value for {tenant}.",
-              "isRequired": true
-            }
-          },
-          "headers": [
-            {
-              "name": "Authorization",
-              "description": "Chronosphere API token. Use Bearer <token>.",
-              "isRequired": true,
-              "isSecret": true
-            }
-          ]
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "fun.cinemo/mcp",
-      "title": "Cinemô",
-      "description": "Cinemô appears to be a consumer movie/video application hosted at `cinemo.fun`. Public probing and the site itself did not reveal developer-facing APIs, GraphQL endpoints, or CLIs beyond the registered MCP server.",
-      "version": "1.0.0",
-      "websiteUrl": "https://integrations.sh/cinemo.fun/cinem-mcp-server/",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/cinemo.fun"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://mcp.cinemo.fun/mcp"
         }
       ]
     }
@@ -6189,9 +6268,9 @@
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.cloudflare/mcp",
       "title": "Cloudflare Developer Platform",
-      "description": "Cloudflare is a cloud connectivity platform offering developer infrastructure, security, Zero Trust, and network services. It provides products including Workers, storage and AI services, CDN and DNS, and application and network protection.",
+      "description": "Cloudflare provides a global cloud platform for application delivery, security, developer compute, storage, AI, and Zero Trust networking. Its products include Workers, R2, D1, AI services, CDN/DNS, and enterprise network and security controls.",
       "version": "1.0.0",
-      "websiteUrl": "https://developers.cloudflare.com/agents/model-context-protocol/cloudflare/servers-for-cloudflare/",
+      "websiteUrl": "https://developers.cloudflare.com/agents/model-context-protocol/",
       "icons": [
         {
           "src": "https://integrations.sh/logo/cloudflare.com"
@@ -6376,27 +6455,6 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.follett/mcp",
-      "title": "College Nation",
-      "description": "College Nation MCP server discovered by integrations.sh.",
-      "version": "1.0.0",
-      "websiteUrl": "https://www.collegenation.com",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/follett.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://api.gptapps-aws.follett.com/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.olutely/color-designer-mcp",
       "title": "Color Designer",
       "description": "Olutely's widget service, operated by Spheric Admin Ltd, provides interactive widgets and basic app behavior inside ChatGPT. Its terms describe widget requests being handled by the company's own MCP servers without storing conversation content persistently.",
@@ -6474,35 +6532,6 @@
         {
           "type": "streamable-http",
           "url": "https://external-agent-mcp.ctmers.io/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "dev.composio/mcp",
-      "title": "Composio",
-      "description": "Composio is an integration platform for AI agents that provides access to many third-party apps, user-scoped authentication handling, tool execution, sessions, triggers, and sandboxed workflows. It lets developers connect agents to external services through managed auth and routing infrastructure.",
-      "version": "1.0.0",
-      "websiteUrl": "https://docs.composio.dev/docs/single-toolkit-mcp",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/composio.dev"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://backend.composio.dev/v3/mcp/YOUR_SERVER_ID?user_id=YOUR_USER_ID",
-          "headers": [
-            {
-              "name": "x-api-key",
-              "description": "Composio project API key. Use <token>.",
-              "isRequired": true,
-              "isSecret": true
-            }
-          ]
         }
       ]
     }
@@ -6786,35 +6815,6 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "de.corrently/mcp",
-      "title": "CorrentlyEnergy",
-      "description": "Corrently is a German green-energy brand of STROMDAO GmbH focused on electricity and gas services plus regional renewable-energy forecasting via its GrünstromIndex. It provides digital energy data and optimization services such as CO2, pricing, and scheduling forecasts for German locations.",
-      "version": "1.0.0",
-      "websiteUrl": "https://console.corrently.io/",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/corrently.de"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://api.corrently.io/v2.0/mcp/tools",
-          "headers": [
-            {
-              "name": "Authorization",
-              "description": "Corrently Energy API access token. Use Bearer <token>.",
-              "isRequired": true,
-              "isSecret": true
-            }
-          ]
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.clarivate/mcp",
       "title": "Cortellis Regulatory Intelligence",
       "description": "Clarivate provides data, analytics, and workflow products across academic research, intellectual property, and life sciences. Its products include Web of Science, Cortellis, Derwent, Converis, and related research and regulatory information services.",
@@ -6879,15 +6879,10 @@
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.cosmicjs/cosmic-hosted-mcp-agent-scope",
-      "title": "Cosmic Hosted  (agent scope)",
-      "description": "Cosmic is a headless CMS and AI-enabled content platform for managing structured content, media, and related workflows. Users create projects and buckets in the Cosmic dashboard, then access that content through APIs, MCP, and tooling.",
+      "title": "Cosmic",
+      "description": "Cosmic hosted MCP server for agent-scoped access to CMS buckets and content.",
       "version": "1.0.0",
       "websiteUrl": "https://www.cosmicjs.com/docs/agent-skills",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/cosmicjs.com"
-        }
-      ],
       "remotes": [
         {
           "type": "streamable-http",
@@ -6896,47 +6891,6 @@
             {
               "name": "Authorization",
               "description": "Agent key. Use Bearer <token>.",
-              "isRequired": true,
-              "isSecret": true
-            }
-          ]
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.cosmicjs/cosmic-hosted-mcp-bucket-scope",
-      "title": "Cosmic Hosted  (bucket scope)",
-      "description": "Cosmic is a headless CMS and AI-enabled content platform for managing structured content, media, and related workflows. Users create projects and buckets in the Cosmic dashboard, then access that content through APIs, MCP, and tooling.",
-      "version": "1.0.0",
-      "websiteUrl": "https://www.cosmicjs.com/docs/mcp-server",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/cosmicjs.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://mcp.cosmicjs.com/v1/buckets/{your-bucket-slug}",
-          "variables": {
-            "your-bucket-slug": {
-              "description": "Bucket slug for the bucket the MCP server should access.",
-              "isRequired": true
-            }
-          },
-          "headers": [
-            {
-              "name": "Authorization",
-              "description": "Bucket read key. Use Bearer <token>.",
-              "isRequired": true,
-              "isSecret": true
-            },
-            {
-              "name": "X-Cosmic-Write-Key",
-              "description": "Bucket read key. Use <token>.",
               "isRequired": true,
               "isSecret": true
             }
@@ -7292,27 +7246,6 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.cruisebound/mcp",
-      "title": "Cruisebound",
-      "description": "Cruisebound is an online cruise search and booking platform for ocean and river cruises. It aggregates cruise itineraries, pricing, and availability across multiple cruise lines and lets travelers compare and book sailings.",
-      "version": "1.0.0",
-      "websiteUrl": "https://cruisebound.com/llms.txt",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/cruisebound.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "sse",
-          "url": "https://mcp.cruisebound.com/openai/sse"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.crypto/mcp",
       "title": "Crypto.com Market Data",
       "description": "Crypto.com is a cryptocurrency and financial services platform offering exchange trading, payments, and developer tooling for the Cronos blockchain ecosystem. Its products include exchange services, merchant payments, on-chain developer services, and AI/MCP-based access to market data.",
@@ -7411,6 +7344,48 @@
         {
           "type": "streamable-http",
           "url": "https://mcp.daloopa.com/server/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "cc.databuddy/databuddy-mcp-server",
+      "title": "Databuddy",
+      "description": "Databuddy is a privacy-focused developer analytics platform that combines web analytics, event tracking, feature flags, uptime monitoring, short links, and related tooling. It also provides AI-agent access to that data and configuration through an MCP server and agent-auth metadata.",
+      "version": "1.0.0",
+      "websiteUrl": "https://www.databuddy.cc/docs/api/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/databuddy.cc"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.databuddy.cc/v1/mcp/"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "cc.databuddy/databuddy-mcp-alternate-endpoint",
+      "title": "Databuddy  alternate endpoint",
+      "description": "Databuddy is a privacy-focused developer analytics platform that combines web analytics, event tracking, feature flags, uptime monitoring, short links, and related tooling. It also provides AI-agent access to that data and configuration through an MCP server and agent-auth metadata.",
+      "version": "1.0.0",
+      "websiteUrl": "https://www.databuddy.cc/docs/api/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/databuddy.cc"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.databuddy.cc/mcp"
         }
       ]
     }
@@ -7628,35 +7603,6 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.dbt/mcp",
-      "title": "dbt",
-      "description": "dbt is a data transformation and analytics engineering platform for building, running, and governing data projects. Its platform includes administrative APIs, metadata and semantic query interfaces, and AI-assisted tooling around dbt projects.",
-      "version": "1.0.0",
-      "websiteUrl": "https://docs.getdbt.com/docs/dbt-ai/mcp-quickstart-remote",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/dbt.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://YOUR_DBT_HOST_URL/api/ai/v1/mcp/",
-          "headers": [
-            {
-              "name": "Authorization",
-              "description": "dbt service account token. Use Bearer or Token <token>.",
-              "isRequired": true,
-              "isSecret": true
-            }
-          ]
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "io.argorand/mcp",
       "title": "DC PASS Contracts",
       "description": "Argorand is an AWS-focused consulting and software services company serving fintech and regulated-industry customers. Its public site describes services such as cloud infrastructure, compliance, systems integrations, and zero-trust architectures.",
@@ -7826,6 +7772,27 @@
         {
           "type": "streamable-http",
           "url": "https://mcp.descope.com"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.descript/mcp",
+      "title": "Descript",
+      "description": "Descript is an audio and video editing platform with AI-assisted editing, transcription, publishing, and collaboration features. It is used to create and edit podcasts, videos, captions, clips, and other media projects.",
+      "version": "1.0.0",
+      "websiteUrl": "https://help.descript.com/hc/en-us/articles/46351582343309-Connect-Descript-to-any-AI-assistant-custom-MCP",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/descript.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.descript.com/v2/mcp"
         }
       ]
     }
@@ -8064,6 +8031,48 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "org.dmfam/dmf-app-webmcp-tools",
+      "title": "DMF app WebMCP tools",
+      "description": "DMF (Digital Monetary Framework) is a non-custodial protocol on Base that issues dmfUSD, a USDC-backed digital token with deterministic minting, redemption, and transparent on-chain reserves. Its site and app provide documentation, transparency data, and WebMCP-based agent interactions around the protocol.",
+      "version": "1.0.0",
+      "websiteUrl": "https://integrations.sh/dmfam.org/dmf-app-webmcp-tools/",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/dmfam.org"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://app.dmfam.org"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "org.dmfam/dmf-site-webmcp-tools",
+      "title": "DMF site WebMCP tools",
+      "description": "DMF (Digital Monetary Framework) is a non-custodial protocol on Base that issues dmfUSD, a USDC-backed digital token with deterministic minting, redemption, and transparent on-chain reserves. Its site and app provide documentation, transparency data, and WebMCP-based agent interactions around the protocol.",
+      "version": "1.0.0",
+      "websiteUrl": "https://raw.githubusercontent.com/dmf-frame/knowledge/main/agents/webmcp-tool-catalog.md",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/dmfam.org"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://dmfam.org"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.docketai/mcp",
       "title": "Docket",
       "description": "Docket provides AI agents for B2B marketing and sales teams, including website engagement, sales knowledge retrieval, and workflow integrations. Its platform connects to business systems like CRM, collaboration, and knowledge tools to power those agents.",
@@ -8192,9 +8201,9 @@
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.docusign/mcp",
       "title": "Docusign",
-      "description": "Docusign MCP server discovered by integrations.sh.",
+      "description": "Docusign provides electronic signature and agreement management products, including APIs for eSignature, admin, rooms, web forms, workflows, and related agreement operations. Its platform also offers AI-tool access through a hosted MCP server and developer tooling for building and managing integrations.",
       "version": "1.0.0",
-      "websiteUrl": "https://developers.docusign.com/tools/mcp-server/",
+      "websiteUrl": "https://developers.docusign.com/platform/mcp-server/",
       "icons": [
         {
           "src": "https://integrations.sh/logo/docusign.com"
@@ -8203,28 +8212,15 @@
       "remotes": [
         {
           "type": "streamable-http",
-          "url": "https://mcp.docusign.com/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "app.domotz/domotz-mcp-server",
-      "title": "Domotz",
-      "description": "Domotz is a cloud-based network monitoring and management platform for MSPs, IT teams, and enterprise environments. It provides device discovery, topology and status monitoring, remote access, diagnostics, and related network operations features across distributed sites.",
-      "version": "1.0.0",
-      "websiteUrl": "https://help.domotz.com/integrations/domotz-mcp-server-setup/",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/domotz.app"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://mcp.ov.domotz.app/mcp"
+          "url": "https://mcp.docusign.com/mcp",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "Docusign OAuth access token. Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
         }
       ]
     }
@@ -8240,27 +8236,6 @@
       "icons": [
         {
           "src": "https://integrations.sh/logo/domotz.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://mcp.domotz.com/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "app.domotz/domotz-mcp-server-documented-endpoint",
-      "title": "Domotz   (documented endpoint)",
-      "description": "Domotz is a cloud-based network monitoring and management platform for MSPs, IT teams, and enterprise environments. It provides device discovery, topology and status monitoring, remote access, diagnostics, and related network operations features across distributed sites.",
-      "version": "1.0.0",
-      "websiteUrl": "https://help.domotz.com/integrations/domotz-mcp-server-setup/",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/domotz.app"
         }
       ],
       "remotes": [
@@ -8393,60 +8368,6 @@
         {
           "type": "streamable-http",
           "url": "https://www.pyxl.pro/api/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "cloud.dremio/mcp",
-      "title": "Dremio-hosted",
-      "description": "Dremio Cloud is a managed data lakehouse platform for querying, governing, and accelerating access to data across sources. It provides catalog, SQL, job, engine, and AI-agent integration capabilities for cloud-hosted Dremio projects.",
-      "version": "1.0.0",
-      "websiteUrl": "https://docs.dremio.com/dremio-cloud/ai-integration/mcp-server/",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/dremio.cloud"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://mcp.dremio.cloud/mcp/{project_id}",
-          "variables": {
-            "project_id": {
-              "description": "Replace `{project_id}` with your Dremio project ID; the docs say the Project Overview page exposes the MCP endpoint value.",
-              "isRequired": true
-            }
-          }
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.dremio/mcp",
-      "title": "Dremio-hosted",
-      "description": "Dremio is a data lakehouse platform for querying, managing, and governing data across sources, with cloud and self-managed offerings. It also provides AI-agent connectivity through MCP and developer tooling for programmatic access.",
-      "version": "1.0.0",
-      "websiteUrl": "https://docs.dremio.com/dremio-cloud/ai-integration/mcp-server/",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/dremio.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://mcp.dremio.cloud/mcp/{project_id}",
-          "variables": {
-            "project_id": {
-              "description": "Project UUID inserted into the MCP endpoint path.",
-              "isRequired": true
-            }
-          }
         }
       ]
     }
@@ -9044,6 +8965,48 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "dev.evlog/evlog-mcp-server",
+      "title": "evlog",
+      "description": "evlog is a TypeScript logging library for structured logs, wide events, and structured errors across web apps, scripts, and server runtimes. Its documentation covers framework integrations, log drains, audit logging, and AI-observability use cases.",
+      "version": "1.0.0",
+      "websiteUrl": "https://evlog.dev/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/evlog.dev"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://evlog.dev/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "dev.evlog/mcp-server",
+      "title": "Evlog",
+      "description": "evlog is a TypeScript logging library for structured logs, wide events, and structured errors across web apps, scripts, and server runtimes. Its documentation covers framework integrations, log drains, audit logging, and AI-observability use cases.",
+      "version": "1.0.0",
+      "websiteUrl": "https://integrations.sh/evlog.dev/mcp-server/",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/evlog.dev"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://www.evlog.dev/.well-known/mcp/server-card.json"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "ai.exa/mcp",
       "title": "Exa",
       "description": "Exa provides AI-focused web search, content extraction, answer generation, and related research tools. Its platform is used to search the web, fetch and structure webpage content, and support agent workflows.",
@@ -9058,6 +9021,35 @@
         {
           "type": "streamable-http",
           "url": "https://mcp.exa.ai/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.excalidraw/mcp",
+      "title": "Excalidraw",
+      "description": "Excalidraw is a collaborative whiteboarding and diagramming service. Its Excalidraw Plus offering adds workspace management, scenes, collections, and programmable access for integrations and AI clients.",
+      "version": "1.0.0",
+      "websiteUrl": "https://plus.excalidraw.com/docs/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/excalidraw.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.excalidraw.com/mcp",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "Excalidraw Plus API key. Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
         }
       ]
     }
@@ -9100,6 +9092,27 @@
         {
           "type": "streamable-http",
           "url": "https://www.expedia.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.expense-budget-tracker/mcp",
+      "title": "Expense Budget Tracker  Connector",
+      "description": "Expense Budget Tracker is an open-source personal finance and budgeting app for tracking expenses, planning budgets, and viewing financial dashboards with multi-currency support. It offers a managed cloud service as well as self-hosting options.",
+      "version": "1.0.0",
+      "websiteUrl": "https://expense-budget-tracker.com/docs/mcp-connector/",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/expense-budget-tracker.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.expense-budget-tracker.com/mcp"
         }
       ]
     }
@@ -9262,6 +9275,35 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.fakerforge/mcp",
+      "title": "Faker Forge",
+      "description": "Faker Forge is a synthetic data and API mocking platform for developers. It helps users generate realistic mock data from schemas, manage mock APIs with scenarios, and expose those workflows to AI agents through MCP.",
+      "version": "1.0.0",
+      "websiteUrl": "https://fakerforge.com/docs/mcp-quickstart",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/fakerforge.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://fakerforge.com/mcp/fakerforge",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "Faker Forge API token. Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "ai.fal/mcp",
       "title": "fal",
       "description": "fal.ai is a generative media platform for developers to run hosted AI models, deploy serverless model endpoints, and manage related assets, usage, and compute resources. It supports image, video, audio, workflow, and real-time inference use cases.",
@@ -9297,6 +9339,27 @@
         {
           "type": "streamable-http",
           "url": "https://partner-mcp.fareharbor.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.os1221/mcp",
+      "title": "FATE",
+      "description": "os1221.com hosts FATE, a live 2026 FIFA World Cup probability and fantasy draft board that combines match results with simulation and rating data. It publishes read-only data endpoints for standings, market checks, ratings, and related share artifacts.",
+      "version": "1.0.0",
+      "websiteUrl": "https://os1221.com/.well-known/mcp/server-card.json",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/os1221.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://os1221.com"
         }
       ]
     }
@@ -9460,6 +9523,27 @@
       },
       "version": "1.0.3",
       "websiteUrl": "https://www.figma.com",
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.figma.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.figma/mcp",
+      "title": "Figma",
+      "description": "Figma is a collaborative design and product-development platform for interface design, prototyping, whiteboarding, and developer handoff. It also provides organization user-provisioning via SCIM and AI-agent access to design context through its MCP server.",
+      "version": "1.0.0",
+      "websiteUrl": "https://developers.figma.com/docs/figma-mcp-server/remote-server-installation/",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/figma.com"
+        }
+      ],
       "remotes": [
         {
           "type": "streamable-http",
@@ -9755,6 +9839,27 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.flashcards-open-source-app/mcp",
+      "title": "Flashcards",
+      "description": "Flashcards is an open-source spaced-repetition flashcards app with web, iOS, and Android clients plus a self-hosted deployment path. It stores study data in workspaces and supports AI-agent access for reading and modifying cards, decks, media, and package data.",
+      "version": "1.0.0",
+      "websiteUrl": "https://flashcards-open-source-app.com/docs/mcp-connector/",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/flashcards-open-source-app.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.flashcards-open-source-app.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.etraveligroup/mcp",
       "title": "Flight Network",
       "description": "Etraveli Group is a flight technology company that provides travel distribution, payments/fraud, and AI-related products for travel businesses. Its public website describes B2B brands such as Tripstack, Precision, and Wenrix, plus consumer travel brands.",
@@ -9769,6 +9874,27 @@
         {
           "type": "streamable-http",
           "url": "https://mcp-ultrasearch.etraveligroup.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.flightqueue/mcp",
+      "title": "FlightQueue",
+      "description": "FlightQueue provides airport intelligence data such as security wait times, FAA delays, predictions, and historical airport patterns. Its product covers thousands of airports worldwide and includes free and paid access tiers.",
+      "version": "1.0.0",
+      "websiteUrl": "https://flightqueue.com/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/flightqueue.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.flightqueue.com/mcp"
         }
       ]
     }
@@ -9811,6 +9937,27 @@
         {
           "type": "streamable-http",
           "url": "https://flixor.toolpipe.ai/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.flusterduck/mcp",
+      "title": "Flusterduck",
+      "description": "Flusterduck monitors website behavior to detect user friction, score confusing pages, cluster issues, and verify whether deploys fix those problems. It focuses on behavioral signals rather than session replay or personal data collection.",
+      "version": "1.0.0",
+      "websiteUrl": "https://docs.flusterduck.com/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/flusterduck.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.flusterduck.com/mcp"
         }
       ]
     }
@@ -10105,33 +10252,6 @@
         {
           "type": "streamable-http",
           "url": "https://mcp.frontapp.com/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.frontegg/mcp",
-      "title": "Frontegg Agen for SaaS  Gateway",
-      "description": "Frontegg provides customer identity and access management for B2B SaaS applications, including authentication, user management, SSO, SCIM, and entitlements. It also offers managed MCP gateway capabilities so SaaS products can expose tools securely to AI platforms and agents.",
-      "version": "1.0.0",
-      "websiteUrl": "https://developers.frontegg.com/agen-for-saas/getting-started/connect-ai-platform",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/frontegg.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://{gateway-id}.mcp-gw.frontegg.com",
-          "variables": {
-            "gateway-id": {
-              "description": "Your unique MCP Gateway host shown in the Agen for SaaS control plane, e.g. `your-id.mcp-gw.frontegg.com`.",
-              "isRequired": true
-            }
-          }
         }
       ]
     }
@@ -10552,6 +10672,48 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.getoffers.stage/mcp",
+      "title": "GetOffers",
+      "description": "GetOffers is a B2B travel and expense management platform for companies, travel agencies, and hotels. It supports searching, booking, and managing flights, hotels, transfers, car rentals, yachts, and experiences with AI-assisted workflows.",
+      "version": "1.0.0",
+      "websiteUrl": "https://stage.getoffers.com/",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/stage.getoffers.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://stage.getoffers.com/.well-known/mcp/server-card.json"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.getoffers/mcp",
+      "title": "GetOffers",
+      "description": "GetOffers is a B2B corporate travel and expense management platform for searching, booking, and managing flights, hotels, transfers, car rentals, yachts, and experiences. It serves companies, travel agencies, and hotel partners through an AI-assisted booking platform.",
+      "version": "1.0.0",
+      "websiteUrl": "https://getoffers.com/.well-known/mcp/server-card.json",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/getoffers.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://getoffers.com/.well-known/mcp/server-card.json"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.getyourguide/mcp",
       "title": "GetYourGuide",
       "description": "GetYourGuide is a travel marketplace for tours, activities, and attractions. It also operates supplier and connectivity programs that let partners connect reservation and ticketing systems to its marketplace.",
@@ -10566,6 +10728,35 @@
         {
           "type": "streamable-http",
           "url": "https://widget.getyourguide.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.github/mcp",
+      "title": "GitHub",
+      "description": "GitHub is a software development platform centered on Git repositories, collaboration, automation, and code hosting. It also provides APIs, CLI tooling, and agent integrations for working with repositories, issues, pull requests, workflows, and related developer workflows.",
+      "version": "1.0.0",
+      "websiteUrl": "https://github.com/github/github-mcp-server",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/github.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.githubcopilot.com/mcp/",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "GitHub personal access token (fine-grained or classic). Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
         }
       ]
     }
@@ -10604,37 +10795,6 @@
               "isSecret": true
             }
           ]
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "io.gitmcp/mcp",
-      "title": "GitMCP",
-      "description": "GitMCP creates a Model Context Protocol server for public GitHub repositories so AI assistants can read repository documentation and code context. It works by mapping GitHub repository URLs onto gitmcp.io-hosted MCP endpoints.",
-      "version": "1.0.0",
-      "websiteUrl": "https://gitmcp.io/",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/gitmcp.io"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "sse",
-          "url": "https://gitmcp.io/{owner}/{repo}",
-          "variables": {
-            "owner": {
-              "description": "The GitHub account or organization that owns the repository.",
-              "isRequired": true
-            },
-            "repo": {
-              "description": "The GitHub repository name.",
-              "isRequired": true
-            }
-          }
         }
       ]
     }
@@ -10782,27 +10942,6 @@
         {
           "type": "streamable-http",
           "url": "https://agents.talktoglow.com/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.googleapis.gmail/mcp",
-      "title": "Gmail",
-      "description": "Gmail is Google's email service. Its developer interfaces let applications and agents read, manage, and send mail in authorized Gmail accounts.",
-      "version": "1.0.0",
-      "websiteUrl": "https://developers.google.com/workspace/gmail/api/guides/configure-mcp-server",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/gmail.googleapis.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://gmail.googleapis.com/mcp/"
         }
       ]
     }
@@ -11076,27 +11215,6 @@
         {
           "type": "streamable-http",
           "url": "https://playdeveloperreporting.googleapis.com/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.googleapis.shoppingcontent/mcp",
-      "title": "Google Shopping Content",
-      "description": "shoppingcontent.googleapis.com is Google's API host for Merchant Center / Content API for Shopping operations, such as managing products, accounts, and related shopping data. It serves programmatic interfaces used to automate Google Shopping and Merchant Center account management.",
-      "version": "1.0.0",
-      "websiteUrl": "https://developers.google.com/shopping-content/guides",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/shoppingcontent.googleapis.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://shoppingcontent.googleapis.com/mcp"
         }
       ]
     }
@@ -11519,6 +11637,27 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "ai.usehalyard.mcp/halyard-mcp-server",
+      "title": "Halyard",
+      "description": "Halyard is an organizational context engine that indexes a team's knowledge into a graph and lets AI agents retrieve it or ask human experts through Slack. It provides MCP tools for knowledge search and updates, people and org data, expert conversations, and delivery metrics.",
+      "version": "1.0.0",
+      "websiteUrl": "https://mcp.usehalyard.ai/install",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/mcp.usehalyard.ai"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.usehalyard.ai"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "ai.com.mcp/mcp",
       "title": "HAPI  Registry",
       "description": "mcp.com.ai is the documentation and product site for La Rebelion's HAPI MCP stack, which helps developers turn APIs into MCP-compatible services and interact with them through cloud and local tooling. Its docs describe components including HAPI Server, runMCP, chatMCP, and QBot.",
@@ -11673,27 +11812,6 @@
               "isSecret": false
             }
           ]
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.heepsy/mcp",
-      "title": "Heepsy Influencer Search",
-      "description": "Heepsy is an influencer marketing platform for brands and agencies to find, analyze, manage, and pay creators across Instagram, TikTok, and YouTube. Its website also offers public influencer rankings and related marketing tools.",
-      "version": "1.0.0",
-      "websiteUrl": "https://integrations.sh/heepsy.com/heepsy-influencer-search-mcp/",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/heepsy.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://mcp.heepsy.com/mcp"
         }
       ]
     }
@@ -11911,54 +12029,6 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "io.vectorize/hindsight-cloud-mcp-server-multi-bank",
-      "title": "Hindsight Cloud   (multi-bank)",
-      "description": "Vectorize provides hosted tools for building retrieval-augmented generation pipelines and managing data ingestion, retrieval, and chat endpoints for AI applications. It also offers Hindsight Cloud, a managed memory system for AI agents that stores, retrieves, and reasons over persistent agent memory.",
-      "version": "1.0.0",
-      "websiteUrl": "https://docs.hindsight.vectorize.io/mcp",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/vectorize.io"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://api.hindsight.vectorize.io/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "io.vectorize/hindsight-cloud-mcp-server-single-bank",
-      "title": "Hindsight Cloud   (single-bank)",
-      "description": "Vectorize provides hosted tools for building retrieval-augmented generation pipelines and managing data ingestion, retrieval, and chat endpoints for AI applications. It also offers Hindsight Cloud, a managed memory system for AI agents that stores, retrieves, and reasons over persistent agent memory.",
-      "version": "1.0.0",
-      "websiteUrl": "https://docs.hindsight.vectorize.io/mcp",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/vectorize.io"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://api.hindsight.vectorize.io/mcp/{bank_id}/",
-          "variables": {
-            "bank_id": {
-              "description": "Memory bank name in the MCP endpoint path.",
-              "isRequired": true
-            }
-          }
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "au.com.hipages/mcp",
       "title": "hipages",
       "description": "hipages is an Australian home improvement platform that helps homeowners find, compare, and hire tradies, and provides tradies with lead generation and business management tools. It also offers planning resources such as articles, cost guides, calculators, and mobile apps for households and businesses.",
@@ -11973,6 +12043,93 @@
         {
           "type": "streamable-http",
           "url": "https://mcp.hipages.com.au/v1"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.hitkeep.cloud/mcp",
+      "title": "HitKeep",
+      "description": "HitKeep Cloud is a hosted privacy-first web analytics service. It lets teams collect and analyze website traffic, events, conversions, and related reporting data.",
+      "version": "1.0.0",
+      "websiteUrl": "https://hitkeep.com/guides/integrations/mcp/",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/cloud.hitkeep.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://cloud.hitkeep.com/mcp",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "HitKeep API client token. Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.hitkeep/mcp",
+      "title": "HitKeep",
+      "description": "HitKeep is a privacy-first web analytics product available as managed cloud or self-hosted single-binary software. It provides cookie-light tracking, analytics dashboards, exports, and optional AI-assisted analytics features.",
+      "version": "1.0.0",
+      "websiteUrl": "https://hitkeep.com/guides/integrations/mcp/",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/hitkeep.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://hitkeep.com/mcp",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "HitKeep API client bearer token. Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "eu.hitkeep.cloud/mcp",
+      "title": "HitKeep",
+      "description": "HitKeep is a privacy-first web analytics product offered as managed EU/US cloud and self-hosted deployments. It provides analytics, tracking, and AI-facing access to web analytics data.",
+      "version": "1.0.0",
+      "websiteUrl": "https://hitkeep.com/guides/integrations/mcp/",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/cloud.hitkeep.eu"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://cloud.hitkeep.eu/mcp",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "HitKeep API client token. Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
         }
       ]
     }
@@ -12030,6 +12187,35 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "dev.honcho/mcp",
+      "title": "Honcho",
+      "description": "Honcho is a memory and reasoning system for stateful AI agents, with managed APIs and tools for storing conversations, querying representations, and adding persistent memory to agent workflows.",
+      "version": "1.0.0",
+      "websiteUrl": "https://honcho.dev/docs/v3/guides/integrations/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/honcho.dev"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.honcho.dev",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "Honcho API key. Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "io.honeycomb/mcp",
       "title": "Honeycomb",
       "description": "Honeycomb is an observability platform for exploring telemetry from distributed systems and applications. It helps teams investigate performance, reliability, and behavior using high-cardinality event, trace, and related operational data.",
@@ -12057,20 +12243,20 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "cloud.fastmcp/horizon-hosted-mcp-server-endpoint",
-      "title": "Horizon-hosted   endpoint",
-      "description": "FastMCP Cloud, now presented as Prefect Horizon, is a managed platform for deploying and governing MCP servers. It lets users connect GitHub-hosted FastMCP projects to hosted MCP endpoints with built-in authentication and access control.",
+      "name": "com.trainheroic-unofficial/hosted-mcp-server",
+      "title": "Hosted",
+      "description": "trainheroic-unofficial.com documents an unofficial toolkit for accessing the TrainHeroic platform, including hosted and local MCP tooling, a CLI, and an export page. It is a separate project from TrainHeroic and wraps an undocumented upstream TrainHeroic API.",
       "version": "1.0.0",
-      "websiteUrl": "https://gofastmcp.com/deployment/prefect-horizon",
+      "websiteUrl": "https://trainheroic-unofficial.com/mcp/",
       "icons": [
         {
-          "src": "https://integrations.sh/logo/fastmcp.cloud"
+          "src": "https://integrations.sh/logo/trainheroic-unofficial.com"
         }
       ],
       "remotes": [
         {
           "type": "streamable-http",
-          "url": "https://your-server-name.fastmcp.app/mcp"
+          "url": "https://mcp.trainheroic-unofficial.com/mcp"
         }
       ]
     }
@@ -12078,20 +12264,41 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "cloud.fastmcp/horizon-hosted-mcp-server-endpoint-2",
-      "title": "Horizon-hosted   endpoint",
-      "description": "FastMCP Cloud, now presented as Prefect Horizon, is a managed platform for deploying and governing MCP servers. It lets users connect GitHub-hosted FastMCP projects to hosted MCP endpoints with built-in authentication and access control.",
+      "name": "com.trainheroic-unofficial/hosted-mcp-server-athlete-only",
+      "title": "Hosted   (athlete-only)",
+      "description": "trainheroic-unofficial.com documents an unofficial toolkit for accessing the TrainHeroic platform, including hosted and local MCP tooling, a CLI, and an export page. It is a separate project from TrainHeroic and wraps an undocumented upstream TrainHeroic API.",
       "version": "1.0.0",
-      "websiteUrl": "https://prefect.io/horizon",
+      "websiteUrl": "https://trainheroic-unofficial.com/mcp/",
       "icons": [
         {
-          "src": "https://integrations.sh/logo/fastmcp.cloud"
+          "src": "https://integrations.sh/logo/trainheroic-unofficial.com"
         }
       ],
       "remotes": [
         {
           "type": "streamable-http",
-          "url": "https://my-tools.horizon.prefect.io"
+          "url": "https://mcp.trainheroic-unofficial.com/mcp/athlete"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.trainheroic-unofficial/hosted-mcp-server-coach-only",
+      "title": "Hosted   (coach-only)",
+      "description": "trainheroic-unofficial.com documents an unofficial toolkit for accessing the TrainHeroic platform, including hosted and local MCP tooling, a CLI, and an export page. It is a separate project from TrainHeroic and wraps an undocumented upstream TrainHeroic API.",
+      "version": "1.0.0",
+      "websiteUrl": "https://trainheroic-unofficial.com/mcp/",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/trainheroic-unofficial.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.trainheroic-unofficial.com/mcp/coach"
         }
       ]
     }
@@ -12113,6 +12320,35 @@
         {
           "type": "streamable-http",
           "url": "https://hmcp.hostinger.com/chatgpt/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.hostodo/mcp",
+      "title": "Hostodo",
+      "description": "Hostodo is a VPS hosting provider offering unmanaged Linux KVM virtual private servers with NVMe storage and multiple US datacenter locations. Customers use its console and tools to deploy and manage VPS instances.",
+      "version": "1.0.0",
+      "websiteUrl": "https://hostodo.com/docs/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/hostodo.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.hostodo.com/mcp",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "Hostodo MCP token. Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
         }
       ]
     }
@@ -12206,9 +12442,9 @@
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "co.huggingface/hugging-face",
       "title": "Hugging Face",
-      "description": "Hugging Face is a platform for hosting and collaborating on machine learning models, datasets, Spaces, and related AI tooling. It also provides integrated services around inference, jobs, and access-controlled organization resources.",
+      "description": "Hugging Face hosts a platform for sharing and using machine learning models, datasets, and AI applications called Spaces. It also offers managed inference infrastructure and developer tooling around the Hugging Face Hub.",
       "version": "1.0.0",
-      "websiteUrl": "https://huggingface.co/docs/hub/agents-mcp.md",
+      "websiteUrl": "https://huggingface.co/mcp?login&gradio=none",
       "icons": [
         {
           "src": "https://integrations.sh/logo/huggingface.co"
@@ -12227,7 +12463,7 @@
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "co.huggingface/mcp-server",
       "title": "Huggingface",
-      "description": "Hugging Face is a platform for hosting and collaborating on machine learning models, datasets, Spaces, and related AI tooling. It also provides integrated services around inference, jobs, and access-controlled organization resources.",
+      "description": "Hugging Face hosts a platform for sharing and using machine learning models, datasets, and AI applications called Spaces. It also offers managed inference infrastructure and developer tooling around the Hugging Face Hub.",
       "version": "1.0.0",
       "websiteUrl": "https://integrations.sh/huggingface.co/mcp-server/",
       "icons": [
@@ -12281,49 +12517,6 @@
         {
           "type": "streamable-http",
           "url": "https://www.hyatt.com/mcp/browse"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.hygraph/mcp",
-      "title": "Hygraph",
-      "description": "Hygraph is a headless, GraphQL-native content platform for modeling, managing, and delivering structured content across websites, apps, and other channels. It also offers AI-oriented MCP access so assistants can interact with project content and schema using the same underlying platform.",
-      "version": "1.0.0",
-      "websiteUrl": "https://hygraph.com/docs/hygraph-ai/mcp-server-setup",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/hygraph.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://mcp-{REGION}.hygraph.com/{PROJECT_ID}/{ENVIRONMENT}/mcp",
-          "variables": {
-            "REGION": {
-              "description": "Region segment from the MCP Server API endpoint shown in Project Settings → Access → Endpoints.",
-              "isRequired": true
-            },
-            "PROJECT_ID": {
-              "description": "Hygraph project ID in the MCP endpoint path.",
-              "isRequired": true
-            },
-            "ENVIRONMENT": {
-              "description": "Hygraph environment name in the MCP endpoint path.",
-              "isRequired": true
-            }
-          },
-          "headers": [
-            {
-              "name": "Authorization",
-              "description": "Permanent Auth Token (PAT). Use Bearer <token>.",
-              "isRequired": true,
-              "isSecret": true
-            }
-          ]
         }
       ]
     }
@@ -12557,6 +12750,127 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.influencekit.api/influencekit-mcp-server",
+      "title": "InfluenceKit",
+      "description": "InfluenceKit is an influencer marketing platform for brands, agencies, and creators. It supports campaign management, creator discovery, cross-platform content statistics, and shareable reporting.",
+      "version": "1.0.0",
+      "websiteUrl": "https://help.influencekit.com/en/articles/14011645-using-influencekit-with-ai-assistants-mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/api.influencekit.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.influencekit.com/mcp",
+          "headers": [
+            {
+              "name": "X-API-KEY",
+              "description": "InfluenceKit API key. Use <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.influencekit/influencekit-mcp-server",
+      "title": "InfluenceKit",
+      "description": "InfluenceKit is an influencer marketing platform for brands, agencies, and creators. It provides campaign management, creator discovery, cross-platform content statistics, and shareable reporting.",
+      "version": "1.0.0",
+      "websiteUrl": "https://help.influencekit.com/en/articles/14011645-using-influencekit-with-ai-assistants-mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/influencekit.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.influencekit.com/mcp",
+          "headers": [
+            {
+              "name": "X-API-KEY",
+              "description": "InfluenceKit API key. Use <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.influencekit/influencekit-mcp-server-2",
+      "title": "InfluenceKit",
+      "description": "InfluenceKit is an influencer marketing platform for brands, agencies, and creators. It provides campaign management, creator discovery, cross-platform content statistics, and shareable reporting.",
+      "version": "1.0.0",
+      "websiteUrl": "https://help.influencekit.com/en/articles/14011645-using-influencekit-with-ai-assistants-mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/influencekit.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://influencekit.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.influencekit.api/influencekit-public-mcp-server-signup",
+      "title": "InfluenceKit public   (signup)",
+      "description": "InfluenceKit is an influencer marketing platform for brands, agencies, and creators. It supports campaign management, creator discovery, cross-platform content statistics, and shareable reporting.",
+      "version": "1.0.0",
+      "websiteUrl": "https://api.influencekit.com/llms.txt",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/api.influencekit.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.influencekit.com/mcp/public"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.influencekit/influencekit-public-mcp-server-signup",
+      "title": "InfluenceKit public   (signup)",
+      "description": "InfluenceKit is an influencer marketing platform for brands, agencies, and creators. It provides campaign management, creator discovery, cross-platform content statistics, and shareable reporting.",
+      "version": "1.0.0",
+      "websiteUrl": "https://influencekit.com/llms.txt",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/influencekit.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.influencekit.com/mcp/public"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "chat.inline/mcp",
       "title": "Inline",
       "description": "Inline is a work chat product for teams. It provides messaging, bots, and assistant-oriented integrations around conversations, spaces, and direct messages.",
@@ -12693,9 +13007,9 @@
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "sh.integrations/mcp",
       "title": "integrations.sh",
-      "description": "integrations.sh is an open-source registry of integration surfaces across many services, cataloging APIs, GraphQL endpoints, MCP servers, and CLIs with authentication details. The site also provides its own public API and MCP server for querying that registry.",
+      "description": "integrations.sh is a searchable registry of developer and agent integration surfaces for other services. It catalogs APIs, GraphQL endpoints, MCP servers, and CLIs along with authentication metadata and discovery signals.",
       "version": "1.0.0",
-      "websiteUrl": "https://integrations.sh/integrations.sh/integrations-mcp-server/",
+      "websiteUrl": "https://integrations.sh/integrations.sh/integrations-sh-mcp-server/",
       "icons": [
         {
           "src": "https://integrations.sh/logo/integrations.sh"
@@ -13487,6 +13801,35 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "ai.kakunin/mcp",
+      "title": "Kakunin",
+      "description": "Kakunin provides identity, certificate issuance, behavioral monitoring, and compliance/audit tooling for AI agents. It issues X.509 certificates to agents, scores and logs their behavior, and exposes public verification artifacts for third parties to validate agent credentials.",
+      "version": "1.0.0",
+      "websiteUrl": "https://kakunin.ai/docs/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/kakunin.ai"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://www.kakunin.ai/api/mcp",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "Kakunin API key. Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.kbb/mcp",
       "title": "Kelley Blue Book",
       "description": "Kelley Blue Book provides vehicle data, values, and related automotive content. Its business offerings include APIs such as InfoDriver Web Service and advertising data services for integrating KBB data into applications.",
@@ -13501,6 +13844,41 @@
         {
           "type": "sse",
           "url": "https://kbb-chatgpt-app-prod-a.awskbbcs.kbb.com/mcp/messages"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "work.kennel/mcp",
+      "title": "kennel",
+      "description": "kennel is an open-source task list application with tasks, projects, and labels, plus a web dashboard. It lets apps and AI agents read and modify that task data over HTTP and MCP.",
+      "version": "1.0.0",
+      "websiteUrl": "https://kennel.work/docs",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/kennel.work"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://kennel.work/mcp",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "kennel API key. Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            },
+            {
+              "name": "x-api-key",
+              "description": "kennel API key. Use <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
         }
       ]
     }
@@ -13881,34 +14259,20 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.konghq/mcp",
-      "title": "Kong Konnect",
-      "description": "Kong provides API gateway and API platform products, including the hosted Konnect platform for managing gateway configuration, developer portals, analytics, and related API infrastructure. It also offers developer tools such as decK, kongctl, and Insomnia's Inso CLI.",
+      "name": "ai.thekontextco/mcp",
+      "title": "Kontext",
+      "description": "Kontext is a user-owned library for saving, organizing, and revisiting context created while working with AI, including projects, tasks, documents, and quick saves. It lets users carry that context across compatible AI clients and share selected work under their control.",
       "version": "1.0.0",
-      "websiteUrl": "https://developer.konghq.com/konnect-platform/konnect-mcp/",
+      "websiteUrl": "https://thekontextco.ai/developers",
       "icons": [
         {
-          "src": "https://integrations.sh/logo/konghq.com"
+          "src": "https://integrations.sh/logo/thekontextco.ai"
         }
       ],
       "remotes": [
         {
           "type": "streamable-http",
-          "url": "https://{region}.mcp.konghq.com/",
-          "variables": {
-            "region": {
-              "description": "Regional MCP server hostname prefix.",
-              "isRequired": true
-            }
-          },
-          "headers": [
-            {
-              "name": "Authorization",
-              "description": "Konnect Personal Access Token (PAT). Use Bearer <token>.",
-              "isRequired": true,
-              "isSecret": true
-            }
-          ]
+          "url": "https://thekontextco.ai/mcp"
         }
       ]
     }
@@ -13930,27 +14294,6 @@
         {
           "type": "streamable-http",
           "url": "https://www.trykopi.ai/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "app.railway.up.email-creation-mcp-node-production/mcp",
-      "title": "Kopi - Shopify Email Creator",
-      "description": "This appears to be a deployed MCP server named Kopi - Shopify Email Creator, hosted on Railway. No broader product site or additional public developer surfaces were found on the given domain.",
-      "version": "1.0.0",
-      "websiteUrl": "https://email-creation-mcp-node-production.up.railway.app/mcp",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/email-creation-mcp-node-production.up.railway.app"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://email-creation-mcp-node-production.up.railway.app/mcp"
         }
       ]
     }
@@ -13993,6 +14336,27 @@
         {
           "type": "streamable-http",
           "url": "https://ai-analytics-mcp.kraken.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "ai.krea/mcp",
+      "title": "Krea",
+      "description": "Krea is an AI creative platform for generating and editing images, video, 3D assets, and related media with many underlying models in one workspace. It also offers enterprise features such as shared workspaces, API access, and agent integrations.",
+      "version": "1.0.0",
+      "websiteUrl": "https://www.krea.ai/docs/developers/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/krea.ai"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.krea.ai/mcp"
         }
       ]
     }
@@ -14218,27 +14582,6 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.lambus/mcp",
-      "title": "Lambus",
-      "description": "Lambus is a trip-planning and travel-organization service for building itineraries, managing stops, bookings, expenses, and shared trip details. It also offers AI-assisted planning features that connect the product to assistants like ChatGPT, Claude, and Gemini.",
-      "version": "1.0.0",
-      "websiteUrl": "https://www.lambus.com/ai-connector",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/lambus.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://lambus.com/.well-known/mcp/server-card.json"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "ai.lmnr/mcp",
       "title": "Laminar",
       "description": "Laminar is an observability platform for AI agents and LLM applications. It helps teams trace runs, inspect failures, manage datasets and evaluations, and debug agent behavior over time.",
@@ -14326,9 +14669,9 @@
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.lastminute/mcp",
       "title": "lastminute.com",
-      "description": "lastminute.com is an online travel service for booking flights, hotels, holiday packages, and related travel products. Its public web presence also includes developer-facing endpoints for an MCP server and a documented API host.",
+      "description": "lastminute.com is an online travel booking service for flights, hotels, and flight-plus-hotel packages. Its public site and related materials describe search and booking capabilities for travel products.",
       "version": "1.0.0",
-      "websiteUrl": "https://integrations.sh/lastminute.com/lastminute-com-mcp-server/",
+      "websiteUrl": "https://technology.lastminute.com/mcp/",
       "icons": [
         {
           "src": "https://integrations.sh/logo/lastminute.com"
@@ -14611,6 +14954,27 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "app.lightfield/mcp",
+      "title": "Lightfield",
+      "description": "Lightfield is an AI-native CRM that captures emails, meetings, and other customer interactions to maintain a continuously updated relationship record. It provides CRM records, workflows, and agent-assisted operations for sales and customer-facing teams.",
+      "version": "1.0.0",
+      "websiteUrl": "https://docs.lightfield.app/getting-started/mcp-quickstart/",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/lightfield.app"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.lightfield.app/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.lilt/mcp",
       "title": "LILT",
       "description": "LILT provides enterprise translation and multilingual content workflow software, including machine translation, human verification, and localization project management. It also offers an MCP-based integration so AI assistants can invoke LILT translation workflows.",
@@ -14634,7 +14998,7 @@
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "app.linear/mcp",
       "title": "Linear",
-      "description": "Linear is a project and issue tracking platform for planning and building software products. It organizes work around issues, projects, roadmaps, teams, and related development workflows.",
+      "description": "Linear is a product development and issue tracking platform for planning roadmaps, managing projects, and coordinating software work. It provides workspaces where teams track issues, projects, documents, cycles, customers, and related development activity.",
       "version": "1.0.0",
       "websiteUrl": "https://linear.app/docs/mcp",
       "icons": [
@@ -15315,6 +15679,27 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.luneresearch.mcp/mcp",
+      "title": "Lune Research",
+      "description": "Lune Research provides access to academic research content and workflows, including searching, retrieving, and subscribing to papers. Its public endpoint on this domain is a remote Model Context Protocol server for MCP-compatible clients.",
+      "version": "1.0.0",
+      "websiteUrl": "https://mcp.luneresearch.com/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/mcp.luneresearch.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.luneresearch.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.lusha/mcp",
       "title": "Lusha",
       "description": "Lusha provides B2B contact, company, prospecting, and signal data used for sales, enrichment, and automation workflows. Its platform helps teams search for prospects, enrich records, and monitor business activity changes.",
@@ -15413,6 +15798,27 @@
         {
           "type": "streamable-http",
           "url": "https://prod-v1.mcp.m6.fr/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.macro/mcp",
+      "title": "Macro",
+      "description": "Macro is an open-source workspace app that combines email, messages, documents, tasks, calls, agents, and CRM in one system. It is designed for teams to work from a unified interface with shared context and AI memory.",
+      "version": "1.0.0",
+      "websiteUrl": "https://docs.macro.com/AI/mcp/overview",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/macro.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp-server.macro.com/mcp"
         }
       ]
     }
@@ -15547,27 +15953,6 @@
         {
           "type": "streamable-http",
           "url": "https://mcp.mailersend.com/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "ai.mainfunc/mcp",
-      "title": "MainFunc",
-      "description": "MainFunc is the company behind Genspark, an AI workspace and browser product focused on autonomous AI agents for knowledge work. Its website primarily describes the company and Genspark products.",
-      "version": "1.0.0",
-      "websiteUrl": "https://mainfunc.ai/blog/genspark_ai_browser",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/mainfunc.ai"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://mainfunc.ai/.well-known/mcp/server-card.json"
         }
       ]
     }
@@ -15772,6 +16157,47 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.marblecms/mcp",
+      "title": "Marble",
+      "description": "Marble is an open-source headless CMS for creating and managing content such as posts, authors, categories, tags, media, and custom fields. It provides hosted workspaces for teams to publish content to websites and applications.",
+      "version": "1.0.0",
+      "websiteUrl": "https://docs.marblecms.com/tools/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/marblecms.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.marblecms.com/mcp",
+          "headers": [
+            {
+              "name": "Mcp-Marble-Api-Key",
+              "description": "Marble API key. Use <token>.",
+              "isRequired": true,
+              "isSecret": true
+            },
+            {
+              "name": "X-Marble-Api-Key",
+              "description": "Marble API key. Use <token>.",
+              "isRequired": true,
+              "isSecret": true
+            },
+            {
+              "name": "Authorization",
+              "description": "Marble API key. Use <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "dev.marcopolo/mcp",
       "title": "MarcoPolo",
       "description": "MarcoPolo is an AI data runtime from Immersa that connects LLMs and agents to enterprise data sources through a secure, persistent workspace. It lets AI query and analyze data across databases, warehouses, cloud storage, and SaaS systems using the Model Context Protocol.",
@@ -15889,6 +16315,33 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.mavolife/mcp",
+      "title": "Mavo  connector",
+      "description": "Mavo Life is a shared family and household organizer for calendars, lists, meals, people, notifications, and related household workflows. It lets families keep one shared plan and offers assistant-driven and API-driven ways to read and update that household data.",
+      "version": "1.0.0",
+      "websiteUrl": "https://mavolife.com/docs/guide/connect-your-assistant",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/mavolife.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mavolife.com/mcp",
+          "variables": {
+            "familySlug": {
+              "description": "Some clients ask which family to use; docs say the family slug is shown in Settings → Developer and can also be sent as `x-mavo-family-slug` in manual setups.",
+              "isRequired": false
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.mcafee/mcp",
       "title": "McAfee",
       "description": "McAfee provides consumer cybersecurity software and cloud-based protection services, including antivirus, identity, privacy, and web protection features. Its customer-facing hub includes the McAfee Protection Center for managing subscriptions, apps, and security features.",
@@ -15903,6 +16356,27 @@
         {
           "type": "streamable-http",
           "url": "https://chatgptcompanion.gateway.api.mcafee.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "ai.usehalyard.mcp/mcp-server",
+      "title": "Mcp",
+      "description": "Halyard is an organizational context engine that indexes a team's knowledge into a graph and lets AI agents retrieve it or ask human experts through Slack. It provides MCP tools for knowledge search and updates, people and org data, expert conversations, and delivery metrics.",
+      "version": "1.0.0",
+      "websiteUrl": "https://integrations.sh/mcp.usehalyard.ai/mcp-server/",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/mcp.usehalyard.ai"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.usehalyard.ai/openapi.json"
         }
       ]
     }
@@ -15933,18 +16407,17 @@
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "org.mozilla/mcp",
       "title": "MDN",
-      "description": "Mozilla is the organization behind Firefox, MDN Web Docs, and related open web tooling and documentation. Its mozilla.org properties include developer documentation and public web resources, including the MDN documentation service.",
-      "version": "1.0.0",
+      "description": "Official MDN Web Docs MCP server for documentation search and browser compatibility data.",
+      "repository": {
+        "url": "https://github.com/mdn/mcp",
+        "source": "github"
+      },
+      "version": "0.0.1",
       "websiteUrl": "https://developer.mozilla.org/en-US/mcp",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/mozilla.org"
-        }
-      ],
       "remotes": [
         {
           "type": "streamable-http",
-          "url": "https://developer.mozilla.org/api/v1/mcp"
+          "url": "https://mcp.mdn.mozilla.net/"
         }
       ]
     }
@@ -16092,6 +16565,27 @@
         {
           "type": "streamable-http",
           "url": "https://mcp.mem0.ai/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.mentionkit.api/mcp",
+      "title": "Mentionkit",
+      "description": "Mentionkit is a social listening service for tracking and reviewing mentions across platforms like Reddit, X, LinkedIn, TikTok, Bluesky, Hacker News, and YouTube. It lets teams query mention data, projects, keywords, and organization usage information, and use that data in agent workflows.",
+      "version": "1.0.0",
+      "websiteUrl": "https://mentionkit.com/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/api.mentionkit.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.mentionkit.com/mcp"
         }
       ]
     }
@@ -16551,33 +17045,6 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.mintmcp/mcp",
-      "title": "MintMCP Gateway  endpoint",
-      "description": "MintMCP is an enterprise gateway and management layer for Model Context Protocol servers and AI agents. It adds authentication, access control, auditing, observability, and hosted deployment around connections between AI clients and business systems.",
-      "version": "1.0.0",
-      "websiteUrl": "https://www.mintmcp.com/docs/claude-code-setup",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/mintmcp.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://app.mintmcp.com/s/{server_id}/mcp",
-          "variables": {
-            "server_id": {
-              "description": "Virtual MCP/server identifier embedded in the per-server connection URL.",
-              "isRequired": true
-            }
-          }
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.minty/mcp",
       "title": "Minty",
       "description": "Minty is a cashback and coupon platform operated by AddShoppers, Inc. It provides browser and mobile tools for finding coupon offers and earning cashback when shopping with participating online merchants.",
@@ -16754,6 +17221,27 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.monarch.api/mcp",
+      "title": "Monarch",
+      "description": "Monarch Money is a personal finance service for tracking accounts, transactions, budgets, and cash flow. Its `api.monarch.com` host currently exposes a Model Context Protocol server for AI clients, though Monarch's help center says the MCP connector is temporarily paused.",
+      "version": "1.0.0",
+      "websiteUrl": "https://help.monarch.com/hc/en-us/articles/50207234679956-Monarch-MCP-Connector",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/api.monarch.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.monarch.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.monday/mcp",
       "title": "monday.com",
       "description": "monday.com is a cloud work management platform for organizing workflows, projects, CRM, service, and related business operations around boards, items, workspaces, and automations. It also offers AI-oriented integration points including a hosted MCP server and agent signup flow.",
@@ -16810,6 +17298,27 @@
         {
           "type": "streamable-http",
           "url": "https://www.moneysupermarket.com/labs/v2/mcp/"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "ai.monid/mcp",
+      "title": "Monid",
+      "description": "Monid is a service that lets agents and applications discover and execute third-party data tools through a single routed interface. It brokers access to many underlying providers and meters usage under either a Monid balance or, for some run flows, x402 wallet payments.",
+      "version": "1.0.0",
+      "websiteUrl": "https://monid.ai/docs/guide/quickstart-mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/monid.ai"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.monid.ai/v1"
         }
       ]
     }
@@ -17456,6 +17965,27 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.negativeev/mcp",
+      "title": "NegativeEV",
+      "description": "NegativeEV is a sports bet checker that grades MLB, WNBA, PGA, and ATP bets against thousands of play-by-play simulations. It compares simulated win probability with the sportsbook's implied probability and returns a written verdict and edge analysis.",
+      "version": "1.0.0",
+      "websiteUrl": "https://negativeev.com/auth.md",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/negativeev.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://negativeev.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.neighbor/mcp",
       "title": "Neighbor",
       "description": "Neighbor is a U.S. marketplace for self-storage, vehicle storage, and monthly parking, combining traditional self-storage facilities with peer-to-peer spaces such as driveways, garages, and sheds. It serves renters looking for storage or parking and hosts who list unused space.",
@@ -17533,27 +18063,6 @@
         {
           "type": "sse",
           "url": "https://mcp.nesha.ai/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.netatmo/mcp",
-      "title": "Netatmo",
-      "description": "Netatmo makes connected home devices including weather stations, security cameras, alarms, and energy or home-control products. Its cloud services let users and third-party apps access device data, home events, and control features.",
-      "version": "1.0.0",
-      "websiteUrl": "https://www.netatmo.com/.well-known/mcp/server-card.json",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/netatmo.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://www.netatmo.com/.well-known/mcp/server-card.json"
         }
       ]
     }
@@ -17906,27 +18415,6 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "site.notion.notion/mcp",
-      "title": "Notion",
-      "description": "Notion is a collaborative workspace product for documents, wikis, projects, databases, and related productivity workflows. It also offers AI, enterprise administration, and developer tooling for integrating with workspace data and operations.",
-      "version": "1.0.0",
-      "websiteUrl": "https://developers.notion.com/guides/mcp/get-started-with-mcp",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/notion.notion.site"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://mcp.notion.com/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "site.notion.notiondevs/mcp",
       "title": "Notion",
       "description": "Notion is a collaborative workspace for documents, wikis, projects, databases, and AI-assisted workflows. Its developer platform lets builders connect external tools, automate workspace operations, deploy Workers, and connect AI agents to Notion.",
@@ -17935,27 +18423,6 @@
       "icons": [
         {
           "src": "https://integrations.sh/logo/notiondevs.notion.site"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "sse",
-          "url": "https://mcp.notion.com/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "so.notion/mcp",
-      "title": "Notion",
-      "description": "Notion is a collaborative workspace platform for documents, wikis, projects, and structured data. Its products let teams organize content and workflows, and it also offers APIs and an MCP server for programmatic access to workspace data.",
-      "version": "1.0.0",
-      "websiteUrl": "https://developers.notion.com/guides/mcp/overview",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/notion.so"
         }
       ],
       "remotes": [
@@ -18327,6 +18794,35 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "io.onboard.rest/mcp",
+      "title": "Onboard",
+      "description": "Onboard is customer onboarding software for managing projects, tasks, KPIs, and related workflow data. It provides hosted operational tooling around that data for direct API integrations and AI-assisted workflows.",
+      "version": "1.0.0",
+      "websiteUrl": "https://docs.onboard.io/docs/mcp-setup",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/rest.onboard.io"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "sse",
+          "url": "https://rest.onboard.io/mcp/rpc",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "Onboard API token. Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.oneuptime/mcp",
       "title": "OneUptime",
       "description": "OneUptime is an open-source observability and incident management platform. It provides monitoring, status pages, alerts, on-call, logs, metrics, traces, and related operational tooling.",
@@ -18341,6 +18837,27 @@
         {
           "type": "streamable-http",
           "url": "https://oneuptime.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.onlineornot/mcp",
+      "title": "OnlineOrNot",
+      "description": "OnlineOrNot is an uptime monitoring platform for websites, APIs, browser flows, and scheduled jobs. It also supports alerts, heartbeats, maintenance windows, and public status pages.",
+      "version": "1.0.0",
+      "websiteUrl": "https://onlineornot.com/docs/reference/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/onlineornot.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.onlineornot.com/mcp"
         }
       ]
     }
@@ -18477,6 +18994,56 @@
             {
               "name": "Authorization",
               "description": "OpenObserve user credentials (email/user ID + password) for HTTP Basic auth. Use Basic <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.openpanel/mcp",
+      "title": "OpenPanel",
+      "description": "OpenPanel is a web hosting control panel built around isolated per-user service containers for websites, databases, mail, and related hosting functions. It includes an end-user panel (OpenPanel) and an administrator panel (OpenAdmin) for managing hosting accounts and server settings.",
+      "version": "1.0.0",
+      "websiteUrl": "https://openpanel.com/docs/panel/account/mcp/",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/openpanel.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://panel.example.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "dev.openpanel/mcp",
+      "title": "OpenPanel",
+      "description": "OpenPanel is an open-source web and product analytics platform for tracking events, users, funnels, retention, and related analytics data. It can be used as a hosted service or self-hosted.",
+      "version": "1.0.0",
+      "websiteUrl": "https://openpanel.dev/docs/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/openpanel.dev"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.openpanel.dev/mcp",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "OpenPanel MCP token. Use Bearer <token>.",
               "isRequired": true,
               "isSecret": true
             }
@@ -18678,27 +19245,6 @@
         {
           "type": "streamable-http",
           "url": "https://www.otomoto.pl/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.otseek/mcp",
-      "title": "OTseek",
-      "description": "OTseek appears to be related to occupational therapy evidence search resources. For the given domain, the only verified programmatic integration surface is the public MCP endpoint on backend.otseek.com.",
-      "version": "1.0.0",
-      "websiteUrl": "https://integrations.sh/otseek.com/otseek-mcp-server/",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/otseek.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://backend.otseek.com/mcp"
         }
       ]
     }
@@ -19064,6 +19610,48 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "email.palisade.api/mcp",
+      "title": "Palisade",
+      "description": "Palisade is an email authentication and DMARC management platform for organizations. It helps teams add domains, publish and verify SPF, DKIM, DMARC, and related DNS records, track remediation tasks, and review reporting and billing.",
+      "version": "1.0.0",
+      "websiteUrl": "https://www.palisade.email/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/api.palisade.email"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.palisade.email/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.pallyy/mcp",
+      "title": "Pallyy",
+      "description": "Pallyy is a social media management platform for scheduling, approving, publishing, and reporting on posts across multiple social networks. It also includes shared inbox, media library, analytics, and link-in-bio features for agencies, brands, and creators.",
+      "version": "1.0.0",
+      "websiteUrl": "https://pallyy.com/llms.txt",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/pallyy.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://pallyy.com/.well-known/mcp/server-card.json"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.palomaparties/mcp",
       "title": "Paloma",
       "description": "Paloma is hospitality booking software for restaurants and venues. It centralizes private-event inquiries, bookings, deposits, and customer communication for venue teams.",
@@ -19156,6 +19744,27 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "bot.parse/mcp",
+      "title": "Parse",
+      "description": "Parse turns websites into managed, callable structured APIs and provides tools to create, revise, export, and execute those APIs. It also offers a marketplace of pre-built APIs for public web data.",
+      "version": "1.0.0",
+      "websiteUrl": "https://docs.parse.bot/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/parse.bot"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.parse.bot/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.particl/mcp",
       "title": "Particl Market Research",
       "description": "Particl provides competitor intelligence for retailers and brands, including pricing, promotions, assortment, sales signals, and marketing-asset data across ecommerce. Its product is delivered primarily through a web app, with an MCP connector that lets AI tools query Particl’s market-research dataset.",
@@ -19191,27 +19800,6 @@
         {
           "type": "streamable-http",
           "url": "https://mcp.inkeep.com/payabli/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.payone/mcp",
-      "title": "PAYONE",
-      "description": "PAYONE provides payment processing products for merchants, including e-commerce, in-store, and payment-link solutions. Its public site links to technical documentation for integrating payment flows and merchant tooling.",
-      "version": "1.0.0",
-      "websiteUrl": "https://www.payone.com/",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/payone.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://www.payone.com/.well-known/mcp/server-card.json"
         }
       ]
     }
@@ -19275,6 +19863,27 @@
         {
           "type": "streamable-http",
           "url": "https://api.pcexpress.ca/v1/agents/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.pearmcp/mcp",
+      "title": "Pear",
+      "description": "Pear MCP is a hosted Model Context Protocol server that gives AI assistants access to a user’s Apple iCloud and Microsoft 365 calendar, tasks, contacts, and mail. It lets users connect those providers once and reuse the same hosted endpoint across supported AI clients.",
+      "version": "1.0.0",
+      "websiteUrl": "https://pearmcp.com/docs",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/pearmcp.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://pearmcp.com/api/mcp"
         }
       ]
     }
@@ -19624,33 +20233,6 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.pigment/mcp",
-      "title": "Pigment",
-      "description": "Pigment is an enterprise business planning and performance management platform for modeling, forecasting, reporting, and analysis across finance, sales, HR, and operations. It centralizes governed business data and provides AI-assisted workflows, including MCP connectivity for external AI systems.",
-      "version": "1.0.0",
-      "websiteUrl": "https://kb.pigment.com/docs/mcp-server-1",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/pigment.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://pigment.app/api/mcp/public/{id}",
-          "variables": {
-            "id": {
-              "description": "Workspace-specific MCP endpoint identifier generated when MCP is enabled.",
-              "isRequired": true
-            }
-          }
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.pinelabsonline/mcp",
       "title": "Pine Labs",
       "description": "Pine Labs provides online payment infrastructure for businesses, including payment collection, payouts, subscriptions, tokenization, and related payment workflows. Its online-payments product documentation also includes AI-oriented tooling such as an MCP server for interacting with payment APIs.",
@@ -19814,41 +20396,6 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "so.plane/mcp",
-      "title": "Plane",
-      "description": "Plane is a project management and work-tracking platform for teams, with cloud and self-hosted deployment options. It combines work items, projects, cycles, modules, pages, automations, and AI-oriented agent features in a single workspace.",
-      "version": "1.0.0",
-      "websiteUrl": "https://developers.plane.so/dev-tools/mcp-server",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/plane.so"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "sse",
-          "url": "https://mcp.plane.so",
-          "headers": [
-            {
-              "name": "x-api-key",
-              "description": "Plane API key / personal access token. Use <token>.",
-              "isRequired": true,
-              "isSecret": true
-            },
-            {
-              "name": "x-workspace-slug",
-              "description": "Plane API key / personal access token. Use <token>.",
-              "isRequired": true,
-              "isSecret": true
-            }
-          ]
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "dev.pscale/mcp",
       "title": "PlanetScale",
       "description": "PlanetScale is a managed database platform for Vitess/MySQL and Postgres. It provides hosted database infrastructure plus management features such as organizations, databases, branches, deploy requests, schema information, and insights.",
@@ -19930,6 +20477,35 @@
           "transport": {
             "type": "stdio"
           }
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.plushcap.www/mcp",
+      "title": "Plushcap",
+      "description": "Plushcap provides developer marketing intelligence data spanning engineering blogs, developer content, YouTube metrics, Hacker News activity, and software trend analysis. It tracks companies and topics and makes that read-only data available through web docs, a public API, and an MCP server.",
+      "version": "1.0.0",
+      "websiteUrl": "https://www.plushcap.com/docs/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/www.plushcap.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.plushcap.com/mcp",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "Plushcap API key. Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
         }
       ]
     }
@@ -20063,76 +20639,6 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "io.port/mcp",
-      "title": "Port",
-      "description": "Port is an internal developer portal platform for building and operating a software catalog, self-service actions, automations, scorecards, and related engineering workflows. It helps platform teams organize service and resource metadata and expose governed developer workflows.",
-      "version": "1.0.0",
-      "websiteUrl": "https://docs.port.io/ai-interfaces/port-mcp-server/token-based-authentication/",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/port.io"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://mcp.port.io",
-          "headers": [
-            {
-              "name": "Authorization",
-              "description": "Port API access token. Use Bearer <token>.",
-              "isRequired": true,
-              "isSecret": true
-            }
-          ]
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "ai.portkey/mcp",
-      "title": "Portkey  Gateway",
-      "description": "Portkey provides infrastructure for building and operating LLM applications and agents, including an AI gateway, MCP gateway, observability, guardrails, and related management features. It sits between client applications or agents and upstream AI or MCP providers to handle routing, authentication, access control, and logging.",
-      "version": "1.0.0",
-      "websiteUrl": "https://docs.portkey.ai/docs/product/mcp-gateway",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/portkey.ai"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://mcp.portkey.ai/{server-slug}/mcp",
-          "variables": {
-            "server-slug": {
-              "description": "Slug for the specific MCP server configured in Portkey; the docs show URLs like `https://mcp.portkey.ai/deepwiki-test-mcp-server/mcp`.",
-              "isRequired": true
-            }
-          },
-          "headers": [
-            {
-              "name": "x-portkey-api-key",
-              "description": "Portkey API key. Use <token>.",
-              "isRequired": true,
-              "isSecret": true
-            },
-            {
-              "name": "Authorization",
-              "description": "Portkey JWT / IdP token for Portkey authentication. Use Bearer <token>.",
-              "isRequired": true,
-              "isSecret": true
-            }
-          ]
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.posthog/mcp",
       "title": "PostHog",
       "description": "PostHog is a product analytics and developer tooling platform that combines event analytics, feature flags, experiments, session replay, error tracking, logs, and related product data tools. It offers both hosted cloud services and self-hosted deployment options for instrumenting and analyzing applications.",
@@ -20147,35 +20653,6 @@
         {
           "type": "streamable-http",
           "url": "https://mcp.posthog.com/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "co.postman/mcp",
-      "title": "Postman",
-      "description": "Postman provides an API platform for designing, testing, managing, and sharing APIs and related workflows. Its products include a cloud API service, command-line tooling, and an MCP server for giving AI agents access to Postman resources.",
-      "version": "1.0.0",
-      "websiteUrl": "https://learning.postman.com/docs/reference/postman-api/postman-mcp-server/overview",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/postman.co"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://mcp.postman.co/mcp",
-          "headers": [
-            {
-              "name": "X-Api-Key",
-              "description": "Postman API key. Use <token>.",
-              "isRequired": true,
-              "isSecret": true
-            }
-          ]
         }
       ]
     }
@@ -20709,6 +21186,62 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.public.mcp/mcp",
+      "title": "Public Hosted",
+      "description": "Public is an investing and brokerage platform for trading stocks, ETFs, options, crypto, bonds, and treasuries. Its hosted MCP offering connects AI assistants to a user’s Public brokerage account for portfolio access and trade actions.",
+      "version": "1.0.0",
+      "websiteUrl": "https://public.com/api/docs/templates/hosted-mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/mcp.public.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.public.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.publora/mcp",
+      "title": "Publora",
+      "description": "Publora is a social media management platform for scheduling and managing posts across multiple social networks. It also offers an MCP server so AI assistants can operate Publora tools in natural language.",
+      "version": "1.0.0",
+      "websiteUrl": "https://docs.publora.com/guides/mcp-server",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/publora.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "sse",
+          "url": "https://mcp.publora.com",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "Publora API key. Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            },
+            {
+              "name": "x-publora-key",
+              "description": "Publora API key. Use <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.pubnub/mcp",
       "title": "PubNub   (hosted)",
       "description": "PubNub is a real-time communications platform for building live, interactive applications with publish/subscribe messaging, presence, and related services. It also provides account-management, analytics, and AI-assistant integration capabilities through its admin, insights, and MCP offerings.",
@@ -21080,6 +21613,27 @@
         {
           "type": "streamable-http",
           "url": "https://my-mcp-server-flame.vercel.app/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "io.raindrop/mcp",
+      "title": "Raindrop.io",
+      "description": "Raindrop.io is a bookmark manager for saving, organizing, and searching links and web content. It also provides AI-agent access to a user's bookmark library through an MCP server.",
+      "version": "1.0.0",
+      "websiteUrl": "https://developer.raindrop.io/mcp/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/raindrop.io"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.raindrop.io/rest/v2/ai/mcp"
         }
       ]
     }
@@ -21867,27 +22421,6 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.yardimcp/mcp",
-      "title": "RentCafe",
-      "description": "yardimcp.com appears to host MCP endpoints related to Yardi-connected services. Publicly discoverable information for this domain is minimal, but a registry-listed RentCafe MCP endpoint is associated with it.",
-      "version": "1.0.0",
-      "websiteUrl": "https://integrations.sh/yardimcp.com/rentcafe-mcp-server/",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/yardimcp.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://rentcafe.yardimcp.com/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "io.rentcast/mcp",
       "title": "RentCast",
       "description": "RentCast provides US real estate and property data, including property records, owner details, valuation estimates, listings, and market statistics. Its product is used by real estate applications, CRMs, and workflows that need on-demand property and rental data.",
@@ -22001,9 +22534,51 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.re-port-flow.lp/mcp",
+      "title": "Report Flow",
+      "description": "Re:port Flow is a cloud service for creating document templates and generating PDFs such as invoices, reports, and application forms. It provides a visual template editor, API-based PDF generation, and AI-client integration via MCP.",
+      "version": "1.0.0",
+      "websiteUrl": "https://doc.re-port-flow.com/docs/integrations/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/lp.re-port-flow.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.re-port-flow.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.re-port-flow/mcp",
+      "title": "Report Flow",
+      "description": "Re:port Flow is a cloud service for designing document templates and generating PDFs from structured data. It is built for automated document output such as invoices, estimates, receipts, and reports, with support for Japanese typography and batch generation.",
+      "version": "1.0.0",
+      "websiteUrl": "https://doc.re-port-flow.com/docs/integrations/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/re-port-flow.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.re-port-flow.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.resend/mcp",
       "title": "Resend",
-      "description": "Resend is an email platform for developers for sending, receiving, and managing transactional and marketing email. It also provides tooling for AI agents through a hosted MCP server and a command-line interface.",
+      "description": "Resend is an email delivery service for developers focused on transactional and marketing email sending, inbound email handling, and related audience, template, webhook, and automation features. It also provides tooling for terminal and AI-agent workflows.",
       "version": "1.0.0",
       "websiteUrl": "https://resend.com/docs/mcp-server",
       "icons": [
@@ -22015,6 +22590,27 @@
         {
           "type": "streamable-http",
           "url": "https://mcp.resend.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "io.responsive/mcp",
+      "title": "Responsive",
+      "description": "Responsive provides AI-powered response management software for handling RFPs, RFIs, DDQs, security questionnaires, and related trust or proposal workflows. Its platform helps teams centralize approved content, generate responses, and manage response projects and trust information.",
+      "version": "1.0.0",
+      "websiteUrl": "https://www.responsive.io",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/responsive.io"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://app.rfpio.com/oa/v2/mcp"
         }
       ]
     }
@@ -22177,6 +22773,27 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "io.rize/mcp",
+      "title": "Rize",
+      "description": "Rize is automatic time-tracking software for individuals and teams that captures work activity in the background and organizes it into time entries, projects, clients, and reporting. It also offers team analytics, profitability tracking, and integrations with other work tools.",
+      "version": "1.0.0",
+      "websiteUrl": "https://docs.rize.io/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/rize.io"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.rize.io/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "app.roadops/mcp",
       "title": "RoadOps",
       "description": "RoadOps is a tour logistics platform for entertainment teams to plan, share, and execute tour dates across mobile, tablet, and web. It supports scheduling, travel, guest lists, day sheets, and related touring operations workflows.",
@@ -22191,6 +22808,27 @@
         {
           "type": "streamable-http",
           "url": "https://api.roadops.app/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "cloud.rock8.app/mcp",
+      "title": "Rock8Cloud",
+      "description": "Rock8Cloud is a deployment platform that connects to a GitHub repository, builds and runs applications, and provides managed databases, object storage, preview environments, and SSL. It also exposes deployment, logging, and AI-assisted code review capabilities for projects hosted on the platform.",
+      "version": "1.0.0",
+      "websiteUrl": "https://docs.rock8.cloud/docs/guides/mcp-integration",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/app.rock8.cloud"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://app.rock8.cloud/mcp"
         }
       ]
     }
@@ -22303,6 +22941,27 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.safwanyp/mcp",
+      "title": "Safwan Parkar",
+      "description": "safwanyp.com is a personal website for Safwan Parkar that publishes read-only machine-readable discovery endpoints for site search, feeds, API catalog metadata, agent skills, and MCP access.",
+      "version": "1.0.0",
+      "websiteUrl": "https://safwanyp.com/docs/api",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/safwanyp.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://safwanyp.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "io.saleor/mcp",
       "title": "Saleor",
       "description": "Saleor is a headless commerce platform for building and operating online stores. It offers cloud-hosted and self-hosted store environments with GraphQL-based access to commerce data and operations.",
@@ -22353,6 +23012,27 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.saleshandy/mcp",
+      "title": "Saleshandy",
+      "description": "Saleshandy is a multichannel outbound sales platform for managing prospecting, email sequences, email accounts, analytics, inbox workflows, and related sales operations. It also provides lead data and enrichment features for sales teams, agencies, and recruiters.",
+      "version": "1.0.0",
+      "websiteUrl": "https://developer.saleshandy.com/api-reference/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/saleshandy.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.saleshandy.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "io.samrum/mcp",
       "title": "SAMRUM",
       "description": "SAMRUM is a family conversation tool built around personality testing, relationship reports, focus tracks, and post-conflict guidance. It helps families understand interaction patterns and access personalized, read-only insights across web and mobile apps.",
@@ -22367,6 +23047,35 @@
         {
           "type": "streamable-http",
           "url": "https://mcp.samrum.io/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "dev.samva/mcp",
+      "title": "Samva",
+      "description": "Samva is a developer email platform for sending and managing transactional and campaign email, templates, contacts, domains, webhooks, and related analytics. It also offers hosted MCP access so AI agents can perform organization-scoped email operations.",
+      "version": "1.0.0",
+      "websiteUrl": "https://samva.dev/docs/developers/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/samva.dev"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.samva.dev",
+          "headers": [
+            {
+              "name": "X-API-Key",
+              "description": "Samva API key. Use <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
         }
       ]
     }
@@ -22461,6 +23170,35 @@
             {
               "name": "Authorization",
               "description": "Scalar personal access token. Use <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "app.schedulin.developers/mcp",
+      "title": "Schedulin",
+      "description": "Schedulin is a social media scheduling platform for creating, scheduling, publishing, and analyzing posts across multiple social networks. It provides tools for managing posts, media, tags, and connected social accounts.",
+      "version": "1.0.0",
+      "websiteUrl": "https://developers.schedulin.app/guides/oauth",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/developers.schedulin.app"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.schedulin.app/mcp",
+          "headers": [
+            {
+              "name": "x-api-key",
+              "description": "Schedulin API key. Use <token>.",
               "isRequired": true,
               "isSecret": true
             }
@@ -22857,27 +23595,6 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "ai.loomalabs/mcp",
-      "title": "Selah",
-      "description": "Looma Labs is a company focused on AI-powered wellness products. Its Selah product is an app for scripture-based meditation, prayer, and sleep experiences.",
-      "version": "1.0.0",
-      "websiteUrl": "https://loomalabs.ai/",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/loomalabs.ai"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://mcp.loomalabs.ai/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "br.com.semparar/mcp",
       "title": "Sem Parar",
       "description": "Sem Parar is a Brazilian vehicle mobility and payments platform centered on toll and parking tags, free-flow toll payment, and related automotive services. Its public sites also cover customer account management, insurance and roadside assistance, and business solutions.",
@@ -23047,6 +23764,64 @@
         {
           "type": "streamable-http",
           "url": "https://api.introvoke.com/api/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "io.getsequence/mcp",
+      "title": "Sequence",
+      "description": "Sequence provides software for automating and orchestrating money movement across bank accounts, rules, and transfers. Its products include a consumer/business finance automation app and a developer-focused platform for agentic money movement with permissions, limits, and audit trails.",
+      "version": "1.0.0",
+      "websiteUrl": "https://api.getsequence.io/platform/",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/getsequence.io"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://app.getsequence.io/api/mcp",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "Sequence API key. Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.sequenzy/mcp",
+      "title": "Sequenzy",
+      "description": "Sequenzy is an email marketing and lifecycle automation platform for managing subscribers, campaigns, sequences, transactional emails, landing pages, and analytics. It also provides AI-agent access via MCP and agent-oriented authentication flows.",
+      "version": "1.0.0",
+      "websiteUrl": "https://docs.sequenzy.com/concepts/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/sequenzy.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.sequenzy.com/v1/mcp",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "Sequenzy API key. Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
         }
       ]
     }
@@ -23272,6 +24047,27 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.shopify/mcp",
+      "title": "Shopify",
+      "description": "Shopify exposes Admin REST and GraphQL APIs, Storefront, Partner, Customer Account, and Payments GraphQL APIs, plus an MCP endpoint and the `shopify` CLI; auth is mainly via `X-Shopify-Access-Token` app/store or partner tokens, Storefront public/private tokens, Customer Account OAuth, CLI login, while the recorded MCP supports none or OAuth.",
+      "version": "1.0.0",
+      "websiteUrl": "https://integrations.sh/shopify.com/shopify/",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/shopify.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://setup.shopify.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.shortcut/mcp",
       "title": "Shortcut",
       "description": "Shortcut is a project management and issue tracking platform for software teams, with features for stories, epics, iterations, docs, roadmaps, and objectives. It lets teams organize and automate development work across a shared workspace.",
@@ -23421,24 +24217,21 @@
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "io.signoz/mcp",
       "title": "SigNoz",
-      "description": "SigNoz is an open-source observability platform for collecting and analyzing metrics, traces, and logs. It is available as both a self-hosted deployment and a managed SigNoz Cloud service.",
+      "description": "SigNoz Cloud MCP server for metrics, traces, and logs.",
       "version": "1.0.0",
       "websiteUrl": "https://signoz.io/docs/ai/signoz-mcp-server/",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/signoz.io"
-        }
-      ],
       "remotes": [
         {
           "type": "streamable-http",
           "url": "https://mcp.us.signoz.cloud/mcp",
-          "variables": {
-            "region": {
-              "description": "SigNoz Cloud region in the MCP host, e.g. `us` in `https://mcp.us.signoz.cloud/mcp`; docs say it must match your SigNoz Cloud account region.",
-              "isRequired": false
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "SigNoz API key. Use Bearer <token> or SIGNOZ-API-KEY.",
+              "isRequired": true,
+              "isSecret": true
             }
-          }
+          ]
         }
       ]
     }
@@ -23800,7 +24593,7 @@
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.slack/mcp-server",
       "title": "Slack",
-      "description": "Slack is a team communication and collaboration platform for messaging, workflows, apps, and AI-assisted work. It lets organizations organize conversations, automate tasks, and integrate external tools inside shared workspaces.",
+      "description": "Slack is a workplace messaging and collaboration platform for channels, messaging, workflows, and app integrations. It also provides developer tooling for building Slack apps and AI agents that interact with Slack workspaces.",
       "version": "1.0.0",
       "websiteUrl": "https://integrations.sh/slack.com/mcp-server/",
       "icons": [
@@ -23821,9 +24614,9 @@
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.slack/slack-mcp-server",
       "title": "Slack",
-      "description": "Slack is a team communication and collaboration platform for messaging, workflows, apps, and AI-assisted work. It lets organizations organize conversations, automate tasks, and integrate external tools inside shared workspaces.",
+      "description": "Slack is a workplace messaging and collaboration platform for channels, messaging, workflows, and app integrations. It also provides developer tooling for building Slack apps and AI agents that interact with Slack workspaces.",
       "version": "1.0.0",
-      "websiteUrl": "https://slack.com/help/articles/48855576908307-Guide-to-Model-Context-Protocol-in-Slack",
+      "websiteUrl": "https://docs.slack.dev/ai/slack-skills-plugin/",
       "icons": [
         {
           "src": "https://integrations.sh/logo/slack.com"
@@ -23854,6 +24647,27 @@
         {
           "type": "sse",
           "url": "https://chatgpt.sleepcycle.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "app.sleevy/mcp",
+      "title": "Sleevy",
+      "description": "Sleevy is a read-later app for saving URLs, organizing them with folders and tags, and tracking read state across its clients and integrations. It also offers developer access through a REST API and an MCP server for AI agents.",
+      "version": "1.0.0",
+      "websiteUrl": "https://sleevy.app/docs/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/sleevy.app"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.sleevy.app/mcp"
         }
       ]
     }
@@ -23917,27 +24731,6 @@
         {
           "type": "streamable-http",
           "url": "https://mcp.slidesgpt.com/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.smallpdf/mcp",
-      "title": "Smallpdf",
-      "description": "Smallpdf is a web and app-based PDF productivity service for converting, compressing, editing, signing, and organizing PDF documents. It also offers AI-assisted PDF workflows and embeddable PDF viewing tools for website content.",
-      "version": "1.0.0",
-      "websiteUrl": "https://integrations.sh/smallpdf.com/smallpdf-mcp-server/",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/smallpdf.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "sse",
-          "url": "https://chatgpt-app.smallpdf.com/sse"
         }
       ]
     }
@@ -24164,6 +24957,27 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.solana/mcp",
+      "title": "Solana Developer",
+      "description": "Solana is a blockchain platform and developer ecosystem for building applications, tokens, payments, and onchain programs. Its public documentation covers network RPC access, development tooling, and AI-agent resources.",
+      "version": "1.0.0",
+      "websiteUrl": "https://mcp.solana.com/",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/solana.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.solana.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "app.bestsolo401k/mcp",
       "title": "Solo 401k Calculator",
       "description": "bestsolo401k.app appears to host a Solo 401k contribution calculator service. Public discovery for the domain did not reveal broader developer documentation or additional programmatic interfaces.",
@@ -24332,6 +25146,35 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "ai.speko/mcp",
+      "title": "Speko hosted",
+      "description": "Speko is a voice AI gateway that routes speech-to-text, text-to-speech, LLM, and telephony workloads across providers with failover. It also provides tooling for operating voice agents, sessions, calls, phone numbers, and related platform resources.",
+      "version": "1.0.0",
+      "websiteUrl": "https://docs.speko.dev/quickstart/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/speko.ai"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.speko.ai/mcp",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "Speko API key. Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.spinify/mcp",
       "title": "Spinify",
       "description": "Spinify is a sales gamification and employee engagement platform that turns business activity data into leaderboards, competitions, recognition, and coaching workflows. It integrates with CRMs, spreadsheets, BI tools, and custom systems to visualize team performance and motivate behavior.",
@@ -24374,14 +25217,14 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "net.spotify/mcp",
+      "name": "com.spotify/mcp",
       "title": "Spotify",
-      "description": "Spotify is a music, podcast, and audiobook streaming service. Its developer platform primarily documents Spotify APIs on `developer.spotify.com`, while the `spotify.net` domain here is only evidenced as hosting an MCP gateway endpoint.",
+      "description": "Spotify is a music, podcast, and audiobook streaming platform. It also provides developer products for app integrations, playback control, advertising workflows, partner account linking, and embeddable content.",
       "version": "1.0.0",
-      "websiteUrl": "https://mcp-gateway-external-pilot.spotify.net/mcp",
+      "websiteUrl": "https://support.spotify.com/",
       "icons": [
         {
-          "src": "https://integrations.sh/logo/spotify.net"
+          "src": "https://integrations.sh/logo/spotify.com"
         }
       ],
       "remotes": [
@@ -24451,6 +25294,35 @@
         {
           "type": "sse",
           "url": "https://mcp.squareup.com/sse"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.squirrelscan/mcp",
+      "title": "squirrelscan",
+      "description": "squirrelscan is a website auditing service focused on SEO, performance, security, and AI-agent readiness checks. It can run audits locally via CLI and adds cloud features such as hosted crawling, reports, credits, and MCP access.",
+      "version": "1.0.0",
+      "websiteUrl": "https://docs.squirrelscan.com/developers/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/squirrelscan.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.squirrelscan.com/mcp",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "squirrelscan API key. Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
         }
       ]
     }
@@ -24549,6 +25421,48 @@
         {
           "type": "streamable-http",
           "url": "https://api.statsig.com/v1/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.stayingapi/mcp",
+      "title": "StayingAPI",
+      "description": "StayingAPI provides normalized accommodation data across Airbnb, Booking.com, Vrbo, and Google Hotels, including search, availability, pricing, reviews, and cross-OTA price comparison. It offers the same capabilities to developers over REST and to AI agents over MCP.",
+      "version": "1.0.0",
+      "websiteUrl": "https://stayingapi.com/docs/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/stayingapi.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.stayingapi.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.steadily/mcp",
+      "title": "Steadily",
+      "description": "Steadily exposes two partner REST APIs on api.steadily.com (Partner API and Rater Quotes API) that use Steadily-issued API keys—plus bearer tokens for quoting endpoints in the Rater API—and a public no-auth MCP server at https://mcp.steadily.com/mcp per the catalog.",
+      "version": "1.0.0",
+      "websiteUrl": "https://www.steadily.com",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/steadily.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.steadily.com/mcp"
         }
       ]
     }
@@ -24872,6 +25786,35 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.fullstory.subtext/mcp",
+      "title": "Subtext",
+      "description": "Subtext is Fullstory’s standalone product for capturing production web sessions and making them available to AI coding agents for session review and debugging. It records user sessions in a web app and lets agents inspect those sessions, plus related privacy and verification workflows, through hosted tooling.",
+      "version": "1.0.0",
+      "websiteUrl": "https://subtext.fullstory.com/docs/install/manual",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/subtext.fullstory.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.fullstory.com/mcp/subtext",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "Subtext API key. Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "co.success/mcp-server",
       "title": "Success",
       "description": "Success.co is an EOS-focused business operating platform for teams to manage goals, meetings, scorecards, to-dos, issues, and related company operating data. It also offers integrations with calendars, collaboration tools, AI assistants, and automation platforms.",
@@ -25019,6 +25962,27 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.supermemory/mcp",
+      "title": "Supermemory",
+      "description": "Supermemory provides memory and context infrastructure for AI agents, including ingestion, search, user profiles, and connectors. It also offers an MCP-based memory layer so compatible AI clients can access shared spaces and saved context.",
+      "version": "1.0.0",
+      "websiteUrl": "https://supermemory.ai/docs/supermemory-mcp/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/supermemory.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.supermemory.ai/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.supermetrics/mcp",
       "title": "Supermetrics Marketing Analytics",
       "description": "Supermetrics is a marketing intelligence platform that connects marketing, ecommerce, and sales data sources to reporting tools, data warehouses, cloud storage, and AI workflows. It helps teams extract, manage, and analyze marketing data across many third-party platforms.",
@@ -25062,6 +26026,27 @@
               "isSecret": true
             }
           ]
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.superwall/mcp",
+      "title": "Superwall",
+      "description": "Superwall is a subscription infrastructure and paywall platform for consumer mobile and web apps. It provides entitlements, purchase and webhook infrastructure, analytics, SQL/query access, and tools for building and experimenting with paywalls.",
+      "version": "1.0.0",
+      "websiteUrl": "https://superwall.com/docs/dashboard/guides/superwall-mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/superwall.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://superwall-mcp.superwall.com/mcp"
         }
       ]
     }
@@ -25125,27 +26110,6 @@
         {
           "type": "streamable-http",
           "url": "https://app-sdk.sweetspotgov.workers.dev/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.swyftfilings/mcp",
-      "title": "Swyft Filings",
-      "description": "Swyft Filings is a business formation and compliance service that helps customers start companies, file registrations, and manage ongoing requirements like registered agent and annual report filings. It also offers related services such as EIN applications, governance documents, and other compliance products.",
-      "version": "1.0.0",
-      "websiteUrl": "https://www.swyftfilings.com/openai/mcp",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/swyftfilings.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "sse",
-          "url": "https://www.swyftfilings.com/openai/mcp"
         }
       ]
     }
@@ -25255,35 +26219,6 @@
             {
               "name": "Authorization",
               "description": "Tally API key. Use Bearer <token>.",
-              "isRequired": true,
-              "isSecret": true
-            }
-          ]
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.makegov/mcp",
-      "title": "Tango",
-      "description": "MakeGov provides Tango, a service that consolidates U.S. federal procurement and assistance data from sources such as SAM.gov, USAspending, FPDS, Grants.gov, and related systems. It gives customers unified access to contracts, opportunities, entities, grants, forecasts, and related government contracting data.",
-      "version": "1.0.0",
-      "websiteUrl": "https://docs.makegov.com/mcp/",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/makegov.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://tango.makegov.com/mcp/",
-          "headers": [
-            {
-              "name": "X-API-KEY",
-              "description": "Tango API key. Use <token>.",
               "isRequired": true,
               "isSecret": true
             }
@@ -25796,9 +26731,9 @@
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.ticketmaster/mcp",
       "title": "Ticketmaster",
-      "description": "Ticketmaster is a live-event ticketing and event-discovery platform. Its developer portal offers APIs for searching events and, for approved partners, commerce and publishing workflows around ticketing and event data.",
+      "description": "Ticketmaster is a live events and ticketing platform. Its developer portal offers APIs for event discovery and partner/commerce workflows around ticket inventory and transactions.",
       "version": "1.0.0",
-      "websiteUrl": "https://developer.ticketmaster.com/products-and-docs/apis/partner/mcp-server/",
+      "websiteUrl": "https://integrations.sh/ticketmaster.com/ticketmaster-mcp-server/",
       "icons": [
         {
           "src": "https://integrations.sh/logo/ticketmaster.com"
@@ -25983,6 +26918,27 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.todoist/mcp",
+      "title": "Todoist",
+      "description": "Todoist is a task management and collaboration service for organizing personal and team work. Users create and manage tasks, projects, reminders, comments, and workspaces across Todoist apps and integrations.",
+      "version": "1.0.0",
+      "websiteUrl": "https://integrations.sh/todoist.com/todoist/",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/todoist.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://ai.todoist.net/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.tokenterminal/mcp",
       "title": "Token Terminal",
       "description": "Token Terminal provides onchain financial and market data about crypto projects, chains, sectors, assets, and related metrics. Its products let users explore this data in dashboards, APIs, MCP-compatible AI clients, and data-sharing workflows.",
@@ -25997,27 +26953,6 @@
         {
           "type": "streamable-http",
           "url": "https://mcp.tokenterminal.com/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "io.tomba/mcp",
-      "title": "Tomba",
-      "description": "Tomba.io provides email discovery, verification, enrichment, company search, and phone lookup data for sales, marketing, recruiting, and research workflows. Its product centers on finding and validating professional contact information and related company intelligence.",
-      "version": "1.0.0",
-      "websiteUrl": "https://integrations.sh/tomba.io/mcp-server/",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/tomba.io"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://tomba.io/.well-known/mcp/server-card.json"
         }
       ]
     }
@@ -26207,6 +27142,27 @@
         {
           "type": "sse",
           "url": "https://mcp.traktorpool.com/chatgpt-892332849/mcp/"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.transcriptapi/mcp",
+      "title": "TranscriptAPI",
+      "description": "TranscriptAPI provides programmatic access to YouTube transcripts, video metadata, search, channel browsing, and playlist listing. It offers these capabilities through a REST API and a Model Context Protocol server for AI assistants.",
+      "version": "1.0.0",
+      "websiteUrl": "https://transcriptapi.com/docs/mcp/",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/transcriptapi.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://transcriptapi.com/mcp"
         }
       ]
     }
@@ -26492,6 +27448,27 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "sh.tripwire/mcp",
+      "title": "Tripwire OAuth-protected  resource",
+      "description": "Tripwire appears to provide an MCP-related service at tripwire.sh. Publicly discoverable metadata shows an OAuth 2.0 authorization server with dynamic client registration and scopes for identity/profile access.",
+      "version": "1.0.0",
+      "websiteUrl": "https://www.tripwire.sh/.well-known/oauth-authorization-server",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/tripwire.sh"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://www.tripwire.sh"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.trivago/mcp",
       "title": "trivago",
       "description": "trivago is a hotel and accommodation metasearch service that compares offers from booking providers and hotel websites. It also provides partner integrations for advertisers and booking platforms to supply rates, availability, and conversion-tracking data.",
@@ -26611,27 +27588,6 @@
         {
           "type": "streamable-http",
           "url": "https://trykopi.ai/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "io.tubi/mcp",
-      "title": "Tubi",
-      "description": "Tubi is an ad-supported streaming service for movies, TV shows, and live content. Its public web presence is centered on consumer streaming at tubi.tv.",
-      "version": "1.0.0",
-      "websiteUrl": "https://integrations.sh/tubi.io/tubi-mcp/",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/tubi.io"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://openai-app-mcp.main-production-custom.production.k8s.tubi.io/mcp"
         }
       ]
     }
@@ -26765,6 +27721,27 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "sh.typeui/mcp",
+      "title": "TypeUI",
+      "description": "TypeUI provides design systems, UI prompts, and layout guidance for AI coding tools so they can generate more consistent user interfaces. It also offers a public catalog of design skills and prompts, with hosted workspace features for publishing and serving them to MCP-compatible tools.",
+      "version": "1.0.0",
+      "websiteUrl": "https://www.typeui.sh/docs/mcp-server",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/typeui.sh"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.typeui.sh"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "io.usgb/mcp",
       "title": "U.S. Gold Bureau Metal Spots",
       "description": "U.S. Gold Bureau is a precious-metals dealer. The usgb.io domain appears to host an MCP endpoint related to metal spot pricing.",
@@ -26830,7 +27807,7 @@
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.ubereats/mcp",
       "title": "Uber Eats",
-      "description": "Uber Eats is Uber's food ordering and merchant marketplace platform. Its developer offering lets approved partners integrate merchant store operations, menus, and order workflows with Uber Eats.",
+      "description": "Uber Eats is Uber’s food ordering and delivery marketplace for merchants and partners. Its developer offering lets approved partners connect store, menu, order, reporting, and activation workflows to Uber Eats.",
       "version": "1.0.0",
       "websiteUrl": "https://mcp.ubereats.com/eats-claude/mcp",
       "icons": [
@@ -26993,6 +27970,27 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.unitedrentals/mcp",
+      "title": "United Rentals",
+      "description": "United Rentals is an equipment rental company offering fleet, billing, and worksite-management services through its Total Control platform. Its website describes digital system integration capabilities for customers, but public technical integration documentation was not exposed on the mapped domain.",
+      "version": "1.0.0",
+      "websiteUrl": "https://www.unitedrentals.com",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/unitedrentals.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.ur.com/public/eyJvcmdhbml6YXRpb24iOiJvcmdfSlhWRjhIeHFERERmcGszSCIsImNv2UxNWRhZTdiZGQ1NGIxMTk1NTY3MmQ2MDgyMjkyMDQtYXV0b2dlbmVyYXRlZCJ9"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.collegenation/mcp",
       "title": "Universal Commerce Protocol",
       "description": "College Nation is an online retail store built on Shopify. It sells college-themed merchandise and exposes storefront browsing pages plus agent-oriented commerce metadata for AI/shopping assistants.",
@@ -27070,6 +28068,35 @@
         {
           "type": "streamable-http",
           "url": "https://ai-agents.infra.updatron.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "sh.uploads/mcp",
+      "title": "uploads.sh hosted",
+      "description": "uploads.sh is a file-hosting service for sharing screenshots, recordings, and other files, especially into GitHub pull requests and issues. It provides hosted public file URLs and tools for agents and humans, with invitation-based workspace access.",
+      "version": "1.0.0",
+      "websiteUrl": "https://uploads.sh/docs/agents",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/uploads.sh"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://agents.uploads.sh/mcp",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "uploads.sh workspace token. Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
         }
       ]
     }
@@ -27304,6 +28331,56 @@
         {
           "type": "streamable-http",
           "url": "https://mcp.vantage.sh/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "ai.vapi/vapi-mcp-server",
+      "title": "Vapi",
+      "description": "Vapi is a voice AI platform for building, testing, and operating voice agents, calls, chats, and related telephony workflows. It provides tools for managing assistants, phone numbers, calls, workflows, and developer integrations.",
+      "version": "1.0.0",
+      "websiteUrl": "https://docs.vapi.ai/sdk/mcp-server",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/vapi.ai"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.vapi.ai/mcp",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "Vapi API key. Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "ai.vapi/vapi-documentation-mcp-server",
+      "title": "Vapi Documentation",
+      "description": "Vapi is a voice AI platform for building, testing, and operating voice agents, calls, chats, and related telephony workflows. It provides tools for managing assistants, phone numbers, calls, workflows, and developer integrations.",
+      "version": "1.0.0",
+      "websiteUrl": "https://docs.vapi.ai",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/vapi.ai"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://docs.vapi.ai/_mcp/server"
         }
       ]
     }
@@ -27564,33 +28641,6 @@
         {
           "type": "streamable-http",
           "url": "https://cx-mcp.virginatlantic.com/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.visier/mcp",
-      "title": "Visier Query",
-      "description": "Visier provides workforce analytics and planning software for organizations. Its platform lets customers load, model, query, and analyze people and business data, and includes AI features such as Vee and an MCP server for external AI clients.",
-      "version": "1.0.0",
-      "websiteUrl": "https://docs.visier.com/developer/agents/mcp/mcp-server.htm",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/visier.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://{vanity_name}.app.visier.com/visier-query-mcp",
-          "variables": {
-            "vanity_name": {
-              "description": "The setup guide says to replace `{vanity_name}` with your tenant name; example vanity names are derived from Visier service provider URLs.",
-              "isRequired": true
-            }
-          }
         }
       ]
     }
@@ -28082,6 +29132,27 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "ai.webhound/mcp",
+      "title": "Webhound",
+      "description": "Webhound is a research system that runs budget-capped web investigations and returns cited reports, datasets, and related evidence trails. It is designed for users and agents to start research runs, inspect claims and sources, and manage resulting workspace artifacts.",
+      "version": "1.0.0",
+      "websiteUrl": "https://webhound.ai/mcp-setup",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/webhound.ai"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.webhound.ai/api/v2/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "au.com.webjet/mcp",
       "title": "Webjet",
       "description": "Webjet is an Australian online travel booking service for flights, hotels, holiday packages, tours, car hire, insurance, and related travel products. Its public website is focused on consumer travel search and booking.",
@@ -28117,48 +29188,6 @@
         {
           "type": "sse",
           "url": "https://chatgpt-app.wednesday.app/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.wego/mcp",
-      "title": "Wego",
-      "description": "Wego is a travel metasearch and distribution platform for flights and hotels. It provides affiliate search APIs, partner distribution APIs, and provider integration documentation for travel suppliers and marketplaces.",
-      "version": "1.0.0",
-      "websiteUrl": "https://integrations.sh/wego.com/wego-mcp-server/",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/wego.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://mcp.wego.com/chatgpt-app/v1/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.ww/mcp",
-      "title": "WeightWatchers",
-      "description": "WeightWatchers (WW) is a health and wellness company focused on weight management, nutrition guidance, coaching, and clinical support including GLP-1-related programs. It operates consumer programs across multiple markets.",
-      "version": "1.0.0",
-      "websiteUrl": "https://ww.com/llms.txt",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/ww.com"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://api.ww.com/ai/mcp-openai-glp1-recipes/mcp"
         }
       ]
     }
@@ -28243,6 +29272,27 @@
         {
           "type": "sse",
           "url": "https://mcp.wikiloc.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.gowindmill/mcp",
+      "title": "Windmill",
+      "description": "Windmill is a performance management platform for reviews, 1:1s, pulse surveys, analytics, and feedback workflows. It uses AI and connected workplace tools to help teams gather context and run people-management processes.",
+      "version": "1.0.0",
+      "websiteUrl": "https://help.gowindmill.com/features/mcp",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/gowindmill.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.gowindmill.com/mcp"
         }
       ]
     }
@@ -28539,6 +29589,35 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.xquik/mcp",
+      "title": "Xquik",
+      "description": "Xquik is a hosted SaaS platform for searching public X data, exporting results, publishing from connected X accounts, and running monitoring and giveaway workflows. It also provides MCP access so AI agents can use Xquik’s X automation and data tools.",
+      "version": "1.0.0",
+      "websiteUrl": "https://docs.xquik.com/mcp/overview",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/xquik.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://xquik.com/mcp",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "Xquik API Key. Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "jp.yahooapis/mcp",
       "title": "Yahoo! JAPAN Shopping",
       "description": "Yahoo! JAPAN / LY Corporation uses yahooapis.jp for developer-facing endpoints including data-solution APIs and a shopping-related MCP endpoint. The DS.API product provides search and map-related data APIs such as search ranking, search volume, search journey, and date options.",
@@ -28574,27 +29653,6 @@
         {
           "type": "sse",
           "url": "https://yango.com/mcp"
-        }
-      ]
-    }
-  },
-  {
-    "server": {
-      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "tr.com.boyner/mcp",
-      "title": "Yapay Zeka'nın Boyner'i",
-      "description": "Boyner is a Turkish multi-brand retail and e-commerce company selling fashion, cosmetics, sports, accessories, home, and electronics through stores and boyner.com.tr. Its website also advertises an AI-powered gift assistant and same-day delivery options in some areas.",
-      "version": "1.0.0",
-      "websiteUrl": "https://boyner.com.tr/llms.txt",
-      "icons": [
-        {
-          "src": "https://integrations.sh/logo/boyner.com.tr"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "streamable-http",
-          "url": "https://mcp-backend.boyner.com.tr/mcp"
         }
       ]
     }
@@ -28702,6 +29760,48 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.you/you-com-mcp-server",
+      "title": "You.com",
+      "description": "You.com provides APIs and agent tooling for real-time web search, webpage content extraction, and citation-backed research. Its platform also includes hosted agent endpoints and an MCP server for connecting these capabilities to IDEs and AI clients.",
+      "version": "1.0.0",
+      "websiteUrl": "https://you.com/docs/build-with-agents/mcp-server",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/you.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.you.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.you/you-com-mcp-server-free-profile",
+      "title": "You.com   free profile",
+      "description": "You.com provides APIs and agent tooling for real-time web search, webpage content extraction, and citation-backed research. Its platform also includes hosted agent endpoints and an MCP server for connecting these capabilities to IDEs and AI clients.",
+      "version": "1.0.0",
+      "websiteUrl": "https://you.com/docs/build-with-agents/mcp-server",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/you.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.you.com/mcp?profile=free"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.youversionapi/mcp",
       "title": "YouVersion Bible",
       "description": "YouVersion provides a developer platform for integrating Bible content, metadata, and related scripture features into apps and websites. It also offers SDKs and sign-in capabilities tied to registered platform apps.",
@@ -28786,20 +29886,65 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-      "name": "com.zillow/mcp",
-      "title": "Zillow",
-      "description": "Zillow exposes a public no-auth MCP server at https://mcp.zillow.com/api/v1 plus several partner HTTP APIs, authenticated either with a Zillow mortgage `partnerId`, Bridge Interactive access token/password credentials for Bridge-backed data APIs, dotloop OAuth 2.0 for transaction management, or Mortech-issued third-party-name/license-key credentials where Zillow documents them.",
+      "name": "com.zernio/mcp",
+      "title": "Zernio",
+      "description": "Zernio is a social media scheduling, messaging, analytics, and ads platform that provides a unified API for managing posts and connected accounts across many social networks. It also offers AI-agent access through MCP and a command-line interface.",
       "version": "1.0.0",
-      "websiteUrl": "https://mcp.zillow.com/api/v1",
+      "websiteUrl": "https://docs.zernio.com/mcp",
       "icons": [
         {
-          "src": "https://integrations.sh/logo/zillow.com"
+          "src": "https://integrations.sh/logo/zernio.com"
         }
       ],
       "remotes": [
         {
           "type": "streamable-http",
-          "url": "https://mcp.zillow.com/api/v1"
+          "url": "https://mcp.zernio.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.zillapi/mcp",
+      "title": "Zillapi",
+      "description": "Zillapi provides Zillow-sourced U.S. residential property data, including property details, Zestimates, listing search, building extraction, async jobs, and signed webhooks. It is positioned for developers, SaaS products, and AI agents that need structured property data without scraping.",
+      "version": "1.0.0",
+      "websiteUrl": "https://zillapi.com/ai-agents/",
+      "icons": [
+        {
+          "src": "https://integrations.sh/logo/zillapi.com"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.zillapi.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.zillow/mcp",
+      "title": "Zillow",
+      "description": "Zillow MCP server for real-estate listing search.",
+      "version": "1.0.0",
+      "websiteUrl": "https://mcp.zillow.com/mcp",
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.zillow.com/mcp",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "Bearer token.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
         }
       ]
     }

--- a/registry.overlay.json
+++ b/registry.overlay.json
@@ -292,22 +292,14 @@
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.cosmicjs/cosmic-hosted-mcp-agent-scope",
-      "title": "Cosmic",
-      "description": "Cosmic hosted MCP server for agent-scoped access to CMS buckets and content.",
+      "title": "Cosmic Agent",
+      "description": "Cosmic MCP for agent signup at /v1/agent (cosmic_agent_signup, verify, status).",
       "version": "1.0.0",
       "websiteUrl": "https://www.cosmicjs.com/docs/agent-skills",
       "remotes": [
         {
           "type": "streamable-http",
-          "url": "https://mcp.cosmicjs.com/v1/agent",
-          "headers": [
-            {
-              "name": "Authorization",
-              "description": "Agent key. Use Bearer <token>.",
-              "isRequired": true,
-              "isSecret": true
-            }
-          ]
+          "url": "https://mcp.cosmicjs.com/v1/agent"
         }
       ]
     }
@@ -337,21 +329,13 @@
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "io.signoz/mcp",
       "title": "SigNoz",
-      "description": "SigNoz Cloud MCP server for metrics, traces, and logs.",
+      "description": "SigNoz Cloud US MCP server for metrics, traces, and logs. Sign in with OAuth in the agent after install.",
       "version": "1.0.0",
       "websiteUrl": "https://signoz.io/docs/ai/signoz-mcp-server/",
       "remotes": [
         {
           "type": "streamable-http",
-          "url": "https://mcp.us.signoz.cloud/mcp",
-          "headers": [
-            {
-              "name": "Authorization",
-              "description": "SigNoz API key. Use Bearer <token> or SIGNOZ-API-KEY.",
-              "isRequired": true,
-              "isSecret": true
-            }
-          ]
+          "url": "https://mcp.us.signoz.cloud/mcp"
         }
       ]
     }
@@ -361,21 +345,12 @@
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "com.zillow/mcp",
       "title": "Zillow",
-      "description": "Zillow MCP server for real-estate listing search.",
+      "description": "Zillow MCP server for real-estate listing search. Sign in with OAuth in the agent after install.",
       "version": "1.0.0",
-      "websiteUrl": "https://mcp.zillow.com/mcp",
       "remotes": [
         {
           "type": "streamable-http",
-          "url": "https://mcp.zillow.com/mcp",
-          "headers": [
-            {
-              "name": "Authorization",
-              "description": "Bearer token.",
-              "isRequired": true,
-              "isSecret": true
-            }
-          ]
+          "url": "https://mcp.zillow.com/mcp"
         }
       ]
     }

--- a/registry.overlay.json
+++ b/registry.overlay.json
@@ -271,5 +271,113 @@
         }
       ]
     }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.algolia/algolia-productivity-mcp",
+      "title": "Algolia Productivity",
+      "description": "Algolia Productivity MCP for searching and analyzing Algolia applications and indices.",
+      "version": "1.0.0",
+      "websiteUrl": "https://www.algolia.com/doc/guides/model-context-protocol/productivity-mcp",
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.algolia.com/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.cosmicjs/cosmic-hosted-mcp-agent-scope",
+      "title": "Cosmic",
+      "description": "Cosmic hosted MCP server for agent-scoped access to CMS buckets and content.",
+      "version": "1.0.0",
+      "websiteUrl": "https://www.cosmicjs.com/docs/agent-skills",
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.cosmicjs.com/v1/agent",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "Agent key. Use Bearer <token>.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "org.mozilla/mcp",
+      "title": "MDN",
+      "description": "Official MDN Web Docs MCP server for documentation search and browser compatibility data.",
+      "repository": {
+        "url": "https://github.com/mdn/mcp",
+        "source": "github"
+      },
+      "version": "0.0.1",
+      "websiteUrl": "https://developer.mozilla.org/en-US/mcp",
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.mdn.mozilla.net/"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "io.signoz/mcp",
+      "title": "SigNoz",
+      "description": "SigNoz Cloud MCP server for metrics, traces, and logs.",
+      "version": "1.0.0",
+      "websiteUrl": "https://signoz.io/docs/ai/signoz-mcp-server/",
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.us.signoz.cloud/mcp",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "SigNoz API key. Use Bearer <token> or SIGNOZ-API-KEY.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "com.zillow/mcp",
+      "title": "Zillow",
+      "description": "Zillow MCP server for real-estate listing search.",
+      "version": "1.0.0",
+      "websiteUrl": "https://mcp.zillow.com/mcp",
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://mcp.zillow.com/mcp",
+          "headers": [
+            {
+              "name": "Authorization",
+              "description": "Bearer token.",
+              "isRequired": true,
+              "isSecret": true
+            }
+          ]
+        }
+      ]
+    }
   }
 ]

--- a/web/content/docs/04-registry.mdx
+++ b/web/content/docs/04-registry.mdx
@@ -46,7 +46,7 @@ To reset to the default registry, remove the `findRegistries` key or delete the 
 
 ## Missing a server?
 
-The registry is generated from [integrations.sh](https://integrations.sh). To be listed, add your MCP server there. Package-only servers, and remotes integrations.sh dropped that still speak MCP, can be contributed to add-mcp's `registry.overlay.json` on [GitHub](https://github.com/neon-solutions/add-mcp).
+The registry is generated from [integrations.sh](https://integrations.sh). To be listed, add your MCP server there. Package-only servers, and remotes integrations.sh dropped that we still want in `find`, can be contributed to add-mcp's `registry.overlay.json` on [GitHub](https://github.com/neon-solutions/add-mcp).
 
 ## Adding a custom registry
 

--- a/web/content/docs/04-registry.mdx
+++ b/web/content/docs/04-registry.mdx
@@ -46,7 +46,7 @@ To reset to the default registry, remove the `findRegistries` key or delete the 
 
 ## Missing a server?
 
-The registry is generated from [integrations.sh](https://integrations.sh). To be listed, add your MCP server there. Package-only entries that integrations.sh cannot represent yet can be contributed to add-mcp's `registry.overlay.json` on [GitHub](https://github.com/neon-solutions/add-mcp).
+The registry is generated from [integrations.sh](https://integrations.sh). To be listed, add your MCP server there. Package-only servers, and remotes integrations.sh dropped that still speak MCP, can be contributed to add-mcp's `registry.overlay.json` on [GitHub](https://github.com/neon-solutions/add-mcp).
 
 ## Adding a custom registry
 


### PR DESCRIPTION
## Problem

`npx add-mcp find` searches the hosted catalog built from this repo's `registry.json`. A new integrations.sh snapshot dropped five remotes that were in the previous catalog: Algolia Productivity, Cosmic's `/v1/agent` signup server, MDN, SigNoz US Cloud and Zillow.

The previous MDN URL and the previous Zillow URL are also dead. `POST` initialize against `https://developer.mozilla.org/api/v1/mcp` and `https://mcp.zillow.com/api/v1` returns 404.

Without a pin, `find algolia`, `find cosmic`, `find mdn`, `find signoz` and `find zillow` would miss those remotes or install a 404.

## Diagnosis

`scripts/sync-integrations-sh.mjs` writes `registry.json` from integrations.sh, then `mergeEntries` overwrites by `server.name` from `registry.overlay.json`. Overlay is how find keeps remotes the snapshot no longer emits.

This snapshot is 1326 servers to 1380. Overlay is 9 entries to 14. The five new overlay names are the merged `registry.json` rows for those remotes.

`find -y` copies each required registry header into the agent config as `<your-header-value-here>`. Algolia, SigNoz and Zillow authenticate with OAuth. A required `Authorization` header would write a placeholder instead of letting the agent run OAuth.

Live `POST` initialize:

| URL | Status |
| --- | --- |
| `https://mcp.algolia.com/mcp` | 401, `WWW-Authenticate: Bearer resource_metadata="https://mcp.algolia.com/.well-known/oauth-protected-resource"` |
| `https://mcp.us.signoz.cloud/mcp` | 401, `WWW-Authenticate: Bearer resource_metadata="https://mcp.us.signoz.cloud/.well-known/oauth-protected-resource"` |
| `https://mcp.zillow.com/mcp` | 401, `WWW-Authenticate: Bearer` with `resource_metadata` |
| `https://mcp.cosmicjs.com/v1/agent` | 200, `serverInfo.name` `cosmic-mcp` |
| `https://mcp.mdn.mozilla.net/` | 200, `serverInfo.name` `mdn` |

Those overlay remotes declare only `type` and `url`.

## User-facing interface

`find` flags, install writers and npm version `2.3.0` stay as they are. After this catalog is on `main`, these queries list the pinned remotes:

```bash
npx add-mcp find algolia
npx add-mcp find cosmic
npx add-mcp find mdn
npx add-mcp find signoz
npx add-mcp find zillow
```

| Title | Name | Remote |
| --- | --- | --- |
| Algolia Productivity | `com.algolia/algolia-productivity-mcp` | `https://mcp.algolia.com/mcp` |
| Cosmic Agent | `com.cosmicjs/cosmic-hosted-mcp-agent-scope` | `https://mcp.cosmicjs.com/v1/agent` |
| MDN | `org.mozilla/mcp` | `https://mcp.mdn.mozilla.net/` |
| SigNoz | `io.signoz/mcp` | `https://mcp.us.signoz.cloud/mcp` |
| Zillow | `com.zillow/mcp` | `https://mcp.zillow.com/mcp` |

All five are `streamable-http`. Overlay JSON for Zillow:

```json
{
  "server": {
    "name": "com.zillow/mcp",
    "title": "Zillow",
    "description": "Zillow MCP server for real-estate listing search. Sign in with OAuth in the agent after install.",
    "version": "1.0.0",
    "remotes": [
      {
        "type": "streamable-http",
        "url": "https://mcp.zillow.com/mcp"
      }
    ]
  }
}
```

`npx add-mcp find zillow -a cursor -y` writes:

```json
{
  "mcpServers": {
    "zillow": {
      "url": "https://mcp.zillow.com/mcp"
    }
  }
}
```

Cosmic's title is Cosmic Agent. Same install shape, URL `https://mcp.cosmicjs.com/v1/agent`.

README `Missing A Server in integrations.sh?` and docs `Missing a server?`:

```text
Package-only servers, and remotes integrations.sh dropped that we still want in `find`, go in `registry.overlay.json`.
```

## Also in here

`registry.json` is the full snapshot plus overlay. The GitHub overlay entry `io.github.github/github-mcp-server` and the Figma overlay entry `com.figma.mcp/mcp` are the same as on `main`. The snapshot also added `com.github/mcp` and `com.figma/mcp` at those same URLs.

`package.json` stays at `2.3.0`. No changeset. `CHANGELOG.md` is untouched. `registry.json` is what the hosted registry serves; it is not in the npm `files` list.

## Verification

```bash
bun run registry:verify
# Verified 1380 registry entries
```

Initialize probes from this branch:

- `https://mcp.cosmicjs.com/v1/agent` → 200
- `https://mcp.mdn.mozilla.net/` → 200
- `https://developer.mozilla.org/api/v1/mcp` → 404
- `https://mcp.us.signoz.cloud/mcp` → 401 with `resource_metadata`
- `https://mcp.zillow.com/mcp` → 401 with `resource_metadata`
- `https://mcp.zillow.com/api/v1` → 404
- `https://mcp.algolia.com/mcp` → 401 with `resource_metadata`

Production `https://add-mcp.com/registry` still serves the previous snapshot until this is on `main`.

## For your attention

Overlay does not re-pin snapshot dropouts that are placeholders, MCP server-cards, ChatGPT wrappers, DNS-dead hosts or names still listed under another entry (Notion, Spotify, Domotz and Postman at `https://mcp.postman.com/minimal`).

Cosmic's pin is `/v1/agent`, titled Cosmic Agent. The previous catalog's bucket-scope remote `https://mcp.cosmicjs.com/v1/buckets/{your-bucket-slug}` is gone and is not in overlay.

`find github` and `find figma` will show the overlay row and the new snapshot row at the same URL.