### PR TITLE
Add Noodle Biomedical Literature Discovery MCP

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -18305,7 +18305,7 @@
       "name": "io.github.helena-bioinformatics/noodle",
       "title": "Noodle Biomedical Literature Discovery MCP",
       "description": "Search biomedical papers, inspect publication records, and traverse citation or semantic graphs.",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "websiteUrl": "https://noodle.helena.bio",
       "icons": [
         {

--- a/registry.json
+++ b/registry.json
@@ -18302,6 +18302,28 @@
   {
     "server": {
       "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "io.github.helena-bioinformatics/noodle",
+      "title": "Noodle Biomedical Literature Discovery MCP",
+      "description": "Search biomedical papers, inspect publication records, and traverse citation or semantic graphs.",
+      "version": "0.2.0",
+      "websiteUrl": "https://noodle.helena.bio",
+      "icons": [
+        {
+          "src": "https://noodle.helena.bio/favicon.svg",
+          "mimeType": "image/svg+xml"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "streamable-http",
+          "url": "https://api.helena.bio/noodle/v1/mcp"
+        }
+      ]
+    }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
       "name": "live.alpic/noodle-seed-mcp-server",
       "title": "Noodle Seed",
       "description": "Alpic is a cloud platform for building, deploying, hosting, and distributing MCP servers and ChatGPT apps. It also provides analytics, monitoring, testing, and related developer tooling for those AI-native applications.",


### PR DESCRIPTION
Adds the canonical remote Noodle MCP record to `registry.json`.

- Name: `io.github.helena-bioinformatics/noodle`
- Title: Noodle Biomedical Literature Discovery MCP
- Version: `0.2.0`
- Transport: Streamable HTTP
- Endpoint: https://api.helena.bio/noodle/v1/mcp
- Website: https://noodle.helena.bio
- Source: https://github.com/helena-bioinformatics/noodle-mcp
- License: Apache-2.0

The task-first description covers biomedical paper search, publication lookup, and citation/semantic graph traversal. The hosted server is public and read-only, accepts no PHI/private case data, and needs no account or API key.

Validation:
- `jq empty registry.json`
- registry name uniqueness check
- title-order placement before Noodle Seed
- `git diff --check`
- live website, icon, endpoint health, Official Registry record, and public source verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Noodle Biomedical Literature Discovery MCP server to the registry.
  * Included its website, icon, version information, and streamable HTTP connection details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->