### PR TITLE
feat: add Pi agent support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - keep `list` going when one agent's config is unreadable, print that agent's error, and exit nonzero. `remove` and `sync` report the same read errors, skip that file for every agent that uses it, and exit nonzero instead of treating it as empty.
 - exit nonzero when any selected agent fails to install, and print `Failed` or `Installed with errors` instead of `Done!`.
 - skip confirming a `sync` plan that cannot run, and exit nonzero when Copilot/Claude writes are blocked.
+- add `pi` support through the [`pi-mcp-adapter`](https://github.com/nicobailon/pi-mcp-adapter) extension, with project installs to `.pi/mcp.json` and global installs to `$PI_CODING_AGENT_DIR/mcp.json` (default `~/.pi/agent/mcp.json`), including native `requestTimeoutMs` mapping; alias: `pi-agent`. Pi itself has no built-in MCP.
 
 ## [2.3.0] - 2026-08-23
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Add MCP servers to your favorite coding agents with a single command.
 
-Supports **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **VS Code**, **Grok Build** and [14 more](#supported-agents).
+Supports **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **VS Code**, **Grok Build** and [15 more](#supported-agents).
 
 Docs and registry: [add-mcp.com](https://add-mcp.com)
 
@@ -69,11 +69,14 @@ MCP servers can be installed to any of these agents:
 | Kiro CLI               | `kiro-cli`           | `.kiro/settings/mcp.json`                                                     | `~/.kiro/settings/mcp.json` (shared with the Kiro IDE)                                                          |
 | MCPorter               | `mcporter`           | `config/mcporter.json`                                                        | `~/.mcporter/mcporter.json` (or existing `~/.mcporter/mcporter.jsonc`)                                          |
 | OpenCode               | `opencode`           | `opencode.jsonc` (or existing `opencode.json` / `.opencode/` config)          | `~/.config/opencode/opencode.jsonc` (or existing `opencode.json`)                                               |
+| Pi                     | `pi`                 | `.pi/mcp.json`                                                                | `$PI_CODING_AGENT_DIR/mcp.json` (defaults to `~/.pi/agent/mcp.json`)                                            |
 | VS Code                | `vscode`             | `.vscode/mcp.json`                                                            | `~/Library/Application Support/Code/User/mcp.json`                                                              |
 | Windsurf               | `windsurf`           | -                                                                             | `~/.codeium/windsurf/mcp_config.json`                                                                           |
 | Zed                    | `zed`                | `.zed/settings.json`                                                          | `~/Library/Application Support/Zed/settings.json`                                                               |
 
-**Aliases:** `codeium`, `cascade` → `windsurf`, `cline-vscode` → `cline`, `gemini` → `gemini-cli`, `github-copilot` → `vscode`, `grok` → `grok-build`, `kilo`, `kilocode` → `kilo-code`, `kimi` → `kimi-code`, `kiro` → `kiro-cli`
+**Aliases:** `codeium`, `cascade` → `windsurf`, `cline-vscode` → `cline`, `gemini` → `gemini-cli`, `github-copilot` → `vscode`, `grok` → `grok-build`, `kilo`, `kilocode` → `kilo-code`, `kimi` → `kimi-code`, `kiro` → `kiro-cli`, `pi-agent` → `pi`
+
+Pi has no built-in MCP. add-mcp writes the Pi-owned files [`pi-mcp-adapter`](https://github.com/nicobailon/pi-mcp-adapter) reads (`pi install npm:pi-mcp-adapter`). A running Pi session picks the change up after `/reload`.
 
 Kimi Code only loads a project-level `.kimi-code/mcp.json` after you trust the folder in the CLI, so a project install may not take effect until then.
 
@@ -213,12 +216,12 @@ Not every MCP client understands every field. `add-mcp` keeps one canonical
 server config and each agent declares which optional fields it supports, mapping
 them into that client's native shape:
 
-| Field              | Flag                                | Supported by                                                        | Mapped to                                                                                    |
-| ------------------ | ----------------------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| Timeout            | `--timeout`                         | Claude Code, Gemini CLI, Grok Build, Kilo Code, Kimi Code, Kiro CLI | `timeout` (milliseconds); Grok Build `tool_timeout_sec` (seconds), Kimi Code `toolTimeoutMs` |
-| OAuth scopes       | `--scopes`                          | Cursor, Gemini CLI                                                  | Cursor `auth.scopes`, Gemini `oauth.scopes`                                                  |
-| Bearer token env   | `--bearer-token-env`                | fx                                                                  | `bearer_token_env`                                                                           |
-| Tool auto-approval | `--auto-approve` / `--approve-tool` | Codex, Claude Code                                                  | Codex approval modes; Claude Code permission allow rules                                     |
+| Field              | Flag                                | Supported by                                                            | Mapped to                                                                                                           |
+| ------------------ | ----------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Timeout            | `--timeout`                         | Claude Code, Gemini CLI, Grok Build, Kilo Code, Kimi Code, Kiro CLI, Pi | `timeout` (milliseconds); Grok Build `tool_timeout_sec` (seconds), Kimi Code `toolTimeoutMs`, Pi `requestTimeoutMs` |
+| OAuth scopes       | `--scopes`                          | Cursor, Gemini CLI                                                      | Cursor `auth.scopes`, Gemini `oauth.scopes`                                                                         |
+| Bearer token env   | `--bearer-token-env`                | fx                                                                      | `bearer_token_env`                                                                                                  |
+| Tool auto-approval | `--auto-approve` / `--approve-tool` | Codex, Claude Code                                                      | Codex approval modes; Claude Code permission allow rules                                                            |
 
 When you target an agent that does not support a field, `add-mcp` drops it from
 that agent's config and prints a warning (e.g. _"request timeout is not

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "kiro-cli",
     "mcporter",
     "opencode",
+    "pi",
     "vscode",
     "windsurf",
     "zed"

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -20,6 +20,10 @@ function getKimiCodeHome(): string {
   return process.env.KIMI_CODE_HOME || join(home, ".kimi-code");
 }
 
+function getPiAgentDir(): string {
+  return process.env.PI_CODING_AGENT_DIR || join(home, ".pi", "agent");
+}
+
 /**
  * Kilo Code resolves its global config through xdg-basedir on every platform,
  * so Windows uses `~/.config/kilo` rather than `%APPDATA%`.
@@ -436,6 +440,32 @@ function transformKiroCliConfig(
   return remoteConfig;
 }
 
+/**
+ * Pi has no native MCP. pi-mcp-adapter infers transport from `command` vs
+ * `url` and names a per-request timeout `requestTimeoutMs`.
+ */
+function transformPiConfig(
+  _serverName: string,
+  config: McpServerConfig,
+): unknown {
+  if (config.url) {
+    const remote: Record<string, unknown> = { url: config.url };
+    if (config.headers && Object.keys(config.headers).length > 0) {
+      remote.headers = config.headers;
+    }
+    if (typeof config.timeout === "number") {
+      remote.requestTimeoutMs = config.timeout;
+    }
+    return remote;
+  }
+
+  const local = buildStandardLocal(config);
+  if (typeof config.timeout === "number") {
+    local.requestTimeoutMs = config.timeout;
+  }
+  return local;
+}
+
 function headersWithoutAuthorization(
   headers: Record<string, string>,
 ): Record<string, string> {
@@ -774,6 +804,17 @@ function resolveKimiCodeConfigPath(
   return join(getKimiCodeHome(), "mcp.json");
 }
 
+function resolvePiConfigPath(
+  agent: AgentConfig,
+  options: { local: boolean; cwd: string },
+): string {
+  if (options.local && agent.localConfigPath) {
+    return join(options.cwd, agent.localConfigPath);
+  }
+
+  return join(getPiAgentDir(), "mcp.json");
+}
+
 /**
  * Kilo Code reads its config from several candidate filenames, preferring
  * `.kilo/` over the legacy `.kilocode/` and the project root last. Write to the
@@ -1086,6 +1127,23 @@ export const agents: Record<AgentType, AgentConfig> = {
     },
     resolveConfigPath: resolveOpenCodeConfigPath,
     transformConfig: transformOpenCodeConfig,
+  },
+
+  pi: {
+    name: "pi",
+    displayName: "Pi",
+    configPath: join(getPiAgentDir(), "mcp.json"),
+    localConfigPath: ".pi/mcp.json",
+    projectDetectPaths: [".pi"],
+    configKey: "mcpServers",
+    format: "json",
+    supportedTransports: ["stdio", "http", "sse"],
+    supportedFields: ["timeout"],
+    detectGlobalInstall: async () => {
+      return existsSync(getPiAgentDir());
+    },
+    resolveConfigPath: resolvePiConfigPath,
+    transformConfig: transformPiConfig,
   },
 
   vscode: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export type AgentType =
   | "kiro-cli"
   | "mcporter"
   | "opencode"
+  | "pi"
   | "vscode"
   | "windsurf"
   | "zed";
@@ -33,6 +34,7 @@ export const agentAliases: Record<string, AgentType> = {
   kilocode: "kilo-code",
   kimi: "kimi-code",
   kiro: "kiro-cli",
+  "pi-agent": "pi",
 };
 
 export type ConfigFormat = "json" | "yaml" | "toml";

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -60,9 +60,9 @@ function cleanup() {
 // Agent Configuration Tests
 // ============================================
 
-test("getAgentTypes returns all 20 agents", () => {
+test("getAgentTypes returns all 21 agents", () => {
   const types = getAgentTypes();
-  assert.strictEqual(types.length, 20);
+  assert.strictEqual(types.length, 21);
   assert.ok(types.includes("antigravity"));
   assert.ok(types.includes("cline"));
   assert.ok(types.includes("cline-cli"));
@@ -80,6 +80,7 @@ test("getAgentTypes returns all 20 agents", () => {
   assert.ok(types.includes("kiro-cli"));
   assert.ok(types.includes("mcporter"));
   assert.ok(types.includes("opencode"));
+  assert.ok(types.includes("pi"));
   assert.ok(types.includes("vscode"));
   assert.ok(types.includes("windsurf"));
   assert.ok(types.includes("zed"));
@@ -142,6 +143,7 @@ test("supportedFields reflects per-client capabilities", () => {
   assert.deepStrictEqual(agents["kilo-code"].supportedFields, ["timeout"]);
   assert.deepStrictEqual(agents["kimi-code"].supportedFields, ["timeout"]);
   assert.deepStrictEqual(agents["kiro-cli"].supportedFields, ["timeout"]);
+  assert.deepStrictEqual(agents.pi.supportedFields, ["timeout"]);
   // Clients with no extra field support declare an empty list.
   assert.deepStrictEqual(agents.vscode.supportedFields, []);
   assert.deepStrictEqual(agents["claude-desktop"].supportedFields, []);
@@ -164,6 +166,7 @@ test("supportsProjectConfig - returns true for project-capable agents", () => {
   assert.strictEqual(supportsProjectConfig("kimi-code"), true);
   assert.strictEqual(supportsProjectConfig("kiro-cli"), true);
   assert.strictEqual(supportsProjectConfig("mcporter"), true);
+  assert.strictEqual(supportsProjectConfig("pi"), true);
   assert.strictEqual(supportsProjectConfig("codex"), true);
   assert.strictEqual(supportsProjectConfig("zed"), true);
 });
@@ -178,9 +181,9 @@ test("supportsProjectConfig - returns false for global-only agents", () => {
   assert.strictEqual(supportsProjectConfig("fx"), false);
 });
 
-test("getProjectCapableAgents returns 13 agents", () => {
+test("getProjectCapableAgents returns 14 agents", () => {
   const projectAgents = getProjectCapableAgents();
-  assert.strictEqual(projectAgents.length, 13);
+  assert.strictEqual(projectAgents.length, 14);
   assert.ok(projectAgents.includes("claude-code"));
   assert.ok(projectAgents.includes("cursor"));
   assert.ok(projectAgents.includes("vscode"));
@@ -192,6 +195,7 @@ test("getProjectCapableAgents returns 13 agents", () => {
   assert.ok(projectAgents.includes("kimi-code"));
   assert.ok(projectAgents.includes("kiro-cli"));
   assert.ok(projectAgents.includes("mcporter"));
+  assert.ok(projectAgents.includes("pi"));
   assert.ok(projectAgents.includes("codex"));
   assert.ok(projectAgents.includes("zed"));
 });
@@ -462,6 +466,14 @@ test("detectProjectAgents - detects .kiro directory", () => {
   assert.ok(detected.includes("kiro-cli"));
 });
 
+test("detectProjectAgents - detects .pi directory", () => {
+  const tempDir = createTempDir();
+  mkdirSync(join(tempDir, ".pi"));
+
+  const detected = detectProjectAgents(tempDir);
+  assert.ok(detected.includes("pi"));
+});
+
 test("detectProjectAgents - detects .zed directory", () => {
   const tempDir = createTempDir();
   mkdirSync(join(tempDir, ".zed"));
@@ -542,6 +554,7 @@ test("isTransportSupported - most agents support http", () => {
     "kiro-cli",
     "mcporter",
     "opencode",
+    "pi",
     "vscode",
     "windsurf",
     "zed",
@@ -574,6 +587,7 @@ test("isTransportSupported - most agents support sse", () => {
     "kiro-cli",
     "mcporter",
     "opencode",
+    "pi",
     "vscode",
     "windsurf",
     "zed",

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -2345,6 +2345,77 @@ test("E2E CLI: Kiro alias installs into .kiro/settings/mcp.json", () => {
   assert.strictEqual("type" in server, false);
 });
 
+test("E2E CLI: Pi honors PI_CODING_AGENT_DIR for global installs", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+  const piAgentDir = createTempDir();
+
+  const result = runCli(
+    [
+      "https://mcp.example.com/mcp",
+      "-a",
+      "pi-agent",
+      "-g",
+      "-y",
+      "--name",
+      "pi-remote",
+      "--timeout",
+      "5000",
+    ],
+    projectDir,
+    homeDir,
+    { PI_CODING_AGENT_DIR: piAgentDir },
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const configPath = join(piAgentDir, "mcp.json");
+  assert.strictEqual(existsSync(configPath), true);
+  assert.strictEqual(
+    existsSync(join(homeDir, ".pi", "agent", "mcp.json")),
+    false,
+  );
+
+  const saved = JSON.parse(readFileSync(configPath, "utf-8"));
+  const server = saved.mcpServers["pi-remote"] as Record<string, unknown>;
+  assert.ok(server);
+  assert.strictEqual(server.url, "https://mcp.example.com/mcp");
+  assert.strictEqual(server.requestTimeoutMs, 5000);
+  assert.strictEqual("type" in server, false);
+});
+
+test("E2E CLI: Pi global install falls back to ~/.pi/agent", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    ["mcp-server-postgres", "-a", "pi", "-g", "-y", "--name", "pi-local"],
+    projectDir,
+    homeDir,
+    { PI_CODING_AGENT_DIR: "" },
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const configPath = join(homeDir, ".pi", "agent", "mcp.json");
+  assert.strictEqual(existsSync(configPath), true);
+
+  const saved = JSON.parse(readFileSync(configPath, "utf-8"));
+  const server = saved.mcpServers["pi-local"] as Record<string, unknown>;
+  assert.ok(server);
+  assert.strictEqual(server.command, "npx");
+  assert.deepStrictEqual(server.args, ["-y", "mcp-server-postgres"]);
+  assert.strictEqual("type" in server, false);
+});
+
 test("E2E CLI: Kimi alias honors KIMI_CODE_HOME for global installs", () => {
   const projectDir = createTempDir();
   const homeDir = createTempDir();

--- a/tests/e2e/install.test.ts
+++ b/tests/e2e/install.test.ts
@@ -1232,6 +1232,85 @@ test("E2E: Kiro CLI sse install does not write a type field", () => {
 });
 
 // ============================================
+// E2E Tests: Pi (pi-mcp-adapter owned files)
+// ============================================
+
+test("E2E: Install to Pi (local) - stdio", () => {
+  const tempDir = createTempDir();
+  const parsed = parseSource("mcp-server-github");
+  const config = buildServerConfig(parsed, {
+    env: { GITHUB_TOKEN: "secret" },
+  });
+
+  const result = installServerForAgent("github", config, "pi", {
+    local: true,
+    cwd: tempDir,
+  });
+
+  assert.strictEqual(result.success, true);
+
+  const configPath = join(tempDir, ".pi", "mcp.json");
+  assert.strictEqual(existsSync(configPath), true);
+
+  const savedConfig = readJsonConfig(configPath);
+  const mcpServers = savedConfig.mcpServers as Record<
+    string,
+    Record<string, unknown>
+  >;
+  const serverConfig = mcpServers.github;
+  assert.ok(serverConfig);
+  assert.strictEqual(serverConfig.command, "npx");
+  assert.deepStrictEqual(serverConfig.args, ["-y", "mcp-server-github"]);
+  assert.deepStrictEqual(serverConfig.env, { GITHUB_TOKEN: "secret" });
+  assert.strictEqual("type" in serverConfig, false);
+});
+
+test("E2E: Install to Pi (local) - remote omits type and maps timeout", () => {
+  const tempDir = createTempDir();
+  const parsed = parseSource("https://mcp.example.com/api");
+  const config = buildServerConfig(parsed, {
+    headers: { Authorization: "Bearer token" },
+    timeout: 60000,
+  });
+
+  const result = installServerForAgent("example", config, "pi", {
+    local: true,
+    cwd: tempDir,
+  });
+
+  assert.strictEqual(result.success, true);
+
+  const savedConfig = readJsonConfig(join(tempDir, ".pi", "mcp.json"));
+  const mcpServers = savedConfig.mcpServers as Record<
+    string,
+    Record<string, unknown>
+  >;
+  const serverConfig = mcpServers.example;
+  assert.ok(serverConfig);
+  assert.strictEqual(serverConfig.url, "https://mcp.example.com/api");
+  assert.deepStrictEqual(serverConfig.headers, {
+    Authorization: "Bearer token",
+  });
+  assert.strictEqual("type" in serverConfig, false);
+  assert.strictEqual(serverConfig.requestTimeoutMs, 60000);
+  assert.strictEqual("timeout" in serverConfig, false);
+});
+
+test("E2E: Pi sse install does not write a type field", () => {
+  const parsed = parseSource("https://mcp.example.com/sse");
+  const config = buildServerConfig(parsed, { transport: "sse" });
+
+  const transformed = agents.pi.transformConfig("example", config) as Record<
+    string,
+    unknown
+  >;
+
+  assert.strictEqual(transformed.url, "https://mcp.example.com/sse");
+  assert.strictEqual("type" in transformed, false);
+  assert.strictEqual("transport" in transformed, false);
+});
+
+// ============================================
 // E2E Tests: Kilo Code (OpenCode-style JSON)
 // ============================================
 

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -502,6 +502,55 @@ test("installServerForAgent - Claude Code keeps timeout, drops scopes", () => {
   assert.ok(!("oauthScopes" in server));
 });
 
+test("installServerForAgent - Pi maps timeout to requestTimeoutMs", () => {
+  const tempDir = createTempDir();
+  const result = installRemoteWith("pi", tempDir, {
+    timeout: 12000,
+  });
+  assert.ok(result.success);
+  assert.strictEqual(result.droppedFields, undefined);
+
+  const saved = readJsonConfig(join(tempDir, ".pi", "mcp.json"));
+  const server = (saved.mcpServers as Record<string, Record<string, unknown>>)
+    .example;
+  assert.ok(server);
+  assert.strictEqual(server.url, "https://mcp.example.com/mcp");
+  assert.strictEqual(server.requestTimeoutMs, 12000);
+  assert.ok(!("type" in server));
+  assert.ok(!("timeout" in server));
+});
+
+test("installServerForAgent - Pi maps stdio config and timeout", () => {
+  const tempDir = createTempDir();
+  const result = installServerForAgent(
+    "postgres",
+    {
+      command: "npx",
+      args: ["-y", "mcp-server-postgres"],
+      env: { DATABASE_URL: "postgres://localhost/test" },
+      timeout: 12000,
+    },
+    "pi",
+    { local: true, cwd: tempDir },
+  );
+  assert.ok(result.success);
+  assert.strictEqual(result.droppedFields, undefined);
+
+  const saved = readJsonConfig(join(tempDir, ".pi", "mcp.json"));
+  const server = (saved.mcpServers as Record<string, Record<string, unknown>>)
+    .postgres;
+  assert.ok(server);
+  assert.strictEqual(server.command, "npx");
+  assert.deepStrictEqual(server.args, ["-y", "mcp-server-postgres"]);
+  assert.deepStrictEqual(server.env, {
+    DATABASE_URL: "postgres://localhost/test",
+  });
+  assert.strictEqual(server.requestTimeoutMs, 12000);
+  assert.ok(!("type" in server));
+  assert.ok(!("transport" in server));
+  assert.ok(!("timeout" in server));
+});
+
 test("installServerForAgent - VS Code drops both timeout and scopes", () => {
   const tempDir = createTempDir();
   const result = installRemoteWith("vscode", tempDir, {

--- a/web/content/docs/02-cli/01-add.mdx
+++ b/web/content/docs/02-cli/01-add.mdx
@@ -81,12 +81,12 @@ Local servers (npm packages, commands) always use **stdio** transport. Most agen
 
 Not every MCP client understands every field. add-mcp keeps one canonical server config; each agent declares which optional fields it supports and maps them into its native shape:
 
-| Field              | Flag                                | Supported by                                                        | Mapped to                                                                                    |
-| ------------------ | ----------------------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| Timeout            | `--timeout`                         | Claude Code, Gemini CLI, Grok Build, Kilo Code, Kimi Code, Kiro CLI | `timeout` (milliseconds); Grok Build `tool_timeout_sec` (seconds), Kimi Code `toolTimeoutMs` |
-| OAuth scopes       | `--scopes`                          | Cursor, Gemini CLI                                                  | Cursor `auth.scopes`, Gemini `oauth.scopes`                                                  |
-| Bearer token env   | `--bearer-token-env`                | fx                                                                  | `bearer_token_env`                                                                           |
-| Tool auto-approval | `--auto-approve` / `--approve-tool` | Codex, Claude Code                                                  | Codex approval modes; Claude Code permission allow rules                                     |
+| Field              | Flag                                | Supported by                                                            | Mapped to                                                                                                           |
+| ------------------ | ----------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Timeout            | `--timeout`                         | Claude Code, Gemini CLI, Grok Build, Kilo Code, Kimi Code, Kiro CLI, Pi | `timeout` (milliseconds); Grok Build `tool_timeout_sec` (seconds), Kimi Code `toolTimeoutMs`, Pi `requestTimeoutMs` |
+| OAuth scopes       | `--scopes`                          | Cursor, Gemini CLI                                                      | Cursor `auth.scopes`, Gemini `oauth.scopes`                                                                         |
+| Bearer token env   | `--bearer-token-env`                | fx                                                                      | `bearer_token_env`                                                                                                  |
+| Tool auto-approval | `--auto-approve` / `--approve-tool` | Codex, Claude Code                                                      | Codex approval modes; Claude Code permission allow rules                                                            |
 
 When a targeted agent doesn't support a field, add-mcp drops it from that agent's config and prints a warning — other agents still receive it. `--timeout`, `--scopes`, and `--bearer-token-env` apply to remote servers only. When `--bearer-token-env` and `--header Authorization` are both set, fx omits the Authorization header and writes `bearer_token_env`; other agents keep the header.
 

--- a/web/content/docs/03-sdk/01-reference.mdx
+++ b/web/content/docs/03-sdk/01-reference.mdx
@@ -167,6 +167,7 @@ type AgentType =
   | "kiro-cli"
   | "mcporter"
   | "opencode"
+  | "pi"
   | "vscode"
   | "windsurf"
   | "zed";

--- a/web/content/docs/05-agents.mdx
+++ b/web/content/docs/05-agents.mdx
@@ -24,6 +24,7 @@ MCP servers can be installed to any of these agents. Project paths are relative 
 | Kiro CLI               | `kiro-cli`           | `.kiro/settings/mcp.json`                                                     | `~/.kiro/settings/mcp.json` (shared with the Kiro IDE)                                                          |
 | MCPorter               | `mcporter`           | `config/mcporter.json`                                                        | `~/.mcporter/mcporter.json` (or existing `~/.mcporter/mcporter.jsonc`)                                          |
 | OpenCode               | `opencode`           | `opencode.jsonc` (or existing `opencode.json` / `.opencode/` config)          | `~/.config/opencode/opencode.jsonc` (or existing `opencode.json`)                                               |
+| Pi                     | `pi`                 | `.pi/mcp.json`                                                                | `$PI_CODING_AGENT_DIR/mcp.json` (defaults to `~/.pi/agent/mcp.json`)                                            |
 | VS Code                | `vscode`             | `.vscode/mcp.json`                                                            | `~/Library/Application Support/Code/User/mcp.json`                                                              |
 | Windsurf               | `windsurf`           | —                                                                             | `~/.codeium/windsurf/mcp_config.json`                                                                           |
 | Zed                    | `zed`                | `.zed/settings.json`                                                          | `~/Library/Application Support/Zed/settings.json`                                                               |
@@ -40,12 +41,15 @@ MCP servers can be installed to any of these agents. Project paths are relative 
 | `kilo`, `kilocode`   | `kilo-code`  |
 | `kimi`               | `kimi-code`  |
 | `kiro`               | `kiro-cli`   |
+| `pi-agent`           | `pi`         |
 
 ## Troubleshooting
 
 Some agents and editors, like Claude Code, require a restart to load a new MCP server. Others, like Cursor, require you to navigate to the MCP settings page and toggle the new server as enabled.
 
 Kimi Code only loads a project-level `.kimi-code/mcp.json` after you trust the folder in the CLI, so a project install may not take effect until then. Its MCP config is also validated as a whole: if another entry in the file is invalid, Kimi Code disables every MCP server, including a newly added one.
+
+Pi has no built-in MCP. add-mcp writes the Pi-owned files [`pi-mcp-adapter`](https://github.com/nicobailon/pi-mcp-adapter) reads. Install that extension with `pi install npm:pi-mcp-adapter`. A running Pi session picks the change up after `/reload`.
 
 fx reads MCP servers only from `~/.fx/mcp.json`. A project file cannot add a server. A running session applies the change with `/mcp reload`.
 

--- a/web/content/docs/index.mdx
+++ b/web/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: Introduction
 description: add-mcp adds MCP servers to your favorite coding agents with a single command.
 ---
 
-`add-mcp` is an open-source CLI (and TypeScript SDK) that installs [Model Context Protocol](https://modelcontextprotocol.io) servers into the config files of your coding agents — Claude Code, Codex, Cursor, OpenCode, VS Code, Grok Build, and [14 more](/docs/agents) — with a single command.
+`add-mcp` is an open-source CLI (and TypeScript SDK) that installs [Model Context Protocol](https://modelcontextprotocol.io) servers into the config files of your coding agents — Claude Code, Codex, Cursor, OpenCode, VS Code, Grok Build, and [15 more](/docs/agents) — with a single command.
 
 ```bash
 npx add-mcp https://mcp.context7.com/mcp

--- a/web/pages/index.astro
+++ b/web/pages/index.astro
@@ -25,6 +25,7 @@ const agentNames = [
   "Kimi Code",
   "Kiro CLI",
   "MCPorter",
+  "Pi",
   "Windsurf",
   "Zed",
 ];
@@ -256,7 +257,7 @@ const structuredData = JSON.stringify({
         class="text-muted-foreground mx-auto mt-2 max-w-2xl text-sm text-pretty"
       >
         add-mcp installs any MCP server into Claude Code, Codex, Cursor,
-        OpenCode, VS Code, and 15 more coding agents from the same command.
+        OpenCode, VS Code, and 16 more coding agents from the same command.
       </p>
       <div class="mt-4 flex flex-wrap items-center justify-center gap-2">
         {


### PR DESCRIPTION
Supersedes [#104](https://github.com/neon-solutions/add-mcp/pull/104) to resolve its conflicts with current `main`. Co-authored with [David Ferland (@dferland1)](https://github.com/dferland1), retaining his proposed Pi destination.

## Problem

Pi users need an add-mcp destination that writes the configuration consumed by [`pi-mcp-adapter`](https://github.com/nicobailon/pi-mcp-adapter). Pi has no built-in MCP support.

This adds `pi` and the alias `pi-agent`, using Pi-owned files so project installs stay separate from Claude Code's `.mcp.json`.

## Interface

Install the extension, then add a server:

```bash
pi install npm:pi-mcp-adapter

# Project install
npx add-mcp https://mcp.example.com/mcp \
  -a pi --name example --timeout 5000 -y

# Global install using the alias
npx add-mcp mcp-server-postgres -a pi-agent -g -y
```

| Scope | Config file |
| --- | --- |
| Project, the CLI default | `.pi/mcp.json` |
| Global, with `-g` | `$PI_CODING_AGENT_DIR/mcp.json`, defaulting to `~/.pi/agent/mcp.json` |

The project example writes:

```json
{
  "mcpServers": {
    "example": {
      "url": "https://mcp.example.com/mcp",
      "requestTimeoutMs": 5000
    }
  }
}
```

Pi supports stdio, HTTP and SSE destinations. The adapter infers transport from `command` or `url`, so entries omit `type`. Stdio entries preserve `command`, `args` and `env`; remote entries preserve `url` and headers. Timeout values map to `requestTimeoutMs` in milliseconds.

The SDK also accepts `"pi"`:

```ts
import { upsertServer } from "add-mcp";

const result = upsertServer(
  "pi",
  "example",
  { url: "https://mcp.example.com/mcp", timeout: 5000 },
  { local: true, cwd: process.cwd() },
);
```

Project detection recognizes `.pi`; global detection recognizes the Pi agent directory. Existing agents keep their current paths and config formats.

## Also in here

Updates the README, CLI and SDK docs, website agent list, package keywords and changelog for Pi support.

## Verification

`bun run typecheck` and `bun run test` pass locally (full suite, 14 files). CI `test` on this PR is green.

Added tests cover:

- Pi registration, project detection and supported transports.
- Project stdio installs preserving arguments and environment variables.
- Remote installs preserving headers and mapping timeouts.
- Stdio timeout mapping and omission of transport fields.
- CLI installs through `pi-agent` with a custom `PI_CODING_AGENT_DIR`.
- Global fallback to `~/.pi/agent/mcp.json`.

`pi-mcp-adapter`'s `loadMcpConfig` loaded the files add-mcp writes: project `.pi/mcp.json` with `requestTimeoutMs`, and global `$PI_CODING_AGENT_DIR/mcp.json` stdio `command`/`args`. A live Pi session, MCP tool call, and `/reload` were not run.

## For your attention

- add-mcp writes the configuration; users must install `pi-mcp-adapter` separately.
- A running Pi session needs `/reload` to pick up the change.
