### PR TITLE
Add SandBase Harness MCP bridge to registry overlay

### DIFF
--- a/registry.overlay.json
+++ b/registry.overlay.json
@@ -354,5 +354,43 @@
         }
       ]
     }
+  },
+  {
+    "server": {
+      "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+      "name": "io.github.sandbaseai/sandbase-harness",
+      "title": "SandBase Harness",
+      "description": "Local-first MCP bridge for SandBase Harness sessions, sandboxed execution, artifacts, approvals, audit, and replay.",
+      "repository": {
+        "url": "https://github.com/sandbaseai/sandbase-harness",
+        "source": "github"
+      },
+      "version": "0.3.8",
+      "websiteUrl": "https://github.com/sandbaseai/sandbase-harness",
+      "packages": [
+        {
+          "registryType": "oci",
+          "registryBaseUrl": "https://ghcr.io",
+          "identifier": "ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.8",
+          "version": "0.3.8",
+          "transport": {
+            "type": "stdio"
+          },
+          "environmentVariables": [
+            {
+              "name": "MANAGED_AGENTS_URL",
+              "description": "Base URL of the connected SandBase Harness API.",
+              "isRequired": true
+            },
+            {
+              "name": "MANAGED_AGENTS_API_KEY",
+              "description": "Optional API key for the connected Harness deployment.",
+              "isRequired": false,
+              "isSecret": true
+            }
+          ]
+        }
+      ]
+    }
   }
 ]


### PR DESCRIPTION
## Summary

- Add SandBase Harness to `registry.overlay.json` as a published OCI-backed stdio MCP server.
- Pin `ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.8`.
- Document the required Harness URL and optional API key.

## Why overlay

The project is a Docker/OCI MCP bridge rather than an npm package, so it is a good fit for the overlay path documented by add-mcp for package-only entries that integrations.sh cannot represent.

## Verification

- GHCR image exists and is multi-architecture.
- MCP `initialize` and `tools/list` were run against the image; all six bridge tools were returned.
- Source: https://github.com/sandbaseai/sandbase-harness
- Install guide: https://github.com/sandbaseai/sandbase-harness/blob/main/llms-install.md
- This PR changes only `registry.overlay.json`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the SandBase Harness server to the available server registry.
  * Included its website, source repository, package information, and connection configuration.
  * Added support for configuring the managed agents service URL and optional API key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->