### PR TITLE
feat: add Mastra Code agent support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - exit nonzero when any selected agent fails to install, and print `Failed` or `Installed with errors` instead of `Done!`.
 - skip confirming a `sync` plan that cannot run, and exit nonzero when Copilot/Claude writes are blocked.
 - add `pi` support through the [`pi-mcp-adapter`](https://github.com/nicobailon/pi-mcp-adapter) extension, with project installs to `.pi/mcp.json` and global installs to `$PI_CODING_AGENT_DIR/mcp.json` (default `~/.pi/agent/mcp.json`), including native `requestTimeoutMs` mapping; alias: `pi-agent`. Pi itself has no built-in MCP.
+- add `mastracode` support with project installs to `.mastracode/mcp.json` and global installs to `~/.mastracode/mcp.json`, mapping `--scopes` to `oauth.scopes`; alias: `mastra`. Native files are used so installs do not share Claude Code's `.mcp.json`.
 
 ## [2.3.0] - 2026-08-23
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Add MCP servers to your favorite coding agents with a single command.
 
-Supports **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **VS Code**, **Grok Build** and [15 more](#supported-agents).
+Supports **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **VS Code**, **Grok Build** and [16 more](#supported-agents).
 
 Docs and registry: [add-mcp.com](https://add-mcp.com)
 
@@ -67,6 +67,7 @@ MCP servers can be installed to any of these agents:
 | Kilo Code              | `kilo-code`          | `kilo.json` (or existing `.kilo/`, `.kilocode/`, or root `kilo.jsonc` config) | `~/.config/kilo/kilo.json` (or existing `~/.config/kilo/kilo.jsonc`)                                            |
 | Kimi Code              | `kimi-code`          | `.kimi-code/mcp.json`                                                         | `$KIMI_CODE_HOME/mcp.json` (defaults to `~/.kimi-code/mcp.json`)                                                |
 | Kiro CLI               | `kiro-cli`           | `.kiro/settings/mcp.json`                                                     | `~/.kiro/settings/mcp.json` (shared with the Kiro IDE)                                                          |
+| Mastra Code            | `mastracode`         | `.mastracode/mcp.json`                                                        | `~/.mastracode/mcp.json`                                                                                        |
 | MCPorter               | `mcporter`           | `config/mcporter.json`                                                        | `~/.mcporter/mcporter.json` (or existing `~/.mcporter/mcporter.jsonc`)                                          |
 | OpenCode               | `opencode`           | `opencode.jsonc` (or existing `opencode.json` / `.opencode/` config)          | `~/.config/opencode/opencode.jsonc` (or existing `opencode.json`)                                               |
 | Pi                     | `pi`                 | `.pi/mcp.json`                                                                | `$PI_CODING_AGENT_DIR/mcp.json` (defaults to `~/.pi/agent/mcp.json`)                                            |
@@ -74,7 +75,9 @@ MCP servers can be installed to any of these agents:
 | Windsurf               | `windsurf`           | -                                                                             | `~/.codeium/windsurf/mcp_config.json`                                                                           |
 | Zed                    | `zed`                | `.zed/settings.json`                                                          | `~/Library/Application Support/Zed/settings.json`                                                               |
 
-**Aliases:** `codeium`, `cascade` → `windsurf`, `cline-vscode` → `cline`, `gemini` → `gemini-cli`, `github-copilot` → `vscode`, `grok` → `grok-build`, `kilo`, `kilocode` → `kilo-code`, `kimi` → `kimi-code`, `kiro` → `kiro-cli`, `pi-agent` → `pi`
+**Aliases:** `codeium`, `cascade` → `windsurf`, `cline-vscode` → `cline`, `gemini` → `gemini-cli`, `github-copilot` → `vscode`, `grok` → `grok-build`, `kilo`, `kilocode` → `kilo-code`, `kimi` → `kimi-code`, `kiro` → `kiro-cli`, `mastra` → `mastracode`, `pi-agent` → `pi`
+
+Mastra Code also reads project `.mcp.json` for Claude Code compatibility. add-mcp writes `.mastracode/mcp.json` so a mixed Claude + Mastra install does not share that file.
 
 Pi has no built-in MCP. add-mcp writes the Pi-owned files [`pi-mcp-adapter`](https://github.com/nicobailon/pi-mcp-adapter) reads (`pi install npm:pi-mcp-adapter`). A running Pi session picks the change up after `/reload`.
 
@@ -216,12 +219,12 @@ Not every MCP client understands every field. `add-mcp` keeps one canonical
 server config and each agent declares which optional fields it supports, mapping
 them into that client's native shape:
 
-| Field              | Flag                                | Supported by                                                            | Mapped to                                                                                                           |
-| ------------------ | ----------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| Timeout            | `--timeout`                         | Claude Code, Gemini CLI, Grok Build, Kilo Code, Kimi Code, Kiro CLI, Pi | `timeout` (milliseconds); Grok Build `tool_timeout_sec` (seconds), Kimi Code `toolTimeoutMs`, Pi `requestTimeoutMs` |
-| OAuth scopes       | `--scopes`                          | Cursor, Gemini CLI                                                      | Cursor `auth.scopes`, Gemini `oauth.scopes`                                                                         |
-| Bearer token env   | `--bearer-token-env`                | fx                                                                      | `bearer_token_env`                                                                                                  |
-| Tool auto-approval | `--auto-approve` / `--approve-tool` | Codex, Claude Code                                                      | Codex approval modes; Claude Code permission allow rules                                                            |
+| Field              | Flag                                | Supported by                                                                        | Mapped to                                                                                                           |
+| ------------------ | ----------------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Timeout            | `--timeout`                         | Claude Code, Gemini CLI, Grok Build, Kilo Code, Kimi Code, Kiro CLI, Pi             | `timeout` (milliseconds); Grok Build `tool_timeout_sec` (seconds), Kimi Code `toolTimeoutMs`, Pi `requestTimeoutMs` |
+| OAuth scopes       | `--scopes`                          | Cursor, Gemini CLI, Mastra Code                                                     | Cursor `auth.scopes`, Gemini and Mastra Code `oauth.scopes`                                                         |
+| Bearer token env   | `--bearer-token-env`                | fx                                                                                  | `bearer_token_env`                                                                                                  |
+| Tool auto-approval | `--auto-approve` / `--approve-tool` | Codex, Claude Code                                                                  | Codex approval modes; Claude Code permission allow rules                                                            |
 
 When you target an agent that does not support a field, `add-mcp` drops it from
 that agent's config and prints a warning (e.g. _"request timeout is not

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "kimi-code",
     "kiro",
     "kiro-cli",
+    "mastracode",
     "mcporter",
     "opencode",
     "pi",

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -20,6 +20,10 @@ function getKimiCodeHome(): string {
   return process.env.KIMI_CODE_HOME || join(home, ".kimi-code");
 }
 
+function getMastraCodeDir(): string {
+  return join(home, ".mastracode");
+}
+
 function getPiAgentDir(): string {
   return process.env.PI_CODING_AGENT_DIR || join(home, ".pi", "agent");
 }
@@ -464,6 +468,28 @@ function transformPiConfig(
     local.requestTimeoutMs = config.timeout;
   }
   return local;
+}
+
+/**
+ * Mastra Code infers transport from `command` vs `url` and skips an entry
+ * that sets both. OAuth scopes live under `oauth.scopes`.
+ */
+function transformMastraCodeConfig(
+  _serverName: string,
+  config: McpServerConfig,
+): unknown {
+  if (!config.url) {
+    return buildStandardLocal(config);
+  }
+
+  const remote: Record<string, unknown> = { url: config.url };
+  if (config.headers && Object.keys(config.headers).length > 0) {
+    remote.headers = config.headers;
+  }
+  if (config.oauthScopes && config.oauthScopes.length > 0) {
+    remote.oauth = { scopes: config.oauthScopes };
+  }
+  return remote;
 }
 
 function headersWithoutAuthorization(
@@ -1093,6 +1119,22 @@ export const agents: Record<AgentType, AgentConfig> = {
       return existsSync(join(home, ".kiro"));
     },
     transformConfig: transformKiroCliConfig,
+  },
+
+  mastracode: {
+    name: "mastracode",
+    displayName: "Mastra Code",
+    configPath: join(getMastraCodeDir(), "mcp.json"),
+    localConfigPath: ".mastracode/mcp.json",
+    projectDetectPaths: [".mastracode"],
+    configKey: "mcpServers",
+    format: "json",
+    supportedTransports: ["stdio", "http", "sse"],
+    supportedFields: ["scopes"],
+    detectGlobalInstall: async () => {
+      return existsSync(getMastraCodeDir());
+    },
+    transformConfig: transformMastraCodeConfig,
   },
 
   mcporter: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export type AgentType =
   | "kilo-code"
   | "kimi-code"
   | "kiro-cli"
+  | "mastracode"
   | "mcporter"
   | "opencode"
   | "pi"
@@ -34,6 +35,7 @@ export const agentAliases: Record<string, AgentType> = {
   kilocode: "kilo-code",
   kimi: "kimi-code",
   kiro: "kiro-cli",
+  mastra: "mastracode",
   "pi-agent": "pi",
 };
 

--- a/tests/agents.test.ts
+++ b/tests/agents.test.ts
@@ -60,9 +60,9 @@ function cleanup() {
 // Agent Configuration Tests
 // ============================================
 
-test("getAgentTypes returns all 21 agents", () => {
+test("getAgentTypes returns all 22 agents", () => {
   const types = getAgentTypes();
-  assert.strictEqual(types.length, 21);
+  assert.strictEqual(types.length, 22);
   assert.ok(types.includes("antigravity"));
   assert.ok(types.includes("cline"));
   assert.ok(types.includes("cline-cli"));
@@ -78,6 +78,7 @@ test("getAgentTypes returns all 21 agents", () => {
   assert.ok(types.includes("kilo-code"));
   assert.ok(types.includes("kimi-code"));
   assert.ok(types.includes("kiro-cli"));
+  assert.ok(types.includes("mastracode"));
   assert.ok(types.includes("mcporter"));
   assert.ok(types.includes("opencode"));
   assert.ok(types.includes("pi"));
@@ -143,6 +144,7 @@ test("supportedFields reflects per-client capabilities", () => {
   assert.deepStrictEqual(agents["kilo-code"].supportedFields, ["timeout"]);
   assert.deepStrictEqual(agents["kimi-code"].supportedFields, ["timeout"]);
   assert.deepStrictEqual(agents["kiro-cli"].supportedFields, ["timeout"]);
+  assert.deepStrictEqual(agents.mastracode.supportedFields, ["scopes"]);
   assert.deepStrictEqual(agents.pi.supportedFields, ["timeout"]);
   // Clients with no extra field support declare an empty list.
   assert.deepStrictEqual(agents.vscode.supportedFields, []);
@@ -165,6 +167,7 @@ test("supportsProjectConfig - returns true for project-capable agents", () => {
   assert.strictEqual(supportsProjectConfig("kilo-code"), true);
   assert.strictEqual(supportsProjectConfig("kimi-code"), true);
   assert.strictEqual(supportsProjectConfig("kiro-cli"), true);
+  assert.strictEqual(supportsProjectConfig("mastracode"), true);
   assert.strictEqual(supportsProjectConfig("mcporter"), true);
   assert.strictEqual(supportsProjectConfig("pi"), true);
   assert.strictEqual(supportsProjectConfig("codex"), true);
@@ -181,9 +184,9 @@ test("supportsProjectConfig - returns false for global-only agents", () => {
   assert.strictEqual(supportsProjectConfig("fx"), false);
 });
 
-test("getProjectCapableAgents returns 14 agents", () => {
+test("getProjectCapableAgents returns 15 agents", () => {
   const projectAgents = getProjectCapableAgents();
-  assert.strictEqual(projectAgents.length, 14);
+  assert.strictEqual(projectAgents.length, 15);
   assert.ok(projectAgents.includes("claude-code"));
   assert.ok(projectAgents.includes("cursor"));
   assert.ok(projectAgents.includes("vscode"));
@@ -194,6 +197,7 @@ test("getProjectCapableAgents returns 14 agents", () => {
   assert.ok(projectAgents.includes("kilo-code"));
   assert.ok(projectAgents.includes("kimi-code"));
   assert.ok(projectAgents.includes("kiro-cli"));
+  assert.ok(projectAgents.includes("mastracode"));
   assert.ok(projectAgents.includes("mcporter"));
   assert.ok(projectAgents.includes("pi"));
   assert.ok(projectAgents.includes("codex"));
@@ -466,6 +470,23 @@ test("detectProjectAgents - detects .kiro directory", () => {
   assert.ok(detected.includes("kiro-cli"));
 });
 
+test("detectProjectAgents - detects .mastracode directory", () => {
+  const tempDir = createTempDir();
+  mkdirSync(join(tempDir, ".mastracode"));
+
+  const detected = detectProjectAgents(tempDir);
+  assert.ok(detected.includes("mastracode"));
+});
+
+test("detectProjectAgents - does not treat .mcp.json as Mastra Code", () => {
+  const tempDir = createTempDir();
+  writeFileSync(join(tempDir, ".mcp.json"), "{}");
+
+  const detected = detectProjectAgents(tempDir);
+  assert.ok(detected.includes("claude-code"));
+  assert.ok(!detected.includes("mastracode"));
+});
+
 test("detectProjectAgents - detects .pi directory", () => {
   const tempDir = createTempDir();
   mkdirSync(join(tempDir, ".pi"));
@@ -552,6 +573,7 @@ test("isTransportSupported - most agents support http", () => {
     "kilo-code",
     "kimi-code",
     "kiro-cli",
+    "mastracode",
     "mcporter",
     "opencode",
     "pi",
@@ -585,6 +607,7 @@ test("isTransportSupported - most agents support sse", () => {
     "kilo-code",
     "kimi-code",
     "kiro-cli",
+    "mastracode",
     "mcporter",
     "opencode",
     "pi",

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -2416,6 +2416,78 @@ test("E2E CLI: Pi global install falls back to ~/.pi/agent", () => {
   assert.strictEqual("type" in server, false);
 });
 
+test("E2E CLI: Mastra alias installs into .mastracode/mcp.json", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "https://mcp.example.com/mcp",
+      "-a",
+      "mastra",
+      "-y",
+      "--name",
+      "mastra-remote",
+      "--scopes",
+      "read,write",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const configPath = join(projectDir, ".mastracode", "mcp.json");
+  assert.strictEqual(existsSync(configPath), true);
+  assert.strictEqual(existsSync(join(projectDir, ".mcp.json")), false);
+
+  const saved = JSON.parse(readFileSync(configPath, "utf-8"));
+  const server = saved.mcpServers["mastra-remote"] as Record<string, unknown>;
+  assert.ok(server);
+  assert.strictEqual(server.url, "https://mcp.example.com/mcp");
+  assert.deepStrictEqual(server.oauth, { scopes: ["read", "write"] });
+  assert.strictEqual("type" in server, false);
+});
+
+test("E2E CLI: Mastra Code global install writes ~/.mastracode/mcp.json", () => {
+  const projectDir = createTempDir();
+  const homeDir = createTempDir();
+
+  const result = runCli(
+    [
+      "mcp-server-postgres",
+      "-a",
+      "mastracode",
+      "-g",
+      "-y",
+      "--name",
+      "mastra-local",
+    ],
+    projectDir,
+    homeDir,
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      `CLI failed.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+
+  const configPath = join(homeDir, ".mastracode", "mcp.json");
+  assert.strictEqual(existsSync(configPath), true);
+
+  const saved = JSON.parse(readFileSync(configPath, "utf-8"));
+  const server = saved.mcpServers["mastra-local"] as Record<string, unknown>;
+  assert.ok(server);
+  assert.strictEqual(server.command, "npx");
+  assert.deepStrictEqual(server.args, ["-y", "mcp-server-postgres"]);
+  assert.strictEqual("type" in server, false);
+});
+
 test("E2E CLI: Kimi alias honors KIMI_CODE_HOME for global installs", () => {
   const projectDir = createTempDir();
   const homeDir = createTempDir();

--- a/tests/e2e/install.test.ts
+++ b/tests/e2e/install.test.ts
@@ -1313,6 +1313,86 @@ test("E2E: Pi sse install does not write a type field", () => {
 // ============================================
 // E2E Tests: Kilo Code (OpenCode-style JSON)
 // ============================================
+// E2E Tests: Mastra Code
+// ============================================
+
+test("E2E: Install to Mastra Code (local) - stdio", () => {
+  const tempDir = createTempDir();
+  const parsed = parseSource("mcp-server-github");
+  const config = buildServerConfig(parsed, {
+    env: { GITHUB_TOKEN: "secret" },
+  });
+
+  const result = installServerForAgent("github", config, "mastracode", {
+    local: true,
+    cwd: tempDir,
+  });
+
+  assert.strictEqual(result.success, true);
+
+  const configPath = join(tempDir, ".mastracode", "mcp.json");
+  assert.strictEqual(existsSync(configPath), true);
+
+  const savedConfig = readJsonConfig(configPath);
+  const mcpServers = savedConfig.mcpServers as Record<
+    string,
+    Record<string, unknown>
+  >;
+  const serverConfig = mcpServers.github;
+  assert.ok(serverConfig);
+  assert.strictEqual(serverConfig.command, "npx");
+  assert.deepStrictEqual(serverConfig.args, ["-y", "mcp-server-github"]);
+  assert.deepStrictEqual(serverConfig.env, { GITHUB_TOKEN: "secret" });
+  assert.strictEqual("type" in serverConfig, false);
+});
+
+test("E2E: Install to Mastra Code (local) - remote maps oauth.scopes", () => {
+  const tempDir = createTempDir();
+  const parsed = parseSource("https://mcp.example.com/api");
+  const config = buildServerConfig(parsed, {
+    headers: { Authorization: "Bearer token" },
+    oauthScopes: ["read", "write"],
+  });
+
+  const result = installServerForAgent("example", config, "mastracode", {
+    local: true,
+    cwd: tempDir,
+  });
+
+  assert.strictEqual(result.success, true);
+
+  const savedConfig = readJsonConfig(join(tempDir, ".mastracode", "mcp.json"));
+  const mcpServers = savedConfig.mcpServers as Record<
+    string,
+    Record<string, unknown>
+  >;
+  const serverConfig = mcpServers.example;
+  assert.ok(serverConfig);
+  assert.strictEqual(serverConfig.url, "https://mcp.example.com/api");
+  assert.deepStrictEqual(serverConfig.headers, {
+    Authorization: "Bearer token",
+  });
+  assert.deepStrictEqual(serverConfig.oauth, { scopes: ["read", "write"] });
+  assert.strictEqual("type" in serverConfig, false);
+});
+
+test("E2E: Mastra Code sse install does not write a type field", () => {
+  const parsed = parseSource("https://mcp.example.com/sse");
+  const config = buildServerConfig(parsed, { transport: "sse" });
+
+  const transformed = agents.mastracode.transformConfig(
+    "example",
+    config,
+  ) as Record<string, unknown>;
+
+  assert.strictEqual(transformed.url, "https://mcp.example.com/sse");
+  assert.strictEqual("type" in transformed, false);
+  assert.strictEqual("transport" in transformed, false);
+});
+
+// ============================================
+// E2E Tests: Kilo Code (OpenCode-style JSON)
+// ============================================
 
 test("E2E: Install remote MCP to Kilo Code (local)", () => {
   const tempDir = createTempDir();

--- a/tests/installer.test.ts
+++ b/tests/installer.test.ts
@@ -551,6 +551,53 @@ test("installServerForAgent - Pi maps stdio config and timeout", () => {
   assert.ok(!("timeout" in server));
 });
 
+test("installServerForAgent - Mastra Code maps scopes to oauth.scopes", () => {
+  const tempDir = createTempDir();
+  const result = installRemoteWith("mastracode", tempDir, {
+    oauthScopes: ["read", "write"],
+    timeout: 12000,
+  });
+  assert.ok(result.success);
+  assert.deepStrictEqual(result.droppedFields, ["timeout"]);
+
+  const saved = readJsonConfig(join(tempDir, ".mastracode", "mcp.json"));
+  const server = (saved.mcpServers as Record<string, Record<string, unknown>>)
+    .example;
+  assert.ok(server);
+  assert.strictEqual(server.url, "https://mcp.example.com/mcp");
+  assert.deepStrictEqual(server.oauth, { scopes: ["read", "write"] });
+  assert.ok(!("type" in server));
+  assert.ok(!("timeout" in server));
+  assert.ok(!("oauthScopes" in server));
+});
+
+test("installServerForAgent - Mastra Code stdio omits type", () => {
+  const tempDir = createTempDir();
+  const result = installServerForAgent(
+    "postgres",
+    {
+      command: "npx",
+      args: ["-y", "mcp-server-postgres"],
+      env: { DATABASE_URL: "postgres://localhost/test" },
+    },
+    "mastracode",
+    { local: true, cwd: tempDir },
+  );
+  assert.ok(result.success);
+
+  const saved = readJsonConfig(join(tempDir, ".mastracode", "mcp.json"));
+  const server = (saved.mcpServers as Record<string, Record<string, unknown>>)
+    .postgres;
+  assert.ok(server);
+  assert.strictEqual(server.command, "npx");
+  assert.deepStrictEqual(server.args, ["-y", "mcp-server-postgres"]);
+  assert.deepStrictEqual(server.env, {
+    DATABASE_URL: "postgres://localhost/test",
+  });
+  assert.ok(!("type" in server));
+  assert.ok(!("url" in server));
+});
+
 test("installServerForAgent - VS Code drops both timeout and scopes", () => {
   const tempDir = createTempDir();
   const result = installRemoteWith("vscode", tempDir, {

--- a/web/content/docs/02-cli/01-add.mdx
+++ b/web/content/docs/02-cli/01-add.mdx
@@ -81,12 +81,12 @@ Local servers (npm packages, commands) always use **stdio** transport. Most agen
 
 Not every MCP client understands every field. add-mcp keeps one canonical server config; each agent declares which optional fields it supports and maps them into its native shape:
 
-| Field              | Flag                                | Supported by                                                            | Mapped to                                                                                                           |
-| ------------------ | ----------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| Timeout            | `--timeout`                         | Claude Code, Gemini CLI, Grok Build, Kilo Code, Kimi Code, Kiro CLI, Pi | `timeout` (milliseconds); Grok Build `tool_timeout_sec` (seconds), Kimi Code `toolTimeoutMs`, Pi `requestTimeoutMs` |
-| OAuth scopes       | `--scopes`                          | Cursor, Gemini CLI                                                      | Cursor `auth.scopes`, Gemini `oauth.scopes`                                                                         |
-| Bearer token env   | `--bearer-token-env`                | fx                                                                      | `bearer_token_env`                                                                                                  |
-| Tool auto-approval | `--auto-approve` / `--approve-tool` | Codex, Claude Code                                                      | Codex approval modes; Claude Code permission allow rules                                                            |
+| Field              | Flag                                | Supported by                                                                        | Mapped to                                                                                                           |
+| ------------------ | ----------------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Timeout            | `--timeout`                         | Claude Code, Gemini CLI, Grok Build, Kilo Code, Kimi Code, Kiro CLI, Pi             | `timeout` (milliseconds); Grok Build `tool_timeout_sec` (seconds), Kimi Code `toolTimeoutMs`, Pi `requestTimeoutMs` |
+| OAuth scopes       | `--scopes`                          | Cursor, Gemini CLI, Mastra Code                                                     | Cursor `auth.scopes`, Gemini and Mastra Code `oauth.scopes`                                                         |
+| Bearer token env   | `--bearer-token-env`                | fx                                                                                  | `bearer_token_env`                                                                                                  |
+| Tool auto-approval | `--auto-approve` / `--approve-tool` | Codex, Claude Code                                                                  | Codex approval modes; Claude Code permission allow rules                                                            |
 
 When a targeted agent doesn't support a field, add-mcp drops it from that agent's config and prints a warning — other agents still receive it. `--timeout`, `--scopes`, and `--bearer-token-env` apply to remote servers only. When `--bearer-token-env` and `--header Authorization` are both set, fx omits the Authorization header and writes `bearer_token_env`; other agents keep the header.
 

--- a/web/content/docs/03-sdk/01-reference.mdx
+++ b/web/content/docs/03-sdk/01-reference.mdx
@@ -165,6 +165,7 @@ type AgentType =
   | "kilo-code"
   | "kimi-code"
   | "kiro-cli"
+  | "mastracode"
   | "mcporter"
   | "opencode"
   | "pi"

--- a/web/content/docs/05-agents.mdx
+++ b/web/content/docs/05-agents.mdx
@@ -22,6 +22,7 @@ MCP servers can be installed to any of these agents. Project paths are relative 
 | Kilo Code              | `kilo-code`          | `kilo.json` (or existing `.kilo/`, `.kilocode/`, or root `kilo.jsonc` config) | `~/.config/kilo/kilo.json` (or existing `~/.config/kilo/kilo.jsonc`)                                            |
 | Kimi Code              | `kimi-code`          | `.kimi-code/mcp.json`                                                         | `$KIMI_CODE_HOME/mcp.json` (defaults to `~/.kimi-code/mcp.json`)                                                |
 | Kiro CLI               | `kiro-cli`           | `.kiro/settings/mcp.json`                                                     | `~/.kiro/settings/mcp.json` (shared with the Kiro IDE)                                                          |
+| Mastra Code            | `mastracode`         | `.mastracode/mcp.json`                                                        | `~/.mastracode/mcp.json`                                                                                        |
 | MCPorter               | `mcporter`           | `config/mcporter.json`                                                        | `~/.mcporter/mcporter.json` (or existing `~/.mcporter/mcporter.jsonc`)                                          |
 | OpenCode               | `opencode`           | `opencode.jsonc` (or existing `opencode.json` / `.opencode/` config)          | `~/.config/opencode/opencode.jsonc` (or existing `opencode.json`)                                               |
 | Pi                     | `pi`                 | `.pi/mcp.json`                                                                | `$PI_CODING_AGENT_DIR/mcp.json` (defaults to `~/.pi/agent/mcp.json`)                                            |
@@ -41,6 +42,7 @@ MCP servers can be installed to any of these agents. Project paths are relative 
 | `kilo`, `kilocode`   | `kilo-code`  |
 | `kimi`               | `kimi-code`  |
 | `kiro`               | `kiro-cli`   |
+| `mastra`             | `mastracode` |
 | `pi-agent`           | `pi`         |
 
 ## Troubleshooting
@@ -48,6 +50,8 @@ MCP servers can be installed to any of these agents. Project paths are relative 
 Some agents and editors, like Claude Code, require a restart to load a new MCP server. Others, like Cursor, require you to navigate to the MCP settings page and toggle the new server as enabled.
 
 Kimi Code only loads a project-level `.kimi-code/mcp.json` after you trust the folder in the CLI, so a project install may not take effect until then. Its MCP config is also validated as a whole: if another entry in the file is invalid, Kimi Code disables every MCP server, including a newly added one.
+
+Mastra Code also reads project `.mcp.json`. add-mcp writes `.mastracode/mcp.json` (and `~/.mastracode/mcp.json` globally) so a mixed Claude + Mastra install does not share that file.
 
 Pi has no built-in MCP. add-mcp writes the Pi-owned files [`pi-mcp-adapter`](https://github.com/nicobailon/pi-mcp-adapter) reads. Install that extension with `pi install npm:pi-mcp-adapter`. A running Pi session picks the change up after `/reload`.
 

--- a/web/content/docs/index.mdx
+++ b/web/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: Introduction
 description: add-mcp adds MCP servers to your favorite coding agents with a single command.
 ---
 
-`add-mcp` is an open-source CLI (and TypeScript SDK) that installs [Model Context Protocol](https://modelcontextprotocol.io) servers into the config files of your coding agents — Claude Code, Codex, Cursor, OpenCode, VS Code, Grok Build, and [15 more](/docs/agents) — with a single command.
+`add-mcp` is an open-source CLI (and TypeScript SDK) that installs [Model Context Protocol](https://modelcontextprotocol.io) servers into the config files of your coding agents — Claude Code, Codex, Cursor, OpenCode, VS Code, Grok Build, and [16 more](/docs/agents) — with a single command.
 
 ```bash
 npx add-mcp https://mcp.context7.com/mcp

--- a/web/pages/index.astro
+++ b/web/pages/index.astro
@@ -24,6 +24,7 @@ const agentNames = [
   "Kilo Code",
   "Kimi Code",
   "Kiro CLI",
+  "Mastra Code",
   "MCPorter",
   "Pi",
   "Windsurf",
@@ -257,7 +258,7 @@ const structuredData = JSON.stringify({
         class="text-muted-foreground mx-auto mt-2 max-w-2xl text-sm text-pretty"
       >
         add-mcp installs any MCP server into Claude Code, Codex, Cursor,
-        OpenCode, VS Code, and 16 more coding agents from the same command.
+        OpenCode, VS Code, and 17 more coding agents from the same command.
       </p>
       <div class="mt-4 flex flex-wrap items-center justify-center gap-2">
         {


### PR DESCRIPTION
## Problem

Mastra Code users can't select it as an add-mcp destination. Mastra Code also reads Claude Code's project `.mcp.json`, so writing there would make mixed installs share the same file.

Closes #91. Co-authored with [Roshvan Chalkey (@Roshvan)](https://github.com/Roshvan), who filed the issue.

Rebased onto `main` after Pi shipped in #115.

## Interface

Adds `mastracode` with alias `mastra`:

```bash
# Project install: .mastracode/mcp.json
npx add-mcp https://mcp.example.com/mcp \
  -a mastra --name example --scopes read,write -y

# Global install: ~/.mastracode/mcp.json
npx add-mcp mcp-server-postgres -a mastracode -g -y
```

The project example writes:

```json
{
  "mcpServers": {
    "example": {
      "url": "https://mcp.example.com/mcp",
      "oauth": {
        "scopes": ["read", "write"]
      }
    }
  }
}
```

Supports stdio, HTTP and SSE. Stdio entries use `command`, `args` and optional `env`; remote entries use `url`, optional `headers` and `oauth.scopes`. Mastra Code infers transport, so entries omit `type`. `--timeout` is unsupported and follows the existing dropped-field warning behavior.

The SDK accepts the new destination:

```ts
import { upsertServer } from "add-mcp";

const result = upsertServer(
  "mastracode",
  "example",
  {
    url: "https://mcp.example.com/mcp",
    oauthScopes: ["read", "write"],
  },
  { local: true },
);
```

Detection uses the project or home `.mastracode` directory. A project `.mcp.json` alone doesn't identify Mastra Code. Existing destinations keep their config paths and formats.

## Also in here

Updates the README, CLI and SDK docs, website agent list, package keywords and changelog. Agent counts are 22 / 15 project-capable after Pi.

## Verification

`bun run typecheck` and `bun run test` pass locally after rebase onto Pi (full suite, 14 files, 104 passed). CI `test` on this PR is green.

Added tests cover:

- Project detection and excluding `.mcp.json`-only projects from Mastra detection.
- CLI project installs through `mastra`, including OAuth scopes and leaving `.mcp.json` absent.
- CLI global stdio installs to `~/.mastracode/mcp.json`.
- Stdio command, args and env preservation; remote headers and scopes.
- Omitting transport fields and reporting timeout as dropped.

Mastra Code's `loadMcpConfig` loaded both files with no skipped servers: project `.mastracode/mcp.json` with `oauth.scopes`, and global `~/.mastracode/mcp.json` stdio `command`/`args`. A live Mastra session and MCP tool call were not run.
